### PR TITLE
docs: align multilingual README layout with open-connector

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,8 @@ change touches.
 - Put exact serialized and protocol contracts in their technical references under
   [docs/control](docs/control/contracts/control-api.md) and
   [docs/distribution](docs/distribution/command-artifact.md). Implementation history stays in Git.
-- Keep [README.md](README.md) and [README.zh-CN.md](README.zh-CN.md) in sync when changing either.
+- Keep [README.md](README.md) and the translated READMEs under `docs/README.<locale>.md` in sync
+  when changing any of them.
 
 ## Commits and Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Build workflows you can see, code, run, and own.**
 
-[English](README.md) | [简体中文](README.zh-CN.md)
+[English](README.md) | [简体中文](docs/README.zh-CN.md) | [繁體中文](docs/README.zh-TW.md) | [日本語](docs/README.ja.md) | [한국어](docs/README.ko.md) | [Русский](docs/README.ru.md) | [Français](docs/README.fr.md)
 
 [![CI](https://github.com/oomol-lab/open-flow/actions/workflows/ci.yaml/badge.svg)](https://github.com/oomol-lab/open-flow/actions/workflows/ci.yaml)
 [![npm](https://img.shields.io/npm/v/%40oomol-lab%2Fopen-flow/next?label=%40oomol-lab%2Fopen-flow)](https://www.npmjs.com/package/@oomol-lab/open-flow)

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -1,0 +1,219 @@
+<div align="center">
+
+# Open Flow
+
+**Construisez des workflows que vous pouvez voir, coder, exécuter et posséder.**
+
+[English](../README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+[![CI](https://github.com/oomol-lab/open-flow/actions/workflows/ci.yaml/badge.svg)](https://github.com/oomol-lab/open-flow/actions/workflows/ci.yaml)
+[![npm](https://img.shields.io/npm/v/%40oomol-lab%2Fopen-flow/next?label=%40oomol-lab%2Fopen-flow)](https://www.npmjs.com/package/@oomol-lab/open-flow)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](../LICENSE)
+![Node.js 26](https://img.shields.io/badge/Node.js-26-339933)
+![Bun 1.4](https://img.shields.io/badge/Bun-1.4-000000)
+
+</div>
+
+Open Flow est une plateforme open source d'automatisation de workflows qui permet de construire sur un
+canevas visuel sans renoncer au code. Connectez des étapes typées, écrivez du JavaScript ou du
+TypeScript là où c'est pertinent, exécutez vos Flows de manière interactive et publiez-les pour une
+exécution continue sur un déploiement que vous contrôlez.
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="assets/light.png">
+    <img alt="Un workflow Hacker News en cours d'exécution dans le Workbench Open Flow" src="assets/light.png">
+  </picture>
+</p>
+
+> [!IMPORTANT]
+> Open Flow est en phase alpha. Ses contrats sont versionnés, mais le produit n'a pas encore atteint
+> sa première version stable.
+
+## Pourquoi Open Flow
+
+- **Concevez visuellement, étendez avec du code.** Composez des nœuds typés et des Subflows sur le
+  canevas, puis utilisez des nœuds Script et CodeModule pour la logique qui doit rester explicite. Le
+  code reste du code, avec du vrai TypeScript plutôt que des expressions cachées dans des champs de
+  formulaire.
+- **Exécutez et déboguez au même endroit.** Validez les entrées et la structure du Flow avant
+  l'exécution, inspectez la progression et les sorties de chaque nœud, et suivez l'historique complet
+  des événements de chaque Run.
+- **Publiez des automatisations de longue durée.** Démarrez les Flows manuellement ou à partir de
+  planifications Cron, de Webhooks, de sources de polling et d'événements de Provider.
+- **Gardez l'état opérationnel au même endroit.** Les Projects, les Revisions immuables, les
+  Publications, les versions Live, les Runs et l'état des Triggers appartiennent à un seul déploiement
+  sélectionné, au lieu d'être répartis entre des fichiers locaux et des services cachés.
+- **Exécutez du code non fiable en toute sécurité.** Le Server exécute chaque Task de code dans un
+  isolate V8 neuf, au sein d'un processus Executor de longue durée, avec uniquement les Capabilities
+  déclarées par cette Task.
+- **Choisissez où cela s'exécute.** Utilisez le Server auto-hébergé inclus, ou connectez le même
+  Workbench et la même CLI à une autre implémentation de la Control API versionnée.
+
+Open Flow est conçu pour les workflows qui dépassent le stade du prototype no-code mais ne doivent
+pas devenir un ensemble opaque de scripts et d'infrastructure. Le graphe reste compréhensible, le
+code reste du code, et le déploiement reste sous votre contrôle.
+
+## Fonctionnement
+
+```mermaid
+flowchart LR
+  Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
+  CLI["oo flow CLI"] -->|"Control API"| Server
+  Server --> Store["SQLite : Projects, Revisions, Publications, Runs"]
+  Server --> Triggers["Ordonnanceur de Triggers : Cron, Webhook, Poll, Integration"]
+  Server --> Runtime["Runtime JavaScript isolé"]
+  Server -. "optionnel" .-> Connector["Runtime Connector"]
+  Connector --> Providers["Providers tiers"]
+```
+
+Le Workbench et la CLI ne communiquent qu'avec un seul déploiement sélectionné, via la Control API
+versionnée. Le déploiement est responsable de la validation, de l'exécution, de la persistance et de
+l'admission des Triggers. Les identifiants des Providers n'entrent jamais dans Open Flow : les Actions
+adossées à un Connector, les Triggers de Provider et les proxys passent par un runtime Connector tel
+que [OpenConnector](https://github.com/oomol-lab/open-connector), et Open Flow ne conserve que des
+identités de Connection opaques.
+
+## Démarrage rapide
+
+Vous avez besoin de [Docker](https://docs.docker.com/get-docker/) et d'OpenSSL. Clonez le dépôt, créez
+un token opérateur et démarrez le Server auto-hébergé :
+
+```bash
+git clone https://github.com/oomol-lab/open-flow.git
+cd open-flow
+
+export OPEN_FLOW_TOKEN="$(openssl rand -hex 32)"
+docker build --file apps/server/Dockerfile --tag open-flow-server:dev .
+docker run --rm \
+  --publish 3000:3000 \
+  --env OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN" \
+  --volume open-flow-data:/data/open-flow \
+  open-flow-server:dev
+```
+
+Ouvrez [http://127.0.0.1:3000](http://127.0.0.1:3000) et connectez-vous avec la valeur de
+`OPEN_FLOW_TOKEN`. La même valeur sert de Bearer token pour les clients machine de la Control API.
+Les Projects et l'historique des Runs sont persistés dans le volume Docker `open-flow-data`.
+
+Le Server est utile sans services externes. Les Actions adossées à un Connector, les Triggers de
+Provider et les Tasks LLM échouent de manière sûre (fail closed) tant que la capacité hôte
+correspondante n'est pas configurée ; rien ne bascule vers un service non déclaré.
+
+Pour la configuration de production, TLS, les health checks, la persistance, les sauvegardes et les
+limites de ressources, consultez le [guide de déploiement du Server](server/container-delivery.md) et
+la liste de durcissement dans [SECURITY.md](../SECURITY.md#hardening-your-deployment).
+
+## Connecter un Connector
+
+Pour exécuter des Actions et des Triggers de Provider auprès de services tels que GitHub, Gmail, Slack
+ou Notion, pointez le Server vers un runtime Connector. Un
+[OpenConnector](https://github.com/oomol-lab/open-connector) auto-hébergé comme le Connector hébergé
+par OOMOL exposent tous deux l'API runtime requise.
+
+```dotenv
+OPEN_FLOW_CONNECTOR_ORIGIN=http://open-connector:3000
+OPEN_FLOW_CONNECTOR_TOKEN=replace-with-a-scoped-runtime-token
+OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN=https://connector.example.com
+```
+
+L'origine runtime est l'adresse à laquelle le Server joint le Connector ; l'origine console est celle
+que les navigateurs des utilisateurs ouvrent pour autoriser des comptes dans la Connector Console. Les
+définitions de Triggers de Provider sont livrées avec Open Flow et ne nécessitent aucun
+enregistrement. Consultez la [référence de configuration](server/container-delivery.md#4-配置) pour
+les paramètres de callback d'Integration et les contraintes applicables à chaque origine.
+
+## Un seul produit, des déploiements portables
+
+Le Workbench et la CLI parlent une Control API versionnée plutôt que de dépendre d'une base de données
+ou d'un runtime cloud particulier. Un déploiement est responsable de l'exécution et de la
+persistance ; les clients ne créent pas de second format de projet local et ne basculent pas
+silencieusement vers un autre backend.
+
+Ce dépôt contient :
+
+- [`packages/open-flow`](../packages/open-flow) : le paquet npm public `@oomol-lab/open-flow`, avec
+  les points d'entrée d'authoring, d'exécution, de Trigger, de Control API, de conformité et de
+  runtime Workbench ;
+- [`packages/command`](../packages/command) : le runtime de la commande `oo flow` et le Command
+  Artifact immuable consommé par la [oo CLI](https://github.com/oomol-lab/oo-cli) ;
+- [`apps/server`](../apps/server) : le Workbench auto-hébergé, la Control API, la persistance SQLite,
+  l'ordonnanceur de Triggers et le runtime JavaScript isolé.
+
+Lisez les [limites du produit et de l'architecture](architecture.md) pour le modèle durable, ou la
+[référence de la Control API](control/contracts/control-api.md) pour le contrat HTTP.
+
+## Développer à partir des sources
+
+Open Flow utilise [Bun](https://bun.sh/) pour l'espace de travail et Node.js pour le Server. Utilisez
+les versions épinglées dans `.bun-version` et `.node-version`.
+
+```bash
+bun install --frozen-lockfile
+bun run dev
+```
+
+Ouvrez le Workbench de développement à l'adresse
+[http://127.0.0.1:5173](http://127.0.0.1:5173). Ses requêtes API sont relayées vers le Server sur
+`http://127.0.0.1:3000`.
+
+Le premier lancement en développement crée un token opérateur dans
+`apps/server/.open-flow-dev/operator-token`. Les lancements suivants le réutilisent, de sorte que
+redémarrer le serveur de développement n'invalide pas la session Workbench en cours. Définissez
+`OPEN_FLOW_TOKEN` pour utiliser un token explicite à la place.
+
+Avant de soumettre une modification, exécutez :
+
+```bash
+bun run check
+bun run test
+bun run build
+```
+
+Ajoutez `bun run test:package` lorsque vous touchez au paquet publié ou à la CLI, et
+`bun run test:docker` lorsque Docker est disponible, afin de vérifier l'image de release, le runtime
+isolé, le Workbench, l'arrêt propre et la récupération du volume SQLite. N'exécutez pas `bun test` à
+la racine du dépôt : cela contourne les scripts de test de l'espace de travail. Consultez
+[CONTRIBUTING.md](../CONTRIBUTING.md) pour l'ensemble des règles de développement.
+
+## Documentation
+
+Commencez par l'[index de la documentation](README.md). Les références les plus utiles sont :
+
+- [Limites du produit et de l'architecture](architecture.md)
+- [Control API](control/contracts/control-api.md)
+- [Distribution du Command Artifact](distribution/command-artifact.md)
+- [Notes sur le frontend du Workbench et du Designer](authoring/frontend-ui.md)
+- [Déploiement du Server](server/container-delivery.md)
+- [Contribuer](../CONTRIBUTING.md)
+- [Code de conduite](../CODE_OF_CONDUCT.md)
+- [Sécurité](../SECURITY.md)
+
+## Projets liés
+
+- [OpenConnector](https://github.com/oomol-lab/open-connector) : passerelle de connecteurs open source
+  qui fournit le catalogue de Providers, les identifiants et l'exécution des Actions derrière les nœuds
+  adossés à un Connector.
+- [oo CLI](https://github.com/oomol-lab/oo-cli) : boîte à outils d'agent local qui héberge la commande
+  `oo flow` construite à partir de ce dépôt.
+
+## Contribuer
+
+Les issues et les pull requests sont les bienvenues. Lisez [CONTRIBUTING.md](../CONTRIBUTING.md) pour
+la configuration de développement, les règles du dépôt et les vérifications à exécuter avant d'ouvrir
+une pull request. La participation à ce projet est régie par
+[CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md).
+
+## Sécurité
+
+Veuillez signaler les vulnérabilités de manière privée via le
+[signalement privé de vulnérabilités GitHub](https://github.com/oomol-lab/open-flow/security/advisories/new)
+plutôt que par des issues publiques. [SECURITY.md](../SECURITY.md) décrit les versions prises en
+charge, le processus de divulgation, le périmètre couvert et la manière de durcir un déploiement
+auto-hébergé.
+
+## Licence
+
+[Apache-2.0](../LICENSE). Les mentions relatives aux ressources tierces embarquées figurent dans
+[NOTICE](../NOTICE).

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,0 +1,178 @@
+<div align="center">
+
+# Open Flow
+
+**見える、書ける、動かせる、そして自分のものにできるワークフローを構築する。**
+
+[English](../README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+[![CI](https://github.com/oomol-lab/open-flow/actions/workflows/ci.yaml/badge.svg)](https://github.com/oomol-lab/open-flow/actions/workflows/ci.yaml)
+[![npm](https://img.shields.io/npm/v/%40oomol-lab%2Fopen-flow/next?label=%40oomol-lab%2Fopen-flow)](https://www.npmjs.com/package/@oomol-lab/open-flow)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](../LICENSE)
+![Node.js 26](https://img.shields.io/badge/Node.js-26-339933)
+![Bun 1.4](https://img.shields.io/badge/Bun-1.4-000000)
+
+</div>
+
+Open Flow は、コードを手放すことなくビジュアルキャンバス上で構築できるオープンソースのワークフロー自動化プラットフォームです。
+型付けされたステップを接続し、必要な場所で JavaScript または TypeScript を記述し、Flow を対話的に実行し、自分で管理するデプロイメント上で
+継続的に実行されるように公開できます。
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="assets/light.png">
+    <img alt="Open Flow Workbench で実行中の Hacker News ワークフロー" src="assets/light.png">
+  </picture>
+</p>
+
+> [!IMPORTANT]
+> Open Flow は現在 Alpha 段階です。公開されている契約（contract）はバージョン管理されていますが、プロダクトとしての最初の安定版はまだリリースされていません。
+
+## Open Flow を選ぶ理由
+
+- **ビジュアルで設計し、コードで拡張する。** キャンバス上で型付けされたノードと Subflow を組み合わせ、明示的に残すべきロジックには Script ノードや
+  CodeModule ノードを使います。コードはあくまでコードのままで、フォーム項目に隠された式ではなく、本物の TypeScript を書けます。
+- **実行とデバッグを一か所で。** 実行前に入力と Flow の構造を検証し、各ノードの進行状況と出力を確認し、すべての Run の完全なイベント履歴を追跡できます。
+- **長時間動作する自動化を公開する。** Flow は手動で開始できるほか、Cron スケジュール、Webhook、ポーリングソース、Provider のイベントから起動できます。
+- **運用状態をまとめて管理する。** Project、不変の Revision、Publication、Live バージョン、Run、Trigger の状態は、ローカルファイルと隠れたサービスに
+  分散することなく、選択された一つのデプロイメントに属します。
+- **信頼できないコードを安全に実行する。** Server は、長時間稼働する Executor プロセス内で、コードの Task ごとに新しい V8 isolate を作成し、
+  その Task が宣言した Capability だけを公開します。
+- **実行場所を選べる。** 同梱のセルフホスト Server を使うことも、同じ Workbench と CLI をバージョン管理された Control API の別の実装に接続することもできます。
+
+Open Flow は、ノーコードのプロトタイプでは収まらなくなったものの、不透明なスクリプトとインフラの寄せ集めにはしたくないワークフローのために作られています。
+グラフは理解しやすいまま、コードはコードのまま、そしてデプロイメントは自分の管理下に残ります。
+
+## 仕組み
+
+```mermaid
+flowchart LR
+  Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
+  CLI["oo flow CLI"] -->|"Control API"| Server
+  Server --> Store["SQLite：Project、Revision、Publication、Run"]
+  Server --> Triggers["Trigger スケジューラ：Cron、Webhook、Poll、Integration"]
+  Server --> Runtime["分離された JavaScript ランタイム"]
+  Server -. "任意" .-> Connector["Connector ランタイム"]
+  Connector --> Providers["サードパーティ Provider"]
+```
+
+Workbench と CLI は、バージョン管理された Control API を通じて、選択された一つのデプロイメントとだけ通信します。デプロイメント側が検証、実行、永続化、
+Trigger の受け入れを担当します。Provider の認証情報が Open Flow に入ることはありません。Connector を利用する Action、Provider Trigger、proxy は
+[OpenConnector](https://github.com/oomol-lab/open-connector) のような Connector ランタイムを経由し、Open Flow は不透明な Connection の識別子だけを保存します。
+
+## クイックスタート
+
+[Docker](https://docs.docker.com/get-docker/) と OpenSSL が必要です。リポジトリをクローンし、オペレーター Token を作成して、セルフホストの Server を起動します。
+
+```bash
+git clone https://github.com/oomol-lab/open-flow.git
+cd open-flow
+
+export OPEN_FLOW_TOKEN="$(openssl rand -hex 32)"
+docker build --file apps/server/Dockerfile --tag open-flow-server:dev .
+docker run --rm \
+  --publish 3000:3000 \
+  --env OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN" \
+  --volume open-flow-data:/data/open-flow \
+  open-flow-server:dev
+```
+
+[http://127.0.0.1:3000](http://127.0.0.1:3000) を開き、`OPEN_FLOW_TOKEN` の値でサインインします。同じ値は、Control API を利用するマシンクライアントの
+Bearer Token としても使えます。Project と Run の履歴は `open-flow-data` Docker volume に永続化されます。
+
+Server は外部サービスなしでも利用できます。Connector を利用する Action、Provider Trigger、LLM Task は、対応するホストの Capability が設定されるまで
+フェイルクローズで動作し、非公開のサービスにフォールバックすることはありません。
+
+本番環境の設定、TLS、ヘルスチェック、永続化、バックアップ、リソース制限については、[Server デプロイガイド](server/container-delivery.md) と
+[SECURITY.md](../SECURITY.md#hardening-your-deployment) の強化チェックリストを参照してください。
+
+## Connector を接続する
+
+GitHub、Gmail、Slack、Notion などのサービスに対して Action や Provider Trigger を実行するには、Server を Connector ランタイムに向けます。
+セルフホストの [OpenConnector](https://github.com/oomol-lab/open-connector) と OOMOL がホストする Connector のどちらも、必要なランタイム API を提供しています。
+
+```dotenv
+OPEN_FLOW_CONNECTOR_ORIGIN=http://open-connector:3000
+OPEN_FLOW_CONNECTOR_TOKEN=replace-with-a-scoped-runtime-token
+OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN=https://connector.example.com
+```
+
+runtime origin は Server が Connector に到達するためのアドレスで、console origin はユーザーのブラウザがアカウント認可のために Connector Console を開く
+アドレスです。Provider Trigger の定義は Open Flow に同梱されており、登録は不要です。Integration callback の設定と各 origin の制約については
+[設定リファレンス](server/container-delivery.md#4-配置) を参照してください。
+
+## 一つのプロダクト、ポータブルなデプロイメント
+
+Workbench と CLI は、特定のデータベースやクラウドランタイムに依存するのではなく、バージョン管理された Control API で通信します。デプロイメントが実行と
+永続化を所有し、クライアントは第二のローカル Project 形式を作ったり、暗黙のうちに別のバックエンドへ切り替えたりしません。
+
+このリポジトリには次が含まれます。
+
+- [`packages/open-flow`](../packages/open-flow)：公開 npm パッケージ `@oomol-lab/open-flow`。Authoring、Execution、Trigger、Control API、Conformance、
+  Workbench Runtime の各エントリを提供します。
+- [`packages/command`](../packages/command)：`oo flow` コマンドのランタイムと、[oo CLI](https://github.com/oomol-lab/oo-cli) が利用する不変の
+  Command Artifact。
+- [`apps/server`](../apps/server)：セルフホスト可能な Workbench、Control API、SQLite 永続化、Trigger スケジューラ、分離された JavaScript ランタイム。
+
+永続的なモデルについては[プロダクトとアーキテクチャの境界](architecture.md)を、HTTP の契約については
+[Control API リファレンス](control/contracts/control-api.md)を参照してください。
+
+## ソースから開発する
+
+Open Flow はワークスペースに [Bun](https://bun.sh/) を、Server に Node.js を使用します。`.bun-version` と `.node-version` で固定されたバージョンを使ってください。
+
+```bash
+bun install --frozen-lockfile
+bun run dev
+```
+
+開発用の Workbench は [http://127.0.0.1:5173](http://127.0.0.1:5173) で開きます。その API リクエストは `http://127.0.0.1:3000` の Server にプロキシされます。
+
+初回の開発実行時に、オペレーター Token が `apps/server/.open-flow-dev/operator-token` に作成されます。以降の実行ではこの Token が再利用されるため、
+開発サーバーを再起動しても現在の Workbench セッションは無効になりません。明示的な Token を使いたい場合は `OPEN_FLOW_TOKEN` を設定してください。
+
+変更を提出する前に、次を実行してください。
+
+```bash
+bun run check
+bun run test
+bun run build
+```
+
+公開パッケージや CLI に触れる場合は `bun run test:package` を追加し、Docker が利用できる場合は `bun run test:docker` を実行して、リリースイメージ、
+分離ランタイム、Workbench、graceful shutdown、SQLite volume の復旧を検証してください。リポジトリのルートで `bun test` を直接実行しないでください。
+ワークスペースのテストスクリプトを迂回してしまいます。開発ルールの全文は [CONTRIBUTING.md](../CONTRIBUTING.md) を参照してください。
+
+## ドキュメント
+
+[ドキュメント索引](README.md)から始めてください。特によく参照されるものは次のとおりです。
+
+- [プロダクトとアーキテクチャの境界](architecture.md)
+- [Control API](control/contracts/control-api.md)
+- [Command Artifact の配布契約](distribution/command-artifact.md)
+- [Workbench と Designer のフロントエンドに関する注意](authoring/frontend-ui.md)
+- [Server のデプロイ](server/container-delivery.md)
+- [コントリビューション](../CONTRIBUTING.md)
+- [行動規範](../CODE_OF_CONDUCT.md)
+- [セキュリティ](../SECURITY.md)
+
+## 関連プロジェクト
+
+- [OpenConnector](https://github.com/oomol-lab/open-connector)：Connector を利用するノードの背後で Provider カタログ、認証情報、Action の実行を提供する
+  オープンソースの Connector ゲートウェイ。
+- [oo CLI](https://github.com/oomol-lab/oo-cli)：このリポジトリからビルドされる `oo flow` コマンドをホストするローカル Agent ツールキット。
+
+## コントリビューション
+
+Issue と Pull Request を歓迎します。開発環境のセットアップ、リポジトリのルール、Pull Request を作成する前に実行すべきチェックについては
+[CONTRIBUTING.md](../CONTRIBUTING.md) を参照してください。このプロジェクトへの参加は [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md) に従います。
+
+## セキュリティ
+
+脆弱性は公開 Issue ではなく、[GitHub のプライベート脆弱性報告](https://github.com/oomol-lab/open-flow/security/advisories/new)を通じて非公開で報告してください。
+[SECURITY.md](../SECURITY.md) には、サポート対象のバージョン、開示プロセス、報告の範囲、セルフホストデプロイメントの強化方法が記載されています。
+
+## ライセンス
+
+[Apache-2.0](../LICENSE)。同梱アセットに関するサードパーティの通知は [NOTICE](../NOTICE) に記載されています。

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -1,0 +1,196 @@
+<div align="center">
+
+# Open Flow
+
+**보고, 코딩하고, 실행하고, 직접 소유하는 워크플로를 만드세요.**
+
+[English](../README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+[![CI](https://github.com/oomol-lab/open-flow/actions/workflows/ci.yaml/badge.svg)](https://github.com/oomol-lab/open-flow/actions/workflows/ci.yaml)
+[![npm](https://img.shields.io/npm/v/%40oomol-lab%2Fopen-flow/next?label=%40oomol-lab%2Fopen-flow)](https://www.npmjs.com/package/@oomol-lab/open-flow)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](../LICENSE)
+![Node.js 26](https://img.shields.io/badge/Node.js-26-339933)
+![Bun 1.4](https://img.shields.io/badge/Bun-1.4-000000)
+
+</div>
+
+Open Flow는 코드를 포기하지 않고 시각적 캔버스 위에서 워크플로를 만들 수 있는 오픈소스 워크플로 자동화
+플랫폼입니다. 타입이 지정된 단계를 연결하고, 필요한 곳에는 JavaScript 또는 TypeScript를 작성하고, Flow를
+대화식으로 실행한 뒤, 직접 관리하는 배포 환경에 게시해 지속적으로 실행할 수 있습니다.
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="assets/light.png">
+    <img alt="Open Flow Workbench에서 실행 중인 Hacker News 워크플로" src="assets/light.png">
+  </picture>
+</p>
+
+> [!IMPORTANT]
+> Open Flow는 현재 알파 단계입니다. 공개 계약은 버전 관리되지만, 제품은 아직 첫 안정 버전에 도달하지 않았습니다.
+
+## 왜 Open Flow인가
+
+- **시각적으로 설계하고, 코드로 확장합니다.** 캔버스에서 타입이 지정된 노드와 Subflow를 조합하고, 명시적으로
+  남겨야 할 로직은 Script 노드와 CodeModule 노드로 작성합니다. 코드는 폼 필드 안에 숨겨진 표현식이 아니라 실제
+  TypeScript 코드로 유지됩니다.
+- **한 곳에서 실행하고 디버깅합니다.** 실행 전에 입력과 Flow 구조를 검증하고, 노드의 진행 상황과 출력을 확인하며,
+  모든 Run의 전체 이벤트 이력을 따라갈 수 있습니다.
+- **장기 실행 자동화를 게시합니다.** Flow는 수동으로 시작할 수도 있고 Cron 일정, Webhook, 폴링 소스, Provider
+  이벤트로 시작할 수도 있습니다.
+- **운영 상태를 한데 모읍니다.** Project, 불변 Revision, Publication, Live 버전, Run, Trigger 상태는 로컬 파일과
+  숨겨진 서비스에 흩어지지 않고 선택된 하나의 배포에 속합니다.
+- **신뢰할 수 없는 코드를 안전하게 실행합니다.** Server는 오래 유지되는 Executor 프로세스 안에서 코드 Task마다 새
+  V8 isolate를 만들고, 해당 Task가 선언한 Capability만 제공합니다.
+- **실행 위치를 직접 선택합니다.** 포함된 자체 호스팅 Server를 사용하거나, 같은 Workbench와 CLI를 버전 관리되는
+  Control API의 다른 구현에 연결할 수 있습니다.
+
+Open Flow는 노코드 프로토타입 수준을 넘어섰지만 불투명한 스크립트와 인프라 더미가 되어서는 안 되는 워크플로를
+위해 만들어졌습니다. 그래프는 계속 이해할 수 있는 상태로, 코드는 계속 코드로, 배포는 계속 여러분의 통제 아래
+남습니다.
+
+## 동작 방식
+
+```mermaid
+flowchart LR
+  Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
+  CLI["oo flow CLI"] -->|"Control API"| Server
+  Server --> Store["SQLite: Project, Revision, Publication, Run"]
+  Server --> Triggers["Trigger 스케줄러: Cron, Webhook, Poll, Integration"]
+  Server --> Runtime["격리된 JavaScript 런타임"]
+  Server -. "선택 사항" .-> Connector["Connector 런타임"]
+  Connector --> Providers["서드파티 Provider"]
+```
+
+Workbench와 CLI는 버전 관리되는 Control API를 통해 선택된 하나의 배포와만 통신합니다. 배포는 검증, 실행, 영속화,
+Trigger 승인을 담당합니다. Provider 자격 증명은 Open Flow에 들어오지 않습니다. Connector 기반 Action, Provider
+Trigger, 프록시는 [OpenConnector](https://github.com/oomol-lab/open-connector) 같은 Connector 런타임을 거치며,
+Open Flow는 불투명한 Connection 식별자만 저장합니다.
+
+## 빠른 시작
+
+[Docker](https://docs.docker.com/get-docker/)와 OpenSSL이 필요합니다. 저장소를 클론하고, 운영자 토큰을 만든 뒤,
+자체 호스팅 Server를 시작합니다.
+
+```bash
+git clone https://github.com/oomol-lab/open-flow.git
+cd open-flow
+
+export OPEN_FLOW_TOKEN="$(openssl rand -hex 32)"
+docker build --file apps/server/Dockerfile --tag open-flow-server:dev .
+docker run --rm \
+  --publish 3000:3000 \
+  --env OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN" \
+  --volume open-flow-data:/data/open-flow \
+  open-flow-server:dev
+```
+
+[http://127.0.0.1:3000](http://127.0.0.1:3000)을 열고 `OPEN_FLOW_TOKEN` 값으로 로그인합니다. 같은 값은 Control
+API의 머신 클라이언트를 위한 Bearer 토큰으로도 사용할 수 있습니다. Project와 Run 이력은 `open-flow-data` Docker
+볼륨에 저장됩니다.
+
+Server는 외부 서비스 없이도 유용하게 사용할 수 있습니다. Connector 기반 Action, Provider Trigger, LLM Task는 해당
+호스트 Capability가 구성될 때까지 실행을 거부하며, 어떤 것도 공개되지 않은 서비스로 대체되지 않습니다.
+
+프로덕션 구성, TLS, 헬스 체크, 영속화, 백업, 리소스 제한은 [Server 배포 가이드](server/container-delivery.md)와
+[SECURITY.md](../SECURITY.md#hardening-your-deployment)의 강화 체크리스트를 참고하세요.
+
+## Connector 연결
+
+GitHub, Gmail, Slack, Notion 같은 서비스에 대해 Action과 Provider Trigger를 실행하려면 Server가 Connector 런타임을
+가리키도록 설정합니다. 자체 호스팅한 [OpenConnector](https://github.com/oomol-lab/open-connector)와 OOMOL이 호스팅하는
+Connector 모두 필요한 런타임 API를 제공합니다.
+
+```dotenv
+OPEN_FLOW_CONNECTOR_ORIGIN=http://open-connector:3000
+OPEN_FLOW_CONNECTOR_TOKEN=replace-with-a-scoped-runtime-token
+OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN=https://connector.example.com
+```
+
+runtime origin은 Server가 Connector에 접근하는 주소이고, console origin은 사용자의 브라우저가 계정을 승인하기 위해
+Connector Console을 여는 주소입니다. Provider Trigger 정의는 Open Flow에 내장되어 있으므로 별도 등록이 필요 없습니다.
+Integration 콜백 설정과 각 origin의 제약은 [구성 참조](server/container-delivery.md#4-配置)를 참고하세요.
+
+## 하나의 제품, 이식 가능한 배포
+
+Workbench와 CLI는 특정 데이터베이스나 클라우드 런타임에 의존하지 않고 버전 관리되는 Control API로 통신합니다.
+배포가 실행과 영속화를 담당하며, 클라이언트는 두 번째 로컬 Project 형식을 만들거나 다른 백엔드로 조용히 전환하지
+않습니다.
+
+이 저장소에는 다음이 포함되어 있습니다.
+
+- [`packages/open-flow`](../packages/open-flow): Authoring, Execution, Trigger, Control API, Conformance,
+  Workbench Runtime 진입점을 제공하는 공개 `@oomol-lab/open-flow` npm 패키지
+- [`packages/command`](../packages/command): `oo flow` 명령 런타임과
+  [oo CLI](https://github.com/oomol-lab/oo-cli)가 사용하는 불변 Command Artifact
+- [`apps/server`](../apps/server): 자체 호스팅 가능한 Workbench, Control API, SQLite 영속화, Trigger 스케줄러,
+  격리된 JavaScript 런타임
+
+지속되는 제품 모델은 [제품 및 아키텍처 경계](architecture.md)에서, HTTP 계약은
+[Control API 참조](control/contracts/control-api.md)에서 확인할 수 있습니다.
+
+## 소스에서 개발하기
+
+Open Flow는 워크스페이스에 [Bun](https://bun.sh/)을, Server에 Node.js를 사용합니다. `.bun-version`과
+`.node-version`에 고정된 버전을 사용하세요.
+
+```bash
+bun install --frozen-lockfile
+bun run dev
+```
+
+개발용 Workbench는 [http://127.0.0.1:5173](http://127.0.0.1:5173)에서 열 수 있습니다. API 요청은
+`http://127.0.0.1:3000`의 Server로 프록시됩니다.
+
+첫 개발 실행 시 운영자 토큰이 `apps/server/.open-flow-dev/operator-token`에 생성됩니다. 이후 실행에서는 같은 토큰을
+재사용하므로 개발 서버를 재시작해도 현재 Workbench 세션이 무효화되지 않습니다. 명시적인 토큰을 사용하려면
+`OPEN_FLOW_TOKEN`을 설정하세요.
+
+변경 사항을 제출하기 전에 다음을 실행합니다.
+
+```bash
+bun run check
+bun run test
+bun run build
+```
+
+게시되는 패키지나 CLI를 수정할 때는 `bun run test:package`를 추가로 실행하고, Docker를 사용할 수 있다면
+`bun run test:docker`로 릴리스 이미지, 격리 런타임, Workbench, 정상 종료, SQLite 볼륨 복구를 검증하세요. 저장소
+루트에서 `bun test`를 직접 실행하지 마세요. 워크스페이스 테스트 스크립트를 우회하게 됩니다. 전체 개발 규칙은
+[CONTRIBUTING.md](../CONTRIBUTING.md)를 참고하세요.
+
+## 문서
+
+[문서 색인](README.md)에서 시작하세요. 가장 유용한 참조는 다음과 같습니다.
+
+- [제품 및 아키텍처 경계](architecture.md)
+- [Control API](control/contracts/control-api.md)
+- [Command Artifact 배포 계약](distribution/command-artifact.md)
+- [Workbench 및 Designer 프런트엔드 참고 사항](authoring/frontend-ui.md)
+- [Server 배포](server/container-delivery.md)
+- [기여 안내](../CONTRIBUTING.md)
+- [행동 강령](../CODE_OF_CONDUCT.md)
+- [보안 정책](../SECURITY.md)
+
+## 관련 프로젝트
+
+- [OpenConnector](https://github.com/oomol-lab/open-connector): Connector 기반 노드 뒤에서 Provider 카탈로그, 자격
+  증명, Action 실행을 제공하는 오픈소스 Connector 게이트웨이
+- [oo CLI](https://github.com/oomol-lab/oo-cli): 이 저장소에서 빌드된 `oo flow` 명령을 호스팅하는 로컬 Agent 툴킷
+
+## 기여하기
+
+Issue와 Pull Request를 환영합니다. 개발 환경 설정, 저장소 규칙, Pull Request를 열기 전에 실행할 검사는
+[CONTRIBUTING.md](../CONTRIBUTING.md)를 참고하세요. 이 프로젝트 참여는 [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)를
+따릅니다.
+
+## 보안
+
+취약점은 공개 Issue 대신
+[GitHub 비공개 취약점 보고](https://github.com/oomol-lab/open-flow/security/advisories/new)를 통해 비공개로 보고해
+주세요. [SECURITY.md](../SECURITY.md)에 지원되는 버전, 공개 절차, 보고 범위, 자체 호스팅 배포 강화 방법이 설명되어
+있습니다.
+
+## 라이선스
+
+[Apache-2.0](../LICENSE). 번들된 자산의 서드파티 고지는 [NOTICE](../NOTICE)에 정리되어 있습니다.

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -1,0 +1,211 @@
+<div align="center">
+
+# Open Flow
+
+**Создавайте workflow, которые можно увидеть, написать кодом, запустить и полностью контролировать.**
+
+[English](../README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+[![CI](https://github.com/oomol-lab/open-flow/actions/workflows/ci.yaml/badge.svg)](https://github.com/oomol-lab/open-flow/actions/workflows/ci.yaml)
+[![npm](https://img.shields.io/npm/v/%40oomol-lab%2Fopen-flow/next?label=%40oomol-lab%2Fopen-flow)](https://www.npmjs.com/package/@oomol-lab/open-flow)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](../LICENSE)
+![Node.js 26](https://img.shields.io/badge/Node.js-26-339933)
+![Bun 1.4](https://img.shields.io/badge/Bun-1.4-000000)
+
+</div>
+
+Open Flow является платформой автоматизации workflow с открытым исходным кодом. Вы строите процесс на
+визуальном холсте, не отказываясь от кода: соединяете типизированные шаги, пишете JavaScript или
+TypeScript там, где это уместно, запускаете Flow в интерактивном режиме и публикуете его для
+непрерывного выполнения на deployment, который контролируете вы.
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="assets/light.png">
+    <img alt="Workflow для Hacker News, выполняющийся в Open Flow Workbench" src="assets/light.png">
+  </picture>
+</p>
+
+> [!IMPORTANT]
+> Open Flow находится на стадии alpha. Его контракты версионируются, но продукт ещё не достиг первого
+> стабильного релиза.
+
+## Почему Open Flow
+
+- **Проектируйте визуально, расширяйте кодом.** Собирайте типизированные узлы и Subflow на холсте, а
+  логику, которая должна оставаться явной, выносите в узлы Script и CodeModule. Код остаётся кодом:
+  это настоящий TypeScript, а не выражения, спрятанные в полях формы.
+- **Запускайте и отлаживайте в одном месте.** Проверяйте входные данные и структуру Flow до
+  выполнения, следите за прогрессом и выводом узлов и просматривайте полную историю событий каждого
+  Run.
+- **Публикуйте долгоживущую автоматизацию.** Запускайте Flow вручную либо по расписанию Cron, через
+  Webhook, источники polling и события Provider.
+- **Держите операционное состояние вместе.** Project, неизменяемые Revision, Publication, версии
+  Live, Run и состояние Trigger принадлежат одному выбранному deployment, а не разбросаны между
+  локальными файлами и скрытыми сервисами.
+- **Безопасно выполняйте недоверенный код.** Server выполняет каждый кодовый Task в новом V8 isolate
+  внутри долгоживущего процесса Executor и предоставляет только те Capability, которые объявил этот
+  Task.
+- **Выбирайте, где всё работает.** Используйте входящий в комплект self-hosted Server или подключите
+  те же Workbench и CLI к другой реализации версионированного Control API.
+
+Open Flow создан для workflow, которые переросли no-code прототип, но не должны превращаться в
+непрозрачный набор скриптов и инфраструктуры. Граф остаётся понятным, код остаётся кодом, а
+deployment остаётся под вашим контролем.
+
+## Как это работает
+
+```mermaid
+flowchart LR
+  Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
+  CLI["oo flow CLI"] -->|"Control API"| Server
+  Server --> Store["SQLite: Project, Revision, Publication, Run"]
+  Server --> Triggers["Планировщик Trigger: Cron, Webhook, Poll, Integration"]
+  Server --> Runtime["Изолированная среда выполнения JavaScript"]
+  Server -. "опционально" .-> Connector["Среда выполнения Connector"]
+  Connector --> Providers["Сторонние Provider"]
+```
+
+Workbench и CLI общаются только с одним выбранным deployment через версионированный Control API.
+Deployment отвечает за валидацию, выполнение, персистентность и допуск Trigger. Учётные данные
+Provider никогда не попадают в Open Flow: Action на базе Connector, Trigger от Provider и proxy
+проходят через среду выполнения Connector, например
+[OpenConnector](https://github.com/oomol-lab/open-connector), а Open Flow хранит только непрозрачные
+идентификаторы Connection.
+
+## Быстрый старт
+
+Вам понадобятся [Docker](https://docs.docker.com/get-docker/) и OpenSSL. Клонируйте репозиторий,
+создайте токен оператора и запустите self-hosted Server:
+
+```bash
+git clone https://github.com/oomol-lab/open-flow.git
+cd open-flow
+
+export OPEN_FLOW_TOKEN="$(openssl rand -hex 32)"
+docker build --file apps/server/Dockerfile --tag open-flow-server:dev .
+docker run --rm \
+  --publish 3000:3000 \
+  --env OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN" \
+  --volume open-flow-data:/data/open-flow \
+  open-flow-server:dev
+```
+
+Откройте [http://127.0.0.1:3000](http://127.0.0.1:3000) и войдите, указав значение
+`OPEN_FLOW_TOKEN`. То же значение работает как Bearer token для машинных клиентов Control API.
+Project и история Run сохраняются в Docker volume `open-flow-data`.
+
+Server полезен и без внешних сервисов. Action на базе Connector, Trigger от Provider и LLM Task
+отказывают безопасно (fail closed), пока не настроена соответствующая host capability; ничто не
+переключается на нераскрытый сервис.
+
+Конфигурация для production, TLS, health check, персистентность, резервное копирование и лимиты
+ресурсов описаны в [руководстве по развёртыванию Server](server/container-delivery.md) и в чеклисте
+по усилению защиты в [SECURITY.md](../SECURITY.md#hardening-your-deployment).
+
+## Подключение Connector
+
+Чтобы выполнять Action и Trigger от Provider для таких сервисов, как GitHub, Gmail, Slack или Notion,
+укажите Server среду выполнения Connector. Необходимый runtime API предоставляют как self-hosted
+[OpenConnector](https://github.com/oomol-lab/open-connector), так и Connector, размещённый OOMOL.
+
+```dotenv
+OPEN_FLOW_CONNECTOR_ORIGIN=http://open-connector:3000
+OPEN_FLOW_CONNECTOR_TOKEN=replace-with-a-scoped-runtime-token
+OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN=https://connector.example.com
+```
+
+Runtime origin определяет, где Server обращается к Connector; console origin определяет, где браузеры
+пользователей открывают Connector Console для авторизации аккаунтов. Определения Trigger от Provider
+поставляются вместе с Open Flow и не требуют регистрации. Настройки Integration callback и
+ограничения для каждого origin см. в [справочнике по конфигурации](server/container-delivery.md#4-配置).
+
+## Один продукт, переносимые deployment
+
+Workbench и CLI используют версионированный Control API и не зависят от конкретной базы данных или
+облачной среды выполнения. Deployment владеет выполнением и персистентностью; клиенты не создают
+второй локальный формат проекта и не переключаются молча на другой backend.
+
+Этот репозиторий содержит:
+
+- [`packages/open-flow`](../packages/open-flow): публичный npm-пакет `@oomol-lab/open-flow` с
+  точками входа для authoring, execution, Trigger, Control API, conformance и Workbench runtime;
+- [`packages/command`](../packages/command): среду выполнения команды `oo flow` и неизменяемый
+  Command Artifact, который использует [oo CLI](https://github.com/oomol-lab/oo-cli);
+- [`apps/server`](../apps/server): self-hosted Workbench, Control API, персистентность на SQLite,
+  планировщик Trigger и изолированную среду выполнения JavaScript.
+
+Долгосрочная модель продукта описана в [границах продукта и архитектуры](architecture.md), а HTTP
+контракт в [справочнике Control API](control/contracts/control-api.md).
+
+## Разработка из исходного кода
+
+Open Flow использует [Bun](https://bun.sh/) для workspace и Node.js для Server. Используйте версии,
+зафиксированные в `.bun-version` и `.node-version`.
+
+```bash
+bun install --frozen-lockfile
+bun run dev
+```
+
+Откройте Workbench для разработки по адресу [http://127.0.0.1:5173](http://127.0.0.1:5173). Его
+API-запросы проксируются на Server по адресу `http://127.0.0.1:3000`.
+
+При первом запуске в режиме разработки создаётся токен оператора в
+`apps/server/.open-flow-dev/operator-token`. Последующие запуски используют его повторно, поэтому
+перезапуск сервера разработки не сбрасывает текущую сессию Workbench. Чтобы задать токен явно,
+установите `OPEN_FLOW_TOKEN`.
+
+Перед отправкой изменений выполните:
+
+```bash
+bun run check
+bun run test
+bun run build
+```
+
+Добавьте `bun run test:package`, если затрагиваете публикуемый пакет или CLI, и `bun run test:docker`,
+если доступен Docker, чтобы проверить релизный образ, изолированную среду выполнения, Workbench,
+корректное завершение работы и восстановление SQLite volume. Не запускайте `bun test` в корне
+репозитория: это обходит тестовые скрипты workspace. Полные правила разработки см. в
+[CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Документация
+
+Начните с [индекса документации](README.md). Наиболее полезные справочники:
+
+- [Границы продукта и архитектуры](architecture.md)
+- [Control API](control/contracts/control-api.md)
+- [Дистрибуция Command Artifact](distribution/command-artifact.md)
+- [Заметки по frontend Workbench и Designer](authoring/frontend-ui.md)
+- [Развёртывание Server](server/container-delivery.md)
+- [Участие в разработке](../CONTRIBUTING.md)
+- [Кодекс поведения](../CODE_OF_CONDUCT.md)
+- [Безопасность](../SECURITY.md)
+
+## Связанные проекты
+
+- [OpenConnector](https://github.com/oomol-lab/open-connector): шлюз коннекторов с открытым исходным
+  кодом, который предоставляет каталог Provider, учётные данные и выполнение Action для узлов на базе
+  Connector.
+- [oo CLI](https://github.com/oomol-lab/oo-cli): локальный набор инструментов для агентов, в котором
+  размещается команда `oo flow`, собранная из этого репозитория.
+
+## Участие в разработке
+
+Issue и pull request приветствуются. Настройка окружения, правила репозитория и проверки перед
+открытием pull request описаны в [CONTRIBUTING.md](../CONTRIBUTING.md). Участие в проекте
+регулируется [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md).
+
+## Безопасность
+
+Сообщайте об уязвимостях приватно через
+[приватные отчёты об уязвимостях GitHub](https://github.com/oomol-lab/open-flow/security/advisories/new),
+а не через публичные issue. В [SECURITY.md](../SECURITY.md) описаны поддерживаемые версии, процесс
+раскрытия, область действия и способы усиления защиты self-hosted deployment.
+
+## Лицензия
+
+[Apache-2.0](../LICENSE). Уведомления о сторонних компонентах для включённых ресурсов перечислены в
+[NOTICE](../NOTICE).

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -4,11 +4,11 @@
 
 **在画布上搭工作流，需要时直接写代码，最后部署到自己的环境。**
 
-[English](README.md) | 简体中文
+[English](../README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
 
 [![CI](https://github.com/oomol-lab/open-flow/actions/workflows/ci.yaml/badge.svg)](https://github.com/oomol-lab/open-flow/actions/workflows/ci.yaml)
 [![npm](https://img.shields.io/npm/v/%40oomol-lab%2Fopen-flow/next?label=%40oomol-lab%2Fopen-flow)](https://www.npmjs.com/package/@oomol-lab/open-flow)
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](LICENSE)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](../LICENSE)
 ![Node.js 26](https://img.shields.io/badge/Node.js-26-339933)
 ![Bun 1.4](https://img.shields.io/badge/Bun-1.4-000000)
 
@@ -19,9 +19,9 @@ TypeScript，直接运行和调试 Flow，再把它发布成持续工作的自�
 
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="./docs/assets/dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="./docs/assets/light.png">
-    <img alt="Open Flow Workbench 中正在运行的 Hacker News 工作流" src="./docs/assets/light.png">
+    <source media="(prefers-color-scheme: dark)" srcset="assets/dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="assets/light.png">
+    <img alt="Open Flow Workbench 中正在运行的 Hacker News 工作流" src="assets/light.png">
   </picture>
 </p>
 
@@ -81,7 +81,7 @@ docker run --rm \
 时会拒绝执行，不会退回到来源不明的服务。
 
 生产环境所需的配置、TLS、健康检查、数据持久化、备份和资源限制，参见
-[Server 部署文档](docs/server/container-delivery.md) 和 [SECURITY.md](SECURITY.md#hardening-your-deployment) 中的加固清单。
+[Server 部署文档](server/container-delivery.md) 和 [SECURITY.md](../SECURITY.md#hardening-your-deployment) 中的加固清单。
 
 ## 接入 Connector
 
@@ -96,7 +96,7 @@ OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN=https://connector.example.com
 
 runtime origin 是 Server 访问 Connector 的地址，console origin 是用户浏览器打开 Connector Console 授权账号的地址。Provider Trigger
 定义随 Open Flow 内置，不需要额外注册。Integration callback 的配置和各 origin 的约束参见
-[配置说明](docs/server/container-delivery.md#4-配置)。
+[配置说明](server/container-delivery.md#4-配置)。
 
 ## 一套产品，多种部署
 
@@ -105,14 +105,14 @@ Project 格式，也不会在请求失败时暗中切换后端。
 
 仓库主要包含：
 
-- [`packages/open-flow`](packages/open-flow)：公开的 `@oomol-lab/open-flow` npm 包，提供 Authoring、Execution、Trigger、Control
+- [`packages/open-flow`](../packages/open-flow)：公开的 `@oomol-lab/open-flow` npm 包，提供 Authoring、Execution、Trigger、Control
   API、Conformance 和 Workbench Runtime 入口；
-- [`packages/command`](packages/command)：`oo flow` 命令运行时和交付给 [oo CLI](https://github.com/oomol-lab/oo-cli) 的不可变
+- [`packages/command`](../packages/command)：`oo flow` 命令运行时和交付给 [oo CLI](https://github.com/oomol-lab/oo-cli) 的不可变
   Command Artifact；
-- [`apps/server`](apps/server)：可自行部署的 Workbench、Control API、SQLite 存储、Trigger Scheduler 和隔离的 JavaScript Runtime。
+- [`apps/server`](../apps/server)：可自行部署的 Workbench、Control API、SQLite 存储、Trigger Scheduler 和隔离的 JavaScript Runtime。
 
-长期成立的产品模型记录在[产品与架构边界](docs/architecture.md)中，HTTP 接口定义参见
-[Control API 文档](docs/control/contracts/control-api.md)。
+长期成立的产品模型记录在[产品与架构边界](architecture.md)中，HTTP 接口定义参见
+[Control API 文档](control/contracts/control-api.md)。
 
 ## 从源码开发
 
@@ -138,20 +138,20 @@ bun run build
 ```
 
 改动发布包或 CLI 时加跑 `bun run test:package`；本机有 Docker 时运行 `bun run test:docker`，检查发布镜像、隔离运行时、Workbench、正常退出和
-SQLite volume 恢复。不要在仓库根目录直接运行 `bun test`，它会绕过各工作区的测试脚本。完整的开发规则见 [CONTRIBUTING.md](CONTRIBUTING.md)。
+SQLite volume 恢复。不要在仓库根目录直接运行 `bun test`，它会绕过各工作区的测试脚本。完整的开发规则见 [CONTRIBUTING.md](../CONTRIBUTING.md)。
 
 ## 文档
 
-可以从[文档索引](docs/README.md)开始，常用内容包括：
+可以从[文档索引](README.md)开始，常用内容包括：
 
-- [产品与架构边界](docs/architecture.md)
-- [Control API](docs/control/contracts/control-api.md)
-- [Command Artifact 分发合同](docs/distribution/command-artifact.md)
-- [Workbench 与 Designer 前端注意事项](docs/authoring/frontend-ui.md)
-- [Server 部署](docs/server/container-delivery.md)
-- [参与贡献](CONTRIBUTING.md)
-- [行为准则](CODE_OF_CONDUCT.md)
-- [安全政策](SECURITY.md)
+- [产品与架构边界](architecture.md)
+- [Control API](control/contracts/control-api.md)
+- [Command Artifact 分发合同](distribution/command-artifact.md)
+- [Workbench 与 Designer 前端注意事项](authoring/frontend-ui.md)
+- [Server 部署](server/container-delivery.md)
+- [参与贡献](../CONTRIBUTING.md)
+- [行为准则](../CODE_OF_CONDUCT.md)
+- [安全政策](../SECURITY.md)
 
 ## 相关项目
 
@@ -161,14 +161,14 @@ SQLite volume 恢复。不要在仓库根目录直接运行 `bun test`，它会�
 
 ## 参与贡献
 
-欢迎提交 Issue 和 Pull Request。开发环境、仓库规则和提交前需要运行的检查见 [CONTRIBUTING.md](CONTRIBUTING.md)。参与本项目需遵守
-[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)。
+欢迎提交 Issue 和 Pull Request。开发环境、仓库规则和提交前需要运行的检查见 [CONTRIBUTING.md](../CONTRIBUTING.md)。参与本项目需遵守
+[CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)。
 
 ## 安全
 
 请通过 [GitHub 私密漏洞报告](https://github.com/oomol-lab/open-flow/security/advisories/new) 报告安全问题，不要提交公开
-Issue。[SECURITY.md](SECURITY.md) 说明了受支持的版本、披露流程、报告范围以及自行部署时的加固建议。
+Issue。[SECURITY.md](../SECURITY.md) 说明了受支持的版本、披露流程、报告范围以及自行部署时的加固建议。
 
 ## 许可证
 
-[Apache-2.0](LICENSE)。打包资源涉及的第三方声明见 [NOTICE](NOTICE)。
+[Apache-2.0](../LICENSE)。打包资源涉及的第三方声明见 [NOTICE](../NOTICE)。

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -1,0 +1,174 @@
+<div align="center">
+
+# Open Flow
+
+**在畫布上建立工作流程，需要時直接寫程式碼，最後部署到自己的環境。**
+
+[English](../README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+[![CI](https://github.com/oomol-lab/open-flow/actions/workflows/ci.yaml/badge.svg)](https://github.com/oomol-lab/open-flow/actions/workflows/ci.yaml)
+[![npm](https://img.shields.io/npm/v/%40oomol-lab%2Fopen-flow/next?label=%40oomol-lab%2Fopen-flow)](https://www.npmjs.com/package/@oomol-lab/open-flow)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](../LICENSE)
+![Node.js 26](https://img.shields.io/badge/Node.js-26-339933)
+![Bun 1.4](https://img.shields.io/badge/Bun-1.4-000000)
+
+</div>
+
+Open Flow 是一個開源的工作流程自動化平台。你可以在畫布上連接具型別約束的節點，在合適的位置撰寫 JavaScript 或
+TypeScript，直接執行和偵錯 Flow，再把它發布成持續運作的自動化流程，並部署在自己掌控的環境中。
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="assets/light.png">
+    <img alt="Open Flow Workbench 中正在執行的 Hacker News 工作流程" src="assets/light.png">
+  </picture>
+</p>
+
+> [!IMPORTANT]
+> Open Flow 目前處於 Alpha 階段。公開協定有版本管理，但產品尚未發布第一個穩定版本。
+
+## 為什麼選擇 Open Flow
+
+- **視覺化設計，用程式碼擴充。** 在畫布上組合具型別約束的節點和 Subflow；遇到更適合用程式碼處理的邏輯，直接使用 Script 或 CodeModule
+  節點，寫的是真正的 TypeScript，而不是藏在表單裡的運算式。
+- **執行和偵錯在同一處。** 執行前檢查輸入和 Flow 結構，執行時查看每個節點的進度、輸出和完整事件記錄。
+- **發布為長期執行的自動化。** Flow 可以手動啟動，也可以由 Cron、Webhook、輪詢資料來源或 Provider Event 觸發。
+- **執行狀態集中管理。** Project、不可變的 Revision、Publication、Live 版本、Run 和 Trigger 狀態都由目前的部署管理，不會散落在本機檔案和隱藏服務中。
+- **安全地執行使用者程式碼。** Server 在常駐的 Executor 程序中為每次程式碼 Task 呼叫建立全新的 V8 isolate，只開放該 Task 明確宣告的 Capability。
+- **自由選擇執行環境。** 可以使用儲存庫內建的 Server 自行部署，也可以讓同一套 Workbench 和 CLI 連接其他相容 Control API 的實作。
+
+Open Flow 適合已經超出簡單無程式碼原型，但又不想變成一堆腳本和基礎設施的工作流程。流程圖仍然容易理解，需要撰寫的程式碼也保留為正常的程式碼，執行環境由你決定。
+
+## 運作方式
+
+```mermaid
+flowchart LR
+  Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
+  CLI["oo flow CLI"] -->|"Control API"| Server
+  Server --> Store["SQLite：Project、Revision、Publication、Run"]
+  Server --> Triggers["Trigger 排程：Cron、Webhook、Poll、Integration"]
+  Server --> Runtime["隔離的 JavaScript 執行環境"]
+  Server -. "選用" .-> Connector["Connector 執行環境"]
+  Connector --> Providers["第三方 Provider"]
+```
+
+Workbench 和 CLI 只透過有版本的 Control API 與目前選定的一個部署通訊。部署端負責 validation、執行、持久化和 Trigger 准入。Provider
+憑證不會進入 Open Flow：Connector Action、Provider Trigger 和 proxy 都經由
+[OpenConnector](https://github.com/oomol-lab/open-connector) 這類 Connector 執行環境完成，Open Flow 只保存不透明的 Connection 識別。
+
+## 快速開始
+
+準備好 [Docker](https://docs.docker.com/get-docker/) 和 OpenSSL，然後複製儲存庫、產生管理員 Token 並啟動 Server：
+
+```bash
+git clone https://github.com/oomol-lab/open-flow.git
+cd open-flow
+
+export OPEN_FLOW_TOKEN="$(openssl rand -hex 32)"
+docker build --file apps/server/Dockerfile --tag open-flow-server:dev .
+docker run --rm \
+  --publish 3000:3000 \
+  --env OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN" \
+  --volume open-flow-data:/data/open-flow \
+  open-flow-server:dev
+```
+
+開啟 [http://127.0.0.1:3000](http://127.0.0.1:3000)，使用 `OPEN_FLOW_TOKEN` 的值登入。同一個值也可以作為 Control API 的 Bearer Token
+供機器用戶端使用。Project 和 Run 歷史會儲存在 `open-flow-data` Docker volume 中。
+
+不接外部服務時，Server 仍然可以獨立使用。Connector Action、Provider Trigger 和 LLM Task 在沒有設定對應 Host Capability
+時會拒絕執行，不會退回到來源不明的服務。
+
+正式環境所需的設定、TLS、健康檢查、資料持久化、備份和資源限制，請參閱
+[Server 部署文件](server/container-delivery.md) 和 [SECURITY.md](../SECURITY.md#hardening-your-deployment) 中的強化清單。
+
+## 接入 Connector
+
+要對 GitHub、Gmail、Slack、Notion 等服務執行 Action 和 Provider Trigger，需要把 Server 指向一個 Connector 執行環境。自行部署的
+[OpenConnector](https://github.com/oomol-lab/open-connector) 和 OOMOL 託管的 Connector 都提供所需的執行環境 API。
+
+```dotenv
+OPEN_FLOW_CONNECTOR_ORIGIN=http://open-connector:3000
+OPEN_FLOW_CONNECTOR_TOKEN=replace-with-a-scoped-runtime-token
+OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN=https://connector.example.com
+```
+
+runtime origin 是 Server 存取 Connector 的位址，console origin 是使用者瀏覽器開啟 Connector Console 授權帳號的位址。Provider Trigger
+定義隨 Open Flow 內建，不需要額外註冊。Integration callback 的設定和各 origin 的限制請參閱
+[設定說明](server/container-delivery.md#4-配置)。
+
+## 一套產品，多種部署
+
+Workbench 和 CLI 透過有版本的 Control API 運作，不依賴特定資料庫或雲端執行環境。部署端負責執行和持久化；用戶端不會建立第二套本機
+Project 格式，也不會在請求失敗時暗中切換後端。
+
+儲存庫主要包含：
+
+- [`packages/open-flow`](../packages/open-flow)：公開的 `@oomol-lab/open-flow` npm 套件，提供 Authoring、Execution、Trigger、Control
+  API、Conformance 和 Workbench Runtime 進入點；
+- [`packages/command`](../packages/command)：`oo flow` 命令執行環境和交付給 [oo CLI](https://github.com/oomol-lab/oo-cli) 的不可變
+  Command Artifact；
+- [`apps/server`](../apps/server)：可自行部署的 Workbench、Control API、SQLite 儲存、Trigger Scheduler 和隔離的 JavaScript Runtime。
+
+長期成立的產品模型記錄在[產品與架構邊界](architecture.md)中，HTTP 介面定義請參閱
+[Control API 文件](control/contracts/control-api.md)。
+
+## 從原始碼開發
+
+Open Flow 的工作區使用 [Bun](https://bun.sh/)，Server 執行在 Node.js 上。請使用 `.bun-version` 和 `.node-version` 中固定的版本。
+
+```bash
+bun install --frozen-lockfile
+bun run dev
+```
+
+開發環境的 Workbench 位於 [http://127.0.0.1:5173](http://127.0.0.1:5173)，API 請求會代理到
+`http://127.0.0.1:3000` 上的 Server。
+
+第一次啟動開發環境時，Server 會把管理員 Token 寫入 `apps/server/.open-flow-dev/operator-token`，後續啟動繼續使用同一個
+Token，因此重新啟動開發服務不會讓目前的 Workbench 登入狀態失效。如果需要指定 Token，可以設定 `OPEN_FLOW_TOKEN`。
+
+提交程式碼前請執行：
+
+```bash
+bun run check
+bun run test
+bun run build
+```
+
+修改發布套件或 CLI 時加跑 `bun run test:package`；本機有 Docker 時執行 `bun run test:docker`，檢查發布映像檔、隔離執行環境、Workbench、正常結束和
+SQLite volume 復原。不要在儲存庫根目錄直接執行 `bun test`，它會繞過各工作區的測試腳本。完整的開發規則請參閱 [CONTRIBUTING.md](../CONTRIBUTING.md)。
+
+## 文件
+
+可以從[文件索引](README.md)開始，常用內容包括：
+
+- [產品與架構邊界](architecture.md)
+- [Control API](control/contracts/control-api.md)
+- [Command Artifact 發布合約](distribution/command-artifact.md)
+- [Workbench 與 Designer 前端注意事項](authoring/frontend-ui.md)
+- [Server 部署](server/container-delivery.md)
+- [參與貢獻](../CONTRIBUTING.md)
+- [行為準則](../CODE_OF_CONDUCT.md)
+- [安全政策](../SECURITY.md)
+
+## 相關專案
+
+- [OpenConnector](https://github.com/oomol-lab/open-connector)：開源的 Connector 閘道，為 Connector 節點提供 Provider 目錄、憑證管理和
+  Action 執行。
+- [oo CLI](https://github.com/oomol-lab/oo-cli)：本機 Agent 工具組，承載由本儲存庫建置的 `oo flow` 命令。
+
+## 參與貢獻
+
+歡迎提交 Issue 和 Pull Request。開發環境、儲存庫規則和提交前需要執行的檢查請參閱 [CONTRIBUTING.md](../CONTRIBUTING.md)。參與本專案需遵守
+[CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)。
+
+## 安全
+
+請透過 [GitHub 私密漏洞回報](https://github.com/oomol-lab/open-flow/security/advisories/new) 回報安全問題，不要提交公開
+Issue。[SECURITY.md](../SECURITY.md) 說明了受支援的版本、揭露流程、回報範圍以及自行部署時的強化建議。
+
+## 授權條款
+
+[Apache-2.0](../LICENSE)。打包資源涉及的第三方聲明請參閱 [NOTICE](../NOTICE)。


### PR DESCRIPTION
Open Flow kept its only translation, _README.zh-CN.md_, at the repository root while open-connector puts every translation under _docs/_ behind a shared language bar, so the two projects read differently side by side and Open Flow offered just English and Simplified Chinese.

This moves the Simplified Chinese README to _docs/README.zh-CN.md_ with its relative links rewritten for the new location, adds Traditional Chinese, Japanese, Korean, Russian, and French translations that mirror its structure, and updates the language bar in _README.md_ and the sync rule in _CONTRIBUTING.md_ to cover every `docs/README.<locale>.md`. Product terms stay untranslated, the bash and dotenv blocks are byte-identical across all seven files, only mermaid node labels are localized, and `bun run format -- --check` passes.
