### PR TITLE
docs: add security, conduct, and contributing policies

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Code of Conduct
+
+## Our Standard
+
+We want this project to be a respectful, practical, and productive place to collaborate.
+
+Examples of welcome behavior:
+
+- Be direct, factual, and kind.
+- Assume good intent while still asking for clarity.
+- Keep technical disagreement focused on evidence, tradeoffs, and maintainability.
+- Respect different experience levels and backgrounds.
+
+Examples of unacceptable behavior:
+
+- Harassment, threats, or personal attacks.
+- Discriminatory language or conduct.
+- Publishing private information without permission.
+- Repeatedly derailing issues or pull requests.
+- Bad-faith participation, spam, or abuse.
+
+## Enforcement
+
+Project maintainers may remove comments, close issues, reject pull requests, or block users whose
+behavior is harmful to the project or its participants.
+
+If you need to report a concern, contact the maintainers through the project's public issue tracker
+or by emailing support@oomol.com. Security vulnerabilities are handled separately; see
+[SECURITY.md](SECURITY.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,115 @@
+# Contributing
+
+Thanks for contributing to Open Flow.
+
+## Before You Start
+
+- Read [docs/architecture.md](docs/architecture.md) before changing manifests, Project
+  persistence, compilation, runtime behavior, the Workbench, or public CLI behavior. It is the only
+  product-boundary document, and changes that contradict it will not be merged.
+- Open an issue first for larger changes such as new product boundaries, Control API changes, or new
+  Trigger kinds, so the direction can be agreed before implementation. Bug fixes and small
+  improvements can go straight to a pull request.
+- Do not report security vulnerabilities in public issues or pull requests. Follow
+  [SECURITY.md](SECURITY.md) instead.
+
+## Development Setup
+
+Open Flow uses [Bun](https://bun.sh/) for the workspace and Node.js for the Server. Use the
+versions pinned in `.bun-version` and `.node-version`; the Server depends on the native
+`isolated-vm` module, which must match the Node.js ABI.
+
+```bash
+bun install --frozen-lockfile
+bun run dev
+```
+
+The development Workbench listens on `http://127.0.0.1:5173` and proxies API requests to the
+Server on `http://127.0.0.1:3000`. The first run writes an operator token to
+`apps/server/.open-flow-dev/operator-token`; later runs reuse it. Set `OPEN_FLOW_TOKEN` to use an
+explicit token instead.
+
+## Repository Layout
+
+- [`packages/open-flow`](packages/open-flow): the public `@oomol-lab/open-flow` npm package.
+  It owns the public types, strict decoders, Control API client, black-box conformance,
+  deterministic Project/Run/Trigger semantics, programmatic authoring API, and the product-neutral
+  Workbench runtime.
+- [`packages/command`](packages/command): the `oo flow` command runtime and the immutable Command
+  Artifact build and release. It consumes `packages/open-flow` only through its public package
+  entries.
+- [`apps/server`](apps/server): the self-hosted Server with the same-origin Workbench, Control
+  API, SQLite persistence, Trigger scheduler, `isolated-vm` runtime host, and Docker delivery.
+- [`docs`](docs/README.md): product boundaries, technical contracts, and deployment references.
+
+## Development Rules
+
+- Keep one TypeScript project per deployable workspace unless a real generated-code or platform
+  constraint requires another project.
+- Keep the public npm product in `packages/open-flow`. Deployables belong under `apps/` and must not
+  deep-import another workspace's source files.
+- Preserve `common/browser/node` ownership. Common code must not import browser or Node modules, and
+  browser code must not import Node modules. `bun run check` enforces these boundaries.
+- Use direct imports. Do not add broad barrels or path aliases that hide ownership.
+- Use neutral domain names for product-owned code. The npm scope and serialized format tokens are
+  exceptions, not internal naming patterns.
+- Remove obsolete unpublished behavior instead of adding compatibility adapters.
+- Keep comments in plain English sentence style with terminal punctuation.
+- Before changing frontend interaction involving Select, popup, portal, focus, or outside-click
+  handling, read [docs/authoring/frontend-ui.md](docs/authoring/frontend-ui.md).
+
+## Checks
+
+Run these before opening a pull request:
+
+```bash
+bun run check
+bun run test
+bun run build
+```
+
+- `bun run format` fixes formatting with oxfmt. `bun run check` also runs lint, type checks, and
+  the platform boundary check.
+- Do not use `bun test` at the repository root. It bypasses the workspace test scripts and
+  incorrectly loads Vitest files with Bun's built-in test runner.
+- Run `bun run test:package` when changing the published CLI, bundle entries, package metadata, or
+  static Workbench assets.
+- Run `bun run test:docker` when changing `apps/server/Dockerfile` or anything that ships in the
+  release image. It needs a local Docker daemon and verifies the image, isolated runtime,
+  Workbench, graceful shutdown, and SQLite volume recovery.
+
+CI runs the same checks and scopes the package, command, Server, and image jobs to the files a
+change touches.
+
+## Documentation
+
+- Update [docs/architecture.md](docs/architecture.md) only when a change introduces or revises a
+  durable product boundary, cross-module ownership rule, or runtime invariant. Do not record local
+  data structures, algorithms, UI defaults, or implementation steps there.
+- Put exact serialized and protocol contracts in their technical references under
+  [docs/control](docs/control/contracts/control-api.md) and
+  [docs/distribution](docs/distribution/command-artifact.md). Implementation history stays in Git.
+- Keep [README.md](README.md) and [README.zh-CN.md](README.zh-CN.md) in sync when changing either.
+
+## Commits and Pull Requests
+
+- Write commit and pull request titles in English using
+  [Conventional Commits](https://www.conventionalcommits.org/), for example `fix(server): ...` or
+  `refactor(workbench): ...`.
+- Keep each pull request focused on one change. Describe what changed and why, link the related
+  issue, and include tests and documentation updates with the change.
+- Pull requests must pass CI before review.
+
+## Third-Party Rights
+
+Do not contribute third-party logos, icons, screenshots, documentation excerpts, API schemas, or
+brand assets unless you have the right to do so. Third-party licenses that apply to bundled assets
+are listed in [NOTICE](NOTICE); add to it when introducing such an asset.
+
+Provider names, app names, trademarks, logos, and brand assets belong to their respective owners.
+This project uses such references only for identification and interoperability.
+
+## Contribution License
+
+By submitting a pull request, you agree that your contribution is provided under the Apache License,
+Version 2.0, unless you clearly mark it otherwise in writing.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
-# Open Flow
+<div align="center">
 
-[English](README.md) | [简体中文](README.zh-CN.md)
+# Open Flow
 
 **Build workflows you can see, code, run, and own.**
 
+[English](README.md) | [简体中文](README.zh-CN.md)
+
+[![CI](https://github.com/oomol-lab/open-flow/actions/workflows/ci.yaml/badge.svg)](https://github.com/oomol-lab/open-flow/actions/workflows/ci.yaml)
+[![npm](https://img.shields.io/npm/v/%40oomol-lab%2Fopen-flow/next?label=%40oomol-lab%2Fopen-flow)](https://www.npmjs.com/package/@oomol-lab/open-flow)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](LICENSE)
+![Node.js 26](https://img.shields.io/badge/Node.js-26-339933)
+![Bun 1.4](https://img.shields.io/badge/Bun-1.4-000000)
+
+</div>
+
 Open Flow is an open-source workflow automation platform for building on a visual canvas without
 giving up code. Connect typed steps, write JavaScript or TypeScript where it belongs, run flows
-interactively, and publish them for continuous execution.
+interactively, and publish them for continuous execution on a deployment you control.
 
 <p align="center">
   <picture>
@@ -20,25 +30,47 @@ interactively, and publish them for continuous execution.
 > Open Flow is in alpha. Its contracts are versioned, but the product has not reached its first
 > stable release.
 
-## From idea to running workflow
+## Why Open Flow
 
-- **Design visually, extend with code.** Compose typed nodes and subflows on the canvas, then use
-  script and code modules for logic that should stay explicit.
-- **Run and debug in one place.** Validate inputs before execution, inspect node progress and
-  outputs, and follow the complete event history of every run.
-- **Publish long-running automation.** Start flows manually or from cron schedules, webhooks,
-  polling sources, and provider events.
-- **Keep operational state together.** Projects, immutable revisions, publications, live versions,
-  runs, and trigger state belong to one selected deployment instead of being split across local
+- **Design visually, extend with code.** Compose typed nodes and Subflows on the canvas, then use
+  Script and CodeModule nodes for logic that should stay explicit. The code remains code, with real
+  TypeScript instead of expressions hidden in form fields.
+- **Run and debug in one place.** Validate inputs and the Flow structure before execution, inspect
+  node progress and outputs, and follow the complete event history of every Run.
+- **Publish long-running automation.** Start Flows manually or from Cron schedules, Webhooks,
+  polling sources, and Provider events.
+- **Keep operational state together.** Projects, immutable Revisions, Publications, Live versions,
+  Runs, and Trigger state belong to one selected deployment instead of being split across local
   files and hidden services.
-- **Choose where it runs.** Use the included self-hosted Server or connect the same Workbench and
+- **Run untrusted code safely.** The Server executes every code Task in a fresh V8 isolate inside a
+  long-lived Executor process, with only the Capabilities that Task declared.
+- **Choose where it runs.** Use the included self-hosted Server, or connect the same Workbench and
   CLI to another implementation of the versioned Control API.
 
 Open Flow is built for workflows that outgrow a no-code prototype but should not become an opaque
 collection of scripts and infrastructure. The graph remains understandable, the code remains
 code, and the deployment remains under your control.
 
-## Quick start
+## How It Works
+
+```mermaid
+flowchart LR
+  Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
+  CLI["oo flow CLI"] -->|"Control API"| Server
+  Server --> Store["SQLite: Projects, Revisions, Publications, Runs"]
+  Server --> Triggers["Trigger scheduler: Cron, Webhook, Poll, Integration"]
+  Server --> Runtime["Isolated JavaScript runtime"]
+  Server -. "optional" .-> Connector["Connector runtime"]
+  Connector --> Providers["Third-party Providers"]
+```
+
+The Workbench and CLI only talk to one selected deployment through the versioned Control API. The
+deployment owns validation, execution, persistence, and Trigger admission. Provider credentials
+never enter Open Flow: Connector-backed Actions, Provider Triggers, and proxies go through a
+Connector runtime such as [OpenConnector](https://github.com/oomol-lab/open-connector), and Open Flow
+only stores opaque Connection identities.
+
+## Quick Start
 
 You need [Docker](https://docs.docker.com/get-docker/) and OpenSSL. Clone the repository, create an
 operator token, and start the self-hosted Server:
@@ -57,15 +89,37 @@ docker run --rm \
 ```
 
 Open [http://127.0.0.1:3000](http://127.0.0.1:3000) and sign in with the value of
-`OPEN_FLOW_TOKEN`. Projects and run history are persisted in the `open-flow-data` Docker volume.
+`OPEN_FLOW_TOKEN`. The same value works as a Bearer token for machine clients of the Control API.
+Projects and Run history are persisted in the `open-flow-data` Docker volume.
 
-The Server is useful without external services. Connector-backed actions, provider triggers, and
-LLM tasks fail closed until their corresponding host capability is configured.
+The Server is useful without external services. Connector-backed Actions, Provider Triggers, and
+LLM Tasks fail closed until the corresponding host capability is configured; nothing falls back to
+an undisclosed service.
 
-For production configuration, health checks, persistence, backup, and Connector integration, see
-the [Server deployment guide](docs/server/container-delivery.md).
+For production configuration, TLS, health checks, persistence, backup, and resource limits, see the
+[Server deployment guide](docs/server/container-delivery.md) and the hardening checklist in
+[SECURITY.md](SECURITY.md#hardening-your-deployment).
 
-## One product, portable deployments
+## Connect a Connector
+
+To run Actions and Provider Triggers against services such as GitHub, Gmail, Slack, or Notion,
+point the Server at a Connector runtime. Both a self-hosted
+[OpenConnector](https://github.com/oomol-lab/open-connector) and the OOMOL-hosted Connector expose
+the required runtime API.
+
+```dotenv
+OPEN_FLOW_CONNECTOR_ORIGIN=http://open-connector:3000
+OPEN_FLOW_CONNECTOR_TOKEN=replace-with-a-scoped-runtime-token
+OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN=https://connector.example.com
+```
+
+The runtime origin is where the Server reaches the Connector; the console origin is where users'
+browsers open the Connector Console to authorize accounts. Provider Trigger definitions ship with
+Open Flow and need no registration. See the
+[configuration reference](docs/server/container-delivery.md#4-配置) for Integration callback
+settings and the constraints on each origin.
+
+## One Product, Portable Deployments
 
 The Workbench and CLI speak a versioned Control API rather than depending on a particular database
 or cloud runtime. A deployment owns execution and persistence; clients do not create a second local
@@ -73,17 +127,20 @@ project format or silently switch to another backend.
 
 This repository contains:
 
-- [`packages/open-flow`](packages/open-flow): public authoring, execution, trigger, Control API,
-  conformance, and Workbench runtime packages;
-- [`apps/server`](apps/server): the self-hosted Workbench, Control API, SQLite persistence, trigger
+- [`packages/open-flow`](packages/open-flow): the public `@oomol-lab/open-flow` npm package with
+  authoring, execution, Trigger, Control API, conformance, and Workbench runtime entries;
+- [`packages/command`](packages/command): the `oo flow` command runtime and the immutable Command
+  Artifact consumed by the [oo CLI](https://github.com/oomol-lab/oo-cli);
+- [`apps/server`](apps/server): the self-hosted Workbench, Control API, SQLite persistence, Trigger
   scheduler, and isolated JavaScript runtime.
 
 Read the [product and architecture boundaries](docs/architecture.md) for the durable model, or the
 [Control API reference](docs/control/contracts/control-api.md) for the HTTP contract.
 
-## Develop from source
+## Develop From Source
 
-Open Flow uses [Bun](https://bun.sh/).
+Open Flow uses [Bun](https://bun.sh/) for the workspace and Node.js for the Server. Use the
+versions pinned in `.bun-version` and `.node-version`.
 
 ```bash
 bun install --frozen-lockfile
@@ -105,11 +162,12 @@ Before submitting a change, run:
 bun run check
 bun run test
 bun run build
-bun run test:package
 ```
 
-Use `bun run test:docker` when Docker is available to verify the release image, isolated runtime,
-Workbench, graceful shutdown, and SQLite volume recovery.
+Add `bun run test:package` when touching the published package or CLI, and `bun run test:docker`
+when Docker is available to verify the release image, isolated runtime, Workbench, graceful
+shutdown, and SQLite volume recovery. Do not run `bun test` at the repository root; it bypasses the
+workspace test scripts. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development rules.
 
 ## Documentation
 
@@ -117,8 +175,33 @@ Start with the [documentation index](docs/README.md). The most useful references
 
 - [Product and architecture boundaries](docs/architecture.md)
 - [Control API](docs/control/contracts/control-api.md)
+- [Command Artifact distribution](docs/distribution/command-artifact.md)
+- [Workbench and Designer frontend notes](docs/authoring/frontend-ui.md)
 - [Server deployment](docs/server/container-delivery.md)
+- [Contributing](CONTRIBUTING.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Security](SECURITY.md)
+
+## Related Projects
+
+- [OpenConnector](https://github.com/oomol-lab/open-connector): open-source connector gateway that
+  provides the Provider catalog, credentials, and Action execution behind Connector-backed nodes.
+- [oo CLI](https://github.com/oomol-lab/oo-cli): local agent toolkit that hosts the `oo flow`
+  command built from this repository.
+
+## Contributing
+
+Issues and pull requests are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) for the development
+setup, repository rules, and checks to run before opening a pull request. Participation in this
+project is governed by [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+## Security
+
+Please report vulnerabilities privately through
+[GitHub private vulnerability reporting](https://github.com/oomol-lab/open-flow/security/advisories/new)
+rather than public issues. [SECURITY.md](SECURITY.md) describes the supported versions, the
+disclosure process, what is in scope, and how to harden a self-hosted deployment.
 
 ## License
 
-[Apache-2.0](LICENSE)
+[Apache-2.0](LICENSE). Third-party notices for bundled assets are listed in [NOTICE](NOTICE).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,11 +1,21 @@
-# Open Flow
+<div align="center">
 
-[English](README.md) | 简体中文
+# Open Flow
 
 **在画布上搭工作流，需要时直接写代码，最后部署到自己的环境。**
 
+[English](README.md) | 简体中文
+
+[![CI](https://github.com/oomol-lab/open-flow/actions/workflows/ci.yaml/badge.svg)](https://github.com/oomol-lab/open-flow/actions/workflows/ci.yaml)
+[![npm](https://img.shields.io/npm/v/%40oomol-lab%2Fopen-flow/next?label=%40oomol-lab%2Fopen-flow)](https://www.npmjs.com/package/@oomol-lab/open-flow)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](LICENSE)
+![Node.js 26](https://img.shields.io/badge/Node.js-26-339933)
+![Bun 1.4](https://img.shields.io/badge/Bun-1.4-000000)
+
+</div>
+
 Open Flow 是一个开源的工作流自动化平台。你可以在画布上连接有类型约束的节点，在合适的位置编写 JavaScript 或
-TypeScript，直接运行和调试 Flow，再把它发布成持续工作的自动化流程。
+TypeScript，直接运行和调试 Flow，再把它发布成持续工作的自动化流程，并部署在自己控制的环境中。
 
 <p align="center">
   <picture>
@@ -18,15 +28,34 @@ TypeScript，直接运行和调试 Flow，再把它发布成持续工作的自�
 > [!IMPORTANT]
 > Open Flow 目前处于 Alpha 阶段。公开协议有版本管理，但产品还没有发布第一个稳定版本。
 
-## 从想法到线上运行
+## 为什么选择 Open Flow
 
-- 在画布上组合节点和 Subflow，并用类型约束输入与输出。遇到更适合代码的逻辑，可以直接使用 Script 或 CodeModule。
-- 运行前检查输入和 Flow 结构，运行时查看每个节点的进度、输出和完整事件记录。
-- Flow 可以手动启动，也可以由 Cron、Webhook、轮询数据源或 Provider Event 触发。
-- Project、不可变 Revision、Publication、Live 版本、Run 和 Trigger 状态都由当前部署管理，不会散落在本地文件和隐藏服务中。
-- 可以使用仓库自带的 Server 自行部署，也可以让同一套 Workbench 和 CLI 连接其他兼容 Control API 的实现。
+- **可视化设计，用代码扩展。** 在画布上组合有类型约束的节点和 Subflow；遇到更适合代码的逻辑，直接使用 Script 或 CodeModule
+  节点，写的是真正的 TypeScript，而不是藏在表单里的表达式。
+- **运行和调试在同一处。** 运行前检查输入和 Flow 结构，运行时查看每个节点的进度、输出和完整事件记录。
+- **发布为长期运行的自动化。** Flow 可以手动启动，也可以由 Cron、Webhook、轮询数据源或 Provider Event 触发。
+- **运行状态集中管理。** Project、不可变 Revision、Publication、Live 版本、Run 和 Trigger 状态都由当前部署管理，不会散落在本地文件和隐藏服务中。
+- **安全地执行用户代码。** Server 在长驻的 Executor 进程中为每次代码 Task 调用创建全新的 V8 isolate，只暴露该 Task 明确声明的 Capability。
+- **自由选择运行环境。** 可以使用仓库自带的 Server 自行部署，也可以让同一套 Workbench 和 CLI 连接其他兼容 Control API 的实现。
 
 Open Flow 适合已经超过简单无代码原型，但又不想变成一堆脚本和基础设施的工作流。流程图仍然容易理解，需要写的代码也保留为正常代码，运行环境由你选择。
+
+## 工作原理
+
+```mermaid
+flowchart LR
+  Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
+  CLI["oo flow CLI"] -->|"Control API"| Server
+  Server --> Store["SQLite：Project、Revision、Publication、Run"]
+  Server --> Triggers["Trigger 调度：Cron、Webhook、Poll、Integration"]
+  Server --> Runtime["隔离的 JavaScript 运行时"]
+  Server -. "可选" .-> Connector["Connector 运行时"]
+  Connector --> Providers["第三方 Provider"]
+```
+
+Workbench 和 CLI 只通过有版本的 Control API 与当前选定的一个部署通信。部署端负责 validation、执行、持久化和 Trigger 准入。Provider
+凭据不会进入 Open Flow：Connector Action、Provider Trigger 和 proxy 都经由
+[OpenConnector](https://github.com/oomol-lab/open-connector) 这类 Connector 运行时完成，Open Flow 只保存不透明的 Connection 标识。
 
 ## 快速开始
 
@@ -45,14 +74,29 @@ docker run --rm \
   open-flow-server:dev
 ```
 
-打开 [http://127.0.0.1:3000](http://127.0.0.1:3000)，使用 `OPEN_FLOW_TOKEN` 的值登录。Project 和 Run 历史会保存在
-`open-flow-data` Docker volume 中。
+打开 [http://127.0.0.1:3000](http://127.0.0.1:3000)，使用 `OPEN_FLOW_TOKEN` 的值登录。同一个值也可以作为 Control API 的 Bearer Token
+供机器客户端使用。Project 和 Run 历史会保存在 `open-flow-data` Docker volume 中。
 
 不接外部服务时，Server 仍然可以独立使用。Connector Action、Provider Trigger 和 LLM Task 在没有配置对应 Host Capability
 时会拒绝执行，不会退回到来源不明的服务。
 
-生产环境所需的配置、健康检查、数据持久化、备份和 Connector 接入方式，参见
-[Server 部署文档](docs/server/container-delivery.md)。
+生产环境所需的配置、TLS、健康检查、数据持久化、备份和资源限制，参见
+[Server 部署文档](docs/server/container-delivery.md) 和 [SECURITY.md](SECURITY.md#hardening-your-deployment) 中的加固清单。
+
+## 接入 Connector
+
+要对 GitHub、Gmail、Slack、Notion 等服务执行 Action 和 Provider Trigger，需要把 Server 指向一个 Connector 运行时。自行部署的
+[OpenConnector](https://github.com/oomol-lab/open-connector) 和 OOMOL 托管的 Connector 都提供所需的运行时 API。
+
+```dotenv
+OPEN_FLOW_CONNECTOR_ORIGIN=http://open-connector:3000
+OPEN_FLOW_CONNECTOR_TOKEN=replace-with-a-scoped-runtime-token
+OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN=https://connector.example.com
+```
+
+runtime origin 是 Server 访问 Connector 的地址，console origin 是用户浏览器打开 Connector Console 授权账号的地址。Provider Trigger
+定义随 Open Flow 内置，不需要额外注册。Integration callback 的配置和各 origin 的约束参见
+[配置说明](docs/server/container-delivery.md#4-配置)。
 
 ## 一套产品，多种部署
 
@@ -61,7 +105,10 @@ Project 格式，也不会在请求失败时暗中切换后端。
 
 仓库主要包含：
 
-- [`packages/open-flow`](packages/open-flow)：公开的 Authoring、Execution、Trigger、Control API、Conformance 和 Workbench Runtime；
+- [`packages/open-flow`](packages/open-flow)：公开的 `@oomol-lab/open-flow` npm 包，提供 Authoring、Execution、Trigger、Control
+  API、Conformance 和 Workbench Runtime 入口；
+- [`packages/command`](packages/command)：`oo flow` 命令运行时和交付给 [oo CLI](https://github.com/oomol-lab/oo-cli) 的不可变
+  Command Artifact；
 - [`apps/server`](apps/server)：可自行部署的 Workbench、Control API、SQLite 存储、Trigger Scheduler 和隔离的 JavaScript Runtime。
 
 长期成立的产品模型记录在[产品与架构边界](docs/architecture.md)中，HTTP 接口定义参见
@@ -69,7 +116,7 @@ Project 格式，也不会在请求失败时暗中切换后端。
 
 ## 从源码开发
 
-Open Flow 使用 [Bun](https://bun.sh/)。
+Open Flow 的工作区使用 [Bun](https://bun.sh/)，Server 运行在 Node.js 上。请使用 `.bun-version` 和 `.node-version` 中固定的版本。
 
 ```bash
 bun install --frozen-lockfile
@@ -88,10 +135,10 @@ Token，因此重启开发服务不会让当前 Workbench 登录态失效。如�
 bun run check
 bun run test
 bun run build
-bun run test:package
 ```
 
-本机有 Docker 时，还可以运行 `bun run test:docker`，检查发布镜像、隔离运行时、Workbench、正常退出和 SQLite volume 恢复。
+改动发布包或 CLI 时加跑 `bun run test:package`；本机有 Docker 时运行 `bun run test:docker`，检查发布镜像、隔离运行时、Workbench、正常退出和
+SQLite volume 恢复。不要在仓库根目录直接运行 `bun test`，它会绕过各工作区的测试脚本。完整的开发规则见 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
 ## 文档
 
@@ -99,8 +146,29 @@ bun run test:package
 
 - [产品与架构边界](docs/architecture.md)
 - [Control API](docs/control/contracts/control-api.md)
+- [Command Artifact 分发合同](docs/distribution/command-artifact.md)
+- [Workbench 与 Designer 前端注意事项](docs/authoring/frontend-ui.md)
 - [Server 部署](docs/server/container-delivery.md)
+- [参与贡献](CONTRIBUTING.md)
+- [行为准则](CODE_OF_CONDUCT.md)
+- [安全政策](SECURITY.md)
+
+## 相关项目
+
+- [OpenConnector](https://github.com/oomol-lab/open-connector)：开源的 Connector 网关，为 Connector 节点提供 Provider 目录、凭据管理和
+  Action 执行。
+- [oo CLI](https://github.com/oomol-lab/oo-cli)：本地 Agent 工具集，承载由本仓库构建的 `oo flow` 命令。
+
+## 参与贡献
+
+欢迎提交 Issue 和 Pull Request。开发环境、仓库规则和提交前需要运行的检查见 [CONTRIBUTING.md](CONTRIBUTING.md)。参与本项目需遵守
+[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)。
+
+## 安全
+
+请通过 [GitHub 私密漏洞报告](https://github.com/oomol-lab/open-flow/security/advisories/new) 报告安全问题，不要提交公开
+Issue。[SECURITY.md](SECURITY.md) 说明了受支持的版本、披露流程、报告范围以及自行部署时的加固建议。
 
 ## 许可证
 
-[Apache-2.0](LICENSE)
+[Apache-2.0](LICENSE)。打包资源涉及的第三方声明见 [NOTICE](NOTICE)。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,189 @@
+# Security Policy
+
+Open Flow (`oomol-lab/open-flow`) ships a self-hosted Server that executes operator-authored
+JavaScript and TypeScript inside an isolated runtime, exposes public Webhook and Integration
+callback endpoints, and holds deployment secrets such as the operator token, browser session
+cookies, the Connector runtime token, and the Integration callback key. We take security reports
+seriously and are grateful to the researchers and users who help keep the project and its users
+safe.
+
+This policy explains which versions receive security fixes, how to report a vulnerability privately,
+what to expect after you report, and how operators and contributors share responsibility for keeping
+deployments safe.
+
+## Supported Versions
+
+Open Flow is in alpha and has not reached its first stable release. Security fixes are delivered on
+the **latest released version** and the **`main`** branch. We recommend always running the latest
+release and rebuilding the Server image from it.
+
+| Version                 | Security fixes |
+| ----------------------- | -------------- |
+| Latest release / `main` | Yes            |
+| Older releases          | No             |
+
+## Reporting a Vulnerability
+
+**Please report security vulnerabilities privately.** Do not open a public issue, pull request, or
+discussion, and do not post details on social media or any other public channel, until we have
+released a fix and coordinated disclosure with you. Public reports expose every deployment of the
+project to the vulnerability before a patch exists.
+
+Use one of these private channels:
+
+1. **GitHub private vulnerability reporting (preferred).** Open
+   <https://github.com/oomol-lab/open-flow/security/advisories/new>, or go to the repository's
+   **Security** tab, then **Advisories**, then **Report a vulnerability**. This creates a private
+   advisory visible only to you and the maintainers, and is the fastest path to a coordinated fix
+   and a CVE.
+2. **Email.** If GitHub private reporting is unavailable to you, email **support@oomol.com** with
+   the subject line prefixed `[security]`. Use this only as a fallback; it is not an encrypted
+   channel, so keep secrets out of the message (see below).
+
+If you do not receive an acknowledgement within **3 business days**, please re-send through the other
+channel in case a message was missed.
+
+### What to include
+
+A good report lets us reproduce and assess the issue quickly. Where possible, include:
+
+- A description of the vulnerability and its security impact (what an attacker can do).
+- Step-by-step reproduction, proof-of-concept, or the relevant code path. A minimal Flow or
+  CodeModule that demonstrates the issue is ideal for runtime findings.
+- The affected version, release, or commit, and **how it was deployed**: the Docker image built
+  from `apps/server/Dockerfile`, a from-source `bun run dev` Server, the `@oomol-lab/open-flow`
+  npm package, or the Command Artifact used by `oo flow`.
+- Any known mitigation or workaround.
+
+### Protect secrets in your report
+
+Because a deployment holds live secrets, **do not include real operator tokens, session cookies,
+Connector tokens, callback keys, Provider credentials, or workflow data** in your report. Redact
+them and use placeholder values (for example, `OPEN_FLOW_TOKEN=REDACTED`). If a proof-of-concept
+requires a secret, describe how to generate a disposable test one instead of sharing a live value.
+
+## What to Expect After Reporting
+
+We follow a coordinated disclosure process:
+
+- **Acknowledgement** within **3 business days** that we received your report.
+- An **initial assessment and expected timeline** within **10 business days**. We triage by severity
+  using [CVSS](https://www.first.org/cvss/calculator/4.0).
+- **Regular status updates** as we work on a fix, and notification when it ships.
+- **Credit** to you in the advisory and release notes when the fix is published, unless you ask to
+  remain anonymous.
+
+## Coordinated Disclosure
+
+- Keep the report **private** until a fix is released. We aim to publish within **90 days** of the
+  report; for actively exploited issues we move faster.
+- We develop and review the fix in a **private** GitHub security advisory or fork, never in a public
+  issue or pull request, which would reveal the vulnerability before a patch is available.
+- When the fix is ready, we publish a **GitHub Security Advisory** and, for qualifying issues, request
+  a **CVE** through GitHub (a CVE Numbering Authority) so downstream users are notified.
+- We will coordinate the public disclosure date with you and credit your contribution.
+
+## Scope
+
+**In scope**: vulnerabilities in this repository's own code and defaults, for example:
+
+- **Isolated runtime escapes.** User code in a Script, CodeModule, or Task escaping its isolate or
+  the Executor process, reaching the host filesystem, environment, network, or other Runs, or
+  obtaining a Capability that the current Task invocation did not declare.
+- **Operator authentication and sessions.** Operator token verification, session cookie handling,
+  login rate limiting, and Control API authorization in `apps/server`.
+- **Trigger endpoints.** Bypassing Webhook or Integration callback authentication, admitting one
+  occurrence as more than one Run, defeating admission or rate limits, or turning a callback
+  response into executable content or modified security headers on the Workbench or Control API
+  origin.
+- **Secret leakage.** Operator tokens, Connector tokens, callback keys, or Provider callback
+  verifiers appearing in ProjectRevisions, RunEvents, the Workbench, API responses, or logs.
+- **Resource limit bypasses.** Circumventing the concurrent Run, pending Run, or Run timeout limits
+  from user code or through the API.
+- **Clients and distribution.** The Workbench (XSS, CSRF, and similar), the published
+  `@oomol-lab/open-flow` npm package, the Command Artifact build and verification rules in
+  `packages/command`, and the Docker image defaults.
+
+**Out of scope**: please do not report these as vulnerabilities in Open Flow:
+
+- Vulnerabilities in the Connector service a deployment is configured to use, such as
+  [OpenConnector](https://github.com/oomol-lab/open-connector/security/policy) or the OOMOL-hosted
+  Connector, or in third-party Providers. Report those to the respective project or provider.
+- Behavior that requires operator privileges and works as designed. Open Flow executes code that a
+  deployment operator authored: an operator making a workflow call a network service, read its own
+  Project data, or consume its own deployment's Run limits is not a vulnerability. The isolated
+  runtime is a boundary between user code and the host, not between operators of the same
+  deployment.
+- Insecure **self-hosted configuration** that this project documents how to avoid, for example
+  running without `OPEN_FLOW_TOKEN`, exposing the Server to an untrusted network without TLS,
+  leaving `OPEN_FLOW_SESSION_COOKIE_SECURE` unset behind a TLS ingress, using an HTTP Connector
+  runtime origin across an untrusted network, or sharing the SQLite volume between containers. See
+  [Hardening your deployment](#hardening-your-deployment).
+- The hosted [OOMOL](https://oomol.com/) service and other OOMOL products. These are maintained
+  separately from this repository and are not covered by this policy; report issues in them to
+  support@oomol.com.
+- Reports from automated scanners with no demonstrated impact, missing security headers without a
+  concrete exploit, volumetric denial-of-service, social engineering, and physical attacks.
+
+## Safe Harbor
+
+We will not pursue or support legal action against researchers who, in good faith:
+
+- follow this policy and stay within the scope above,
+- avoid privacy violations, data destruction, and disruption of others' service, and
+- give us a reasonable opportunity to remediate before any disclosure.
+
+If in doubt about whether an action is authorized, ask us first at support@oomol.com. We do not
+currently run a paid bug-bounty program, but we credit every reporter whose finding leads to a fix.
+
+## Hardening Your Deployment
+
+Open Flow Server is self-hosted and runs code on behalf of its operator, so operators share
+responsibility for securing their deployment. At minimum:
+
+- **Use a strong operator token.** Set `OPEN_FLOW_TOKEN` to at least 32 random bytes and inject it
+  through a secret or an env file readable only by the deployer; never bake it into a Dockerfile,
+  image layer, or repository file. The same value authenticates browser sessions and machine
+  clients as a Bearer token. Without it the Control API and Workbench fail closed, but health and
+  callback endpoints keep serving.
+- **Terminate TLS and secure the session cookie.** Put the Server behind a TLS ingress and set
+  `OPEN_FLOW_SESSION_COOKIE_SECURE=true`. The Docker image listens on `0.0.0.0:3000`; only expose
+  it on a trusted network or behind an authenticated proxy.
+- **Protect the Connector link.** Give `OPEN_FLOW_CONNECTOR_TOKEN` a runtime token scoped to the
+  Providers and Actions the deployment actually needs. Keep `OPEN_FLOW_CONNECTOR_ORIGIN` on a
+  trusted private network or behind TLS, and use HTTPS for `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN`
+  outside loopback development.
+- **Protect Integration callbacks.** Use an HTTPS `OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN` and inject
+  `OPEN_FLOW_INTEGRATION_CALLBACK_KEY` (at least 32 bytes) through a secret. Callback verifiers
+  derived from it live only in the Server's runtime state.
+- **Protect the data volume.** The SQLite database under `OPEN_FLOW_DATA_DIR` (`/data/open-flow`
+  in the image) contains Project source, Run history, Trigger state, and Provider callback
+  verifiers. Restrict access to the volume, let only one Server container write to it, and back it
+  up quiesced together with its WAL and SHM files.
+- **Keep resource limits in place.** Tune `OPEN_FLOW_MAX_PENDING_RUNS`,
+  `OPEN_FLOW_MAX_CONCURRENT_RUNS`, `OPEN_FLOW_RUN_TIMEOUT_MS`,
+  `OPEN_FLOW_CALLBACK_REQUESTS_PER_MINUTE`, `OPEN_FLOW_OPERATOR_LOGIN_ATTEMPTS_PER_MINUTE`, and
+  `OPEN_FLOW_RUN_EVENT_RETENTION_DAYS` to your deployment rather than removing the limits.
+- **Stay current.** Rebuild the image from the latest release. When running from source, use the
+  Bun and Node.js versions pinned in `.bun-version` and `.node-version`; the Server depends on the
+  native `isolated-vm` module built for that Node.js ABI.
+
+See the [Server deployment guide](docs/server/container-delivery.md) for the full configuration
+reference, health checks, and backup procedure.
+
+## Handling Secrets in the Codebase
+
+For contributors and anyone working with this repository:
+
+- **Never commit** operator tokens, `.env.server` files, Connector tokens, callback keys, Provider
+  credentials, or captured callback payloads that contain user data. The development operator token
+  under `apps/server/.open-flow-dev/` is git-ignored; keep it that way.
+- If a secret is committed by mistake, treat it as **compromised**: rotate it immediately, then
+  report it privately through the channels above. Removing it from later commits or rewriting git
+  history is not sufficient; assume it was captured.
+- Keep secrets out of ProjectRevisions, RunEvents, the Workbench, API responses, and logs. Do not
+  add Capabilities to the user realm without validating the current Project, Run, Task, and
+  invocation, and do not weaken the isolate, Executor, or callback authentication boundaries
+  described in [docs/architecture.md](docs/architecture.md).
+
+Thank you for helping keep Open Flow and its users secure.


### PR DESCRIPTION
The repository had no security policy, code of conduct, or contributor guide, so vulnerability reports and contribution rules had no home outside _AGENTS.md_ and scattered docs. The three new files follow the shape of the OpenConnector policies, with the security scope, out-of-scope list, and hardening checklist rewritten around what this Server actually has: the isolated runtime, the operator token, Trigger callbacks, and the `OPEN_FLOW_*` configuration documented in _docs/server/container-delivery.md_.

_README.md_ and _README.zh-CN.md_ gain CI, npm, and license badges, a How It Works diagram, a Connector configuration example, the previously missing _packages/command_ entry, related project links, and pointers to the new policies. The two languages are kept in sync, and `bun run check` passes with the new Markdown.
