### PR TITLE
docs: add contributors list and star history chart

### DIFF
--- a/.github/workflows/star-history.yaml
+++ b/.github/workflows/star-history.yaml
@@ -1,0 +1,37 @@
+name: Star History
+
+# Renders this repo's star-growth chart (light/dark SVG + PNG) into
+# assets/star-history/ and rewrites the marker block in README.md. The action
+# detects whether star data actually changed and only commits when it did, with
+# a "[skip ci]" commit message so chart refreshes don't trigger the CI workflow.
+# Daily schedule keeps commit noise low; use workflow_dispatch for an on-demand
+# refresh (e.g. the first run after merging this workflow).
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+# Serialize refreshes so a manual dispatch can't race the scheduled push.
+concurrency:
+  group: star-history
+  cancel-in-progress: true
+
+# The action commits the refreshed chart and README and pushes to main.
+permissions:
+  contents: write
+
+jobs:
+  star-history:
+    name: Render & Commit Chart
+    runs-on: ubuntu-latest
+    steps:
+      # Unlike ci.yaml this checkout keeps persist-credentials on (the default):
+      # the action's push step authenticates with the persisted GITHUB_TOKEN.
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      # Pinned to an immutable SHA rather than the mutable v1 tag: this
+      # third-party action holds contents:write and pushes to the repo, so its
+      # supply chain must not be silently updatable.
+      - name: Render and commit star history
+        uses: narayann7/star-history-action@12543ab7352b91fb7c5eb0c4fbb39772baa0c168 # v1.0.6

--- a/README.md
+++ b/README.md
@@ -207,3 +207,19 @@ disclosure process, what is in scope, and how to harden a self-hosted deployment
 ## License
 
 [Apache-2.0](LICENSE). Third-party notices for bundled assets are listed in [NOTICE](NOTICE).
+
+## Contributors
+
+Thanks to everyone who has helped build Open Flow. Want to join them? See
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
+[![Open Flow contributors](https://contrib.rocks/image?repo=oomol-lab/open-flow)](https://github.com/oomol-lab/open-flow/graphs/contributors)
+
+## Star History
+
+<!-- star-history:start -->
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/star-history/star-history-dark.svg">
+  <img alt="Star history" src="assets/star-history/star-history-light.svg">
+</picture>
+<!-- star-history:end -->

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -217,3 +217,17 @@ auto-hébergé.
 
 [Apache-2.0](../LICENSE). Les mentions relatives aux ressources tierces embarquées figurent dans
 [NOTICE](../NOTICE).
+
+## Contributeurs
+
+Merci à toutes les personnes qui ont contribué à Open Flow. Vous souhaitez les rejoindre ?
+Consultez le [guide de contribution](../CONTRIBUTING.md).
+
+[![Contributeurs Open Flow](https://contrib.rocks/image?repo=oomol-lab/open-flow)](https://github.com/oomol-lab/open-flow/graphs/contributors)
+
+## Historique des Stars
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/star-history/star-history-dark.svg">
+  <img alt="Historique des Stars" src="../assets/star-history/star-history-light.svg">
+</picture>

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -176,3 +176,17 @@ Issue と Pull Request を歓迎します。開発環境のセットアップ、
 ## ライセンス
 
 [Apache-2.0](../LICENSE)。同梱アセットに関するサードパーティの通知は [NOTICE](../NOTICE) に記載されています。
+
+## コントリビューター
+
+Open Flow の開発にご協力いただいたすべての皆さまに感謝します。参加方法については
+[コントリビューションガイド](../CONTRIBUTING.md) をご覧ください。
+
+[![Open Flow コントリビューター](https://contrib.rocks/image?repo=oomol-lab/open-flow)](https://github.com/oomol-lab/open-flow/graphs/contributors)
+
+## Star 履歴
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/star-history/star-history-dark.svg">
+  <img alt="Star 履歴" src="../assets/star-history/star-history-light.svg">
+</picture>

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -194,3 +194,17 @@ Issue와 Pull Request를 환영합니다. 개발 환경 설정, 저장소 규칙
 ## 라이선스
 
 [Apache-2.0](../LICENSE). 번들된 자산의 서드파티 고지는 [NOTICE](../NOTICE)에 정리되어 있습니다.
+
+## 기여자
+
+Open Flow를 함께 만들어 주신 모든 기여자께 감사드립니다.
+[기여 안내](../CONTRIBUTING.md)를 확인하고 함께해 주세요.
+
+[![Open Flow 기여자](https://contrib.rocks/image?repo=oomol-lab/open-flow)](https://github.com/oomol-lab/open-flow/graphs/contributors)
+
+## Star 히스토리
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/star-history/star-history-dark.svg">
+  <img alt="Star 히스토리" src="../assets/star-history/star-history-light.svg">
+</picture>

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -209,3 +209,17 @@ Issue и pull request приветствуются. Настройка окру�
 
 [Apache-2.0](../LICENSE). Уведомления о сторонних компонентах для включённых ресурсов перечислены в
 [NOTICE](../NOTICE).
+
+## Участники
+
+Спасибо всем, кто помогает развивать Open Flow. Хотите присоединиться? Ознакомьтесь с
+[руководством по участию](../CONTRIBUTING.md).
+
+[![Участники Open Flow](https://contrib.rocks/image?repo=oomol-lab/open-flow)](https://github.com/oomol-lab/open-flow/graphs/contributors)
+
+## История звёзд
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/star-history/star-history-dark.svg">
+  <img alt="История звёзд" src="../assets/star-history/star-history-light.svg">
+</picture>

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -174,3 +174,16 @@ Issue。[SECURITY.md](../SECURITY.md) 说明了受支持的版本、披露流程
 ## 许可证
 
 [Apache-2.0](../LICENSE)。打包资源涉及的第三方声明见 [NOTICE](../NOTICE)。
+
+## 贡献者
+
+感谢每一位参与建设 Open Flow 的贡献者。欢迎查看 [贡献指南](../CONTRIBUTING.md)，加入我们。
+
+[![Open Flow 贡献者](https://contrib.rocks/image?repo=oomol-lab/open-flow)](https://github.com/oomol-lab/open-flow/graphs/contributors)
+
+## Star 历史
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/star-history/star-history-dark.svg">
+  <img alt="Star 历史" src="../assets/star-history/star-history-light.svg">
+</picture>

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -172,3 +172,16 @@ Issue。[SECURITY.md](../SECURITY.md) 說明了受支援的版本、揭露流程
 ## 授權條款
 
 [Apache-2.0](../LICENSE)。打包資源涉及的第三方聲明請參閱 [NOTICE](../NOTICE)。
+
+## 貢獻者
+
+感謝每一位參與建設 Open Flow 的貢獻者。歡迎參閱 [貢獻指南](../CONTRIBUTING.md)，加入我們。
+
+[![Open Flow 貢獻者](https://contrib.rocks/image?repo=oomol-lab/open-flow)](https://github.com/oomol-lab/open-flow/graphs/contributors)
+
+## Star 歷史
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/star-history/star-history-dark.svg">
+  <img alt="Star 歷史" src="../assets/star-history/star-history-light.svg">
+</picture>


### PR DESCRIPTION
Mirrors the open-connector layout so both projects present their community sections the same way. README.md and each localized README under _docs/_ gain a Contributors section backed by contrib.rocks and a Star History section that renders light and dark SVGs from _assets/star-history/_.

The new _.github/workflows/star-history.yaml_ renders those SVGs daily with `narayann7/star-history-action`, pinned to an immutable SHA because it holds `contents: write` and pushes to main. Refresh commits carry `[skip ci]` so they never trigger the CI workflow. The chart assets do not exist until the first run, so after merging, trigger the Star History workflow once via `workflow_dispatch` to populate them.
