### PR TITLE
feat(canvas): align controls with shadcn

### DIFF
--- a/docs/authoring/frontend-ui.md
+++ b/docs/authoring/frontend-ui.md
@@ -56,6 +56,20 @@ primitive 家族。页面级和 Canvas overlay 的 shadcn 组件可以采用自�
 
 ## React Flow 画布外围
 
+### Canvas Content 与 Canvas Chrome
+
+Canvas Content 包括 Node、Node 内参数编辑器、Handle、Edge、选择框和随 viewport transform 的内容。它们继续使用 Designer 的紧凑字段密度、
+`--widget-*` token 和节点组件样式；不能为了统一 Workbench 视觉而修改这套规则，也不能通过全局 `button`、`input` 或共享 radius token 间接改变它们。
+
+Canvas Chrome 包括固定在画布四周的状态标记、添加或删除操作、Inspector 开关、缩放与布局控制、Display Mode、MiniMap 和设置控制。它们虽然视觉上
+覆盖画布，但不属于 Canvas Content。Workbench 持有的 Chrome 使用共享 shadcn/Base UI primitive 的原生 variant、size、radius、surface、focus 和 disabled
+状态，feature CSS 只负责定位与 gap。React Flow 持有的 `Controls` 和 `ControlButton` 保留官方结构与行为，并通过 `--xy-*` 映射共享 `--ui-*` token；官方
+组件未覆盖的圆角与 focus ring 只允许在 React Flow 的 Chrome selector 中补齐，不能影响 `.react-flow__node` 或其后代。
+
+独立操作必须作为有间距的独立圆角 Button；不要把它们包成一个 surface 后再对所有子按钮设置 `border-radius: 0`。有单一组合语义的 ToggleGroup 可以保留
+原生的整体圆角和内部连接边，但 feature stylesheet 不得重新声明其 border、background、radius、color、typography 或状态样式。不要为 Canvas Chrome 新增
+平行的颜色或 radius token，也不要为了调整 Chrome 修改 `--ui-radius`，因为共享 primitive 同样会出现在 Node 内部。
+
 Designer 持有、固定在画布 viewport 四周的内容优先使用 React Flow 官方定位与控制结构：
 
 - 任意固定浮层使用 `Panel`；
@@ -68,7 +82,10 @@ React Flow 已提供的颜色、边框和阴影优先通过官方 `--xy-*` CSS v
 
 React Flow `ControlButton` 不转发 DOM ref，不能作为 Base UI `TooltipTrigger render` 的 child。图标 ControlButton 使用 React Flow 官方的 `title` 和
 `aria-label`；不要用 Tooltip wrapper 破坏 Controls 的直接子元素、边框或 ref 语义。共享 shadcn `Button` 必须保持 `forwardRef<HTMLButtonElement>`，以支持
-Dialog、Tooltip 和宿主 focus restoration。
+Dialog、Tooltip 和宿主 focus restoration。连续的 React Flow 命令组在 `Controls` 上按实际布局复用共享 `ButtonGroup` 的 horizontal 或 vertical variant，并在每个
+`ControlButton` 上复用共享 Button 的 `outline`、`icon` variant 与 `data-slot="button"`；这样保留 React Flow 行为，同时由 shadcn 原生规则负责整体圆角、
+内部连接边、focus 和 disabled 状态。方向必须通过 `Controls orientation` 传入，并以 React Flow 实际输出的 `.horizontal` / `.vertical` class 作为 Chrome
+适配 selector；`Controls` 不转发任意 `data-*` 属性，不能依赖调用方添加的 `data-orientation` 或 `data-slot`。
 
 React Flow 没有提供的通用应用控件可以组合在 `Panel` 中，例如 Display Mode 使用共享 shadcn/Base UI `ToggleGroup`。这类 primitive 需要放在
 `[data-canvas-control-scope]` 内，避免接受节点字段网格的紧凑归一化。

--- a/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/BottomRight.test.tsx
+++ b/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/BottomRight.test.tsx
@@ -11,6 +11,7 @@ import { BottomRight } from './BottomRight.tsx'
 
 const captured = vi.hoisted(() => ({
   buttons: [] as ButtonHTMLAttributes<HTMLButtonElement>[],
+  controls: [] as Array<{ readonly className?: string; readonly orientation?: 'horizontal' | 'vertical'; readonly position?: string }>,
   miniMap: undefined as
     | {
         readonly ariaLabel?: string | null
@@ -30,7 +31,19 @@ vi.mock('@xyflow/react', () => ({
       </button>
     )
   },
-  Controls: ({ children, position }: HTMLAttributes<HTMLDivElement> & { readonly position?: string }) => <div data-position={position}>{children}</div>,
+  Controls: ({
+    children,
+    className,
+    orientation,
+    position,
+  }: HTMLAttributes<HTMLDivElement> & { readonly orientation?: 'horizontal' | 'vertical'; readonly position?: string }) => {
+    captured.controls.push({ className, orientation, position })
+    return (
+      <div data-orientation={orientation} data-position={position}>
+        {children}
+      </div>
+    )
+  },
   MiniMap: (props: NonNullable<typeof captured.miniMap>) => {
     captured.miniMap = props
     return <div data-mini-map data-position={props.position} />
@@ -48,6 +61,7 @@ function render(interactiveMode$: Val<InteractiveMode>, miniMapExpanded$: Val<bo
 describe('BottomRight', () => {
   beforeEach(() => {
     captured.buttons = []
+    captured.controls = []
     captured.miniMap = undefined
   })
 
@@ -59,8 +73,12 @@ describe('BottomRight', () => {
     const markup = render(interactiveMode$, miniMapExpanded$, showSettings$)
 
     expect(markup).toContain('data-position="bottom-right"')
+    expect(markup).toContain('data-orientation="horizontal"')
+    expect(captured.controls[0]).toMatchObject({ orientation: 'horizontal', position: 'bottom-right' })
+    expect(captured.controls[0]?.className).toContain('rounded-r-none')
     expect(captured.miniMap).toBeUndefined()
     expect(captured.buttons).toHaveLength(3)
+    expect(captured.buttons.every((button) => button.className?.includes('size-8'))).toBe(true)
 
     captured.buttons[0]?.onClick?.({} as never)
     captured.buttons[1]?.onClick?.({} as never)

--- a/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/BottomRight.tsx
+++ b/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/BottomRight.tsx
@@ -7,6 +7,9 @@ import { memo } from 'react'
 import { useVal } from 'use-value-enhancer'
 import { useTranslate } from 'val-i18n-react'
 import { setValue } from 'value-enhancer'
+import { buttonGroupVariants } from '../../../../ui/browser/button-group.tsx'
+import { buttonVariants } from '../../../../ui/browser/button.tsx'
+import { cn } from '../../../../ui/browser/utils.ts'
 import { iconOf } from '../../jsonSchema/preset.ts'
 
 export interface BottomRightProps {
@@ -27,12 +30,32 @@ export const BottomRight: React.FC<BottomRightProps> = /* @__PURE__ */ memo(func
   return (
     <>
       {!miniMapExpanded && (
-        <Controls position="bottom-right" showFitView={false} showInteractive={false} showZoom={false}>
-          <ControlButton aria-label={modeBtnTitle} onClick={() => props.interactiveMode$.set(isMouse ? 'touchpad' : 'mouse')} title={modeBtnTitle}>
+        <Controls
+          className={buttonGroupVariants({ orientation: 'horizontal' })}
+          orientation="horizontal"
+          position="bottom-right"
+          showFitView={false}
+          showInteractive={false}
+          showZoom={false}
+        >
+          <ControlButton
+            aria-label={modeBtnTitle}
+            className={buttonVariants({ size: 'icon', variant: 'outline' })}
+            data-slot="button"
+            onClick={() => props.interactiveMode$.set(isMouse ? 'touchpad' : 'mouse')}
+            title={modeBtnTitle}
+          >
             {isMouse ? <i className={`${styles.interactionIcon} i-custom:mouse`} /> : <i className={`${styles.interactionIcon} i-custom:touchpad`} />}
           </ControlButton>
           {props.miniMapExpanded$ && (
-            <ControlButton aria-label={t('miniMap')} aria-expanded={false} onClick={() => props.miniMapExpanded$?.set(true)} title={t('miniMap')}>
+            <ControlButton
+              aria-label={t('miniMap')}
+              aria-expanded={false}
+              className={buttonVariants({ size: 'icon', variant: 'outline' })}
+              data-slot="button"
+              onClick={() => props.miniMapExpanded$?.set(true)}
+              title={t('miniMap')}
+            >
               <i className={`${styles.miniMapIcon} i-custom:minimap`} />
             </ControlButton>
           )}
@@ -40,6 +63,8 @@ export const BottomRight: React.FC<BottomRightProps> = /* @__PURE__ */ memo(func
             <ControlButton
               aria-label={settingsBtnTitle}
               aria-expanded={showSettings}
+              className={buttonVariants({ size: 'icon', variant: 'outline' })}
+              data-slot="button"
               onClick={() => setValue(props.showSettings$!, !showSettings)}
               title={settingsBtnTitle}
             >
@@ -51,8 +76,22 @@ export const BottomRight: React.FC<BottomRightProps> = /* @__PURE__ */ memo(func
       {props.miniMapExpanded$ && miniMapExpanded && (
         <>
           <RFMiniMap ariaLabel={t('miniMap')} className={styles.miniMap} pannable position="bottom-right" zoomable />
-          <Controls className={styles.miniMapToggle} position="bottom-right" showFitView={false} showInteractive={false} showZoom={false}>
-            <ControlButton aria-label={t('miniMap')} aria-expanded onClick={() => props.miniMapExpanded$?.set(false)} title={t('miniMap')}>
+          <Controls
+            className={cn(buttonGroupVariants({ orientation: 'horizontal' }), styles.miniMapToggle)}
+            orientation="horizontal"
+            position="bottom-right"
+            showFitView={false}
+            showInteractive={false}
+            showZoom={false}
+          >
+            <ControlButton
+              aria-label={t('miniMap')}
+              aria-expanded
+              className={buttonVariants({ size: 'icon', variant: 'outline' })}
+              data-slot="button"
+              onClick={() => props.miniMapExpanded$?.set(false)}
+              title={t('miniMap')}
+            >
               <i className={`${styles.miniMapIcon} i-carbon:shrink-screen`} />
             </ControlButton>
           </Controls>

--- a/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/DisplayModeToggle.module.scss
+++ b/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/DisplayModeToggle.module.scss
@@ -1,13 +1,5 @@
 .group {
   --display-mode-button-width: 76px;
-
-  height: var(--canvas-control-container-size);
-  gap: 0;
-  border: 1px solid var(--canvas-control-border, var(--ui-border));
-  border-radius: var(--canvas-control-radius);
-  background: var(--canvas-control-background, var(--ui-background));
-  box-shadow: var(--floating-control-shadow);
-  overflow: hidden;
 }
 
 .compact {
@@ -16,26 +8,5 @@
 
 .button {
   width: var(--display-mode-button-width);
-  height: var(--canvas-control-size);
   min-width: 0;
-  padding: 0 12px;
-  border: 0;
-  border-radius: 0;
-  color: var(--canvas-control-foreground, var(--ui-muted-foreground));
-  background: var(--canvas-control-background, var(--ui-background));
-  font-size: 13px;
-  font-weight: 400;
-  line-height: 1;
-  box-shadow: none;
-
-  & + & {
-    border-left: 1px solid var(--canvas-control-border, var(--ui-border));
-  }
-
-  &[aria-pressed='true'] {
-    color: var(--canvas-control-active-foreground, var(--ui-foreground));
-    background: var(--canvas-control-active-background, var(--ui-muted));
-    font-weight: 500;
-    box-shadow: none;
-  }
 }

--- a/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/DisplayModeToggle.tsx
+++ b/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/DisplayModeToggle.tsx
@@ -28,7 +28,7 @@ export const DisplayModeToggle: React.FC<DisplayModeToggleProps> = /*#__PURE__*/
           if (value != null) displayMode$.set(value)
         }}
         spacing={0}
-        size="sm"
+        size="default"
         value={[displayMode]}
         variant="outline"
       >

--- a/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.module.scss
+++ b/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.module.scss
@@ -47,34 +47,49 @@
   }
 
   :global(.react-flow__controls) {
-    width: var(--canvas-control-container-size);
-    border: 1px solid var(--canvas-control-border, var(--ui-border));
-    border-radius: var(--canvas-control-radius);
-    background: var(--canvas-control-background, var(--ui-background));
-    box-shadow: var(--floating-control-shadow);
-    overflow: hidden;
+    width: auto;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+    overflow: visible;
   }
 
-  :global(.react-flow__controls-button) {
-    width: var(--canvas-control-size);
-    height: var(--canvas-control-size);
-    padding: var(--canvas-control-padding);
-    border-radius: 0;
-    font-size: 16px;
-    transition:
-      color 100ms ease,
-      background-color 100ms ease;
+  :global(.react-flow__controls.horizontal) {
+    flex-direction: row !important;
   }
 
-  :global(.react-flow__controls-button:active),
-  :global(.react-flow__controls-button[aria-expanded='true']) {
-    background-color: var(--canvas-control-active-background, var(--ui-muted));
-    color: var(--canvas-control-active-foreground, var(--ui-foreground));
+  :global(.react-flow__controls:is(.horizontal, .vertical) > [data-slot='button']) {
+    width: var(--canvas-control-container-size) !important;
+    height: var(--canvas-control-container-size) !important;
+    border-radius: 0 !important;
   }
 
-  :global(.react-flow__controls-button:focus-visible) {
-    outline: 2px solid var(--ui-ring);
-    outline-offset: -2px;
+  :global(.react-flow__controls.vertical > [data-slot='button']:not(:last-child)) {
+    border-bottom-color: color-mix(in srgb, var(--ui-border) 55%, transparent) !important;
+  }
+
+  :global(.react-flow__controls.horizontal > [data-slot='button']:not(:last-child)) {
+    border-right-color: color-mix(in srgb, var(--ui-border) 55%, transparent) !important;
+  }
+
+  :global(.react-flow__controls.vertical > [data-slot='button']:first-child) {
+    border-top-left-radius: calc(var(--ui-radius) + 2px) !important;
+    border-top-right-radius: calc(var(--ui-radius) + 2px) !important;
+  }
+
+  :global(.react-flow__controls.vertical > [data-slot='button']:last-child) {
+    border-bottom-right-radius: calc(var(--ui-radius) + 2px) !important;
+    border-bottom-left-radius: calc(var(--ui-radius) + 2px) !important;
+  }
+
+  :global(.react-flow__controls.horizontal > [data-slot='button']:first-child) {
+    border-top-left-radius: calc(var(--ui-radius) + 2px) !important;
+    border-bottom-left-radius: calc(var(--ui-radius) + 2px) !important;
+  }
+
+  :global(.react-flow__controls.horizontal > [data-slot='button']:last-child) {
+    border-top-right-radius: calc(var(--ui-radius) + 2px) !important;
+    border-bottom-right-radius: calc(var(--ui-radius) + 2px) !important;
   }
 
   :global(.react-flow__controls-button path) {

--- a/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.module.scss
+++ b/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.module.scss
@@ -54,44 +54,6 @@
     overflow: visible;
   }
 
-  :global(.react-flow__controls.horizontal) {
-    flex-direction: row !important;
-  }
-
-  :global(.react-flow__controls:is(.horizontal, .vertical) > [data-slot='button']) {
-    width: var(--canvas-control-container-size) !important;
-    height: var(--canvas-control-container-size) !important;
-    border-radius: 0 !important;
-  }
-
-  :global(.react-flow__controls.vertical > [data-slot='button']:not(:last-child)) {
-    border-bottom-color: color-mix(in srgb, var(--ui-border) 55%, transparent) !important;
-  }
-
-  :global(.react-flow__controls.horizontal > [data-slot='button']:not(:last-child)) {
-    border-right-color: color-mix(in srgb, var(--ui-border) 55%, transparent) !important;
-  }
-
-  :global(.react-flow__controls.vertical > [data-slot='button']:first-child) {
-    border-top-left-radius: calc(var(--ui-radius) + 2px) !important;
-    border-top-right-radius: calc(var(--ui-radius) + 2px) !important;
-  }
-
-  :global(.react-flow__controls.vertical > [data-slot='button']:last-child) {
-    border-bottom-right-radius: calc(var(--ui-radius) + 2px) !important;
-    border-bottom-left-radius: calc(var(--ui-radius) + 2px) !important;
-  }
-
-  :global(.react-flow__controls.horizontal > [data-slot='button']:first-child) {
-    border-top-left-radius: calc(var(--ui-radius) + 2px) !important;
-    border-bottom-left-radius: calc(var(--ui-radius) + 2px) !important;
-  }
-
-  :global(.react-flow__controls.horizontal > [data-slot='button']:last-child) {
-    border-top-right-radius: calc(var(--ui-radius) + 2px) !important;
-    border-bottom-right-radius: calc(var(--ui-radius) + 2px) !important;
-  }
-
   :global(.react-flow__controls-button path) {
     fill: currentColor;
   }

--- a/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.scss
+++ b/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.scss
@@ -1,0 +1,39 @@
+.oo-designer-root {
+  .react-flow__controls.horizontal {
+    flex-direction: row !important;
+  }
+
+  .react-flow__controls:is(.horizontal, .vertical) > [data-slot='button'] {
+    width: var(--canvas-control-container-size) !important;
+    height: var(--canvas-control-container-size) !important;
+    border-radius: 0 !important;
+  }
+
+  .react-flow__controls.vertical > [data-slot='button']:not(:last-child) {
+    border-bottom-color: color-mix(in srgb, var(--ui-border) 55%, transparent) !important;
+  }
+
+  .react-flow__controls.horizontal > [data-slot='button']:not(:last-child) {
+    border-right-color: color-mix(in srgb, var(--ui-border) 55%, transparent) !important;
+  }
+
+  .react-flow__controls.vertical > [data-slot='button']:first-child {
+    border-top-left-radius: calc(var(--ui-radius) + 2px) !important;
+    border-top-right-radius: calc(var(--ui-radius) + 2px) !important;
+  }
+
+  .react-flow__controls.vertical > [data-slot='button']:last-child {
+    border-bottom-right-radius: calc(var(--ui-radius) + 2px) !important;
+    border-bottom-left-radius: calc(var(--ui-radius) + 2px) !important;
+  }
+
+  .react-flow__controls.horizontal > [data-slot='button']:first-child {
+    border-top-left-radius: calc(var(--ui-radius) + 2px) !important;
+    border-bottom-left-radius: calc(var(--ui-radius) + 2px) !important;
+  }
+
+  .react-flow__controls.horizontal > [data-slot='button']:last-child {
+    border-top-right-radius: calc(var(--ui-radius) + 2px) !important;
+    border-bottom-right-radius: calc(var(--ui-radius) + 2px) !important;
+  }
+}

--- a/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.tsx
+++ b/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.tsx
@@ -1,6 +1,7 @@
 import darkTheme from '../../styles/dark.module.scss'
 import lightTheme from '../../styles/light.module.scss'
 import styles from './ReactFlowContainer.module.scss'
+import './ReactFlowContainer.scss'
 import type {
   Dimensions,
   EdgeTypes,

--- a/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.tsx
+++ b/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.tsx
@@ -59,9 +59,12 @@ import { useVal } from 'use-value-enhancer'
 import { I18nProvider, useTranslate } from 'val-i18n-react'
 import { derive } from 'value-enhancer'
 import { shallowPlainObjectEqual } from '../../../../base/common/equality.ts'
+import { buttonGroupVariants } from '../../../../ui/browser/button-group.tsx'
+import { buttonVariants } from '../../../../ui/browser/button.tsx'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuTrigger } from '../../../../ui/browser/dropdown-menu.tsx'
 import { Popover, PopoverContent, PopoverTrigger } from '../../../../ui/browser/popover.tsx'
 import { TooltipProvider } from '../../../../ui/browser/tooltip.tsx'
+import { cn } from '../../../../ui/browser/utils.ts'
 import { DESIGNER_CLASSNAME, HANDLE_ROW_CLASSNAME } from '../../base/designer.ts'
 import { getScriptletType, getSharedBlockPath, getTriggerType, isWithCommentType, isWithConditionType, isWithValueType } from '../../base/dragNDrop.ts'
 import { makeConnection, toManifestHandleName, toManifestNodeId } from '../../base/rfHelpers.ts'
@@ -212,9 +215,16 @@ const FlowControls = /*#__PURE__*/ memo((props: FlowControlsProps) => {
   return (
     <>
       {props.dottedBackground && <Background id={bgId} color="var(--canvas-grid)" gap={GRID_GAP} variant={BackgroundVariant.Dots} />}
-      <Controls showInteractive={false} showFitView={false} showZoom={false}>
+      <Controls
+        className={buttonGroupVariants({ orientation: 'vertical' })}
+        orientation="vertical"
+        showInteractive={false}
+        showFitView={false}
+        showZoom={false}
+      >
         <ControlButton
-          className={`${styles.btnCtrl} react-flow__controls-button-zoom-in`}
+          className={cn(buttonVariants({ size: 'icon', variant: 'outline' }), styles.btnCtrl, 'react-flow__controls-button-zoom-in')}
+          data-slot="button"
           onClick={() => rf.zoomIn()}
           title={t('zoomIn')}
           aria-label={t('zoomIn')}
@@ -223,7 +233,8 @@ const FlowControls = /*#__PURE__*/ memo((props: FlowControlsProps) => {
           <i className="i-codicon:zoom-in" />
         </ControlButton>
         <ControlButton
-          className={`${styles.btnCtrl} react-flow__controls-button-zoom-out`}
+          className={cn(buttonVariants({ size: 'icon', variant: 'outline' }), styles.btnCtrl, 'react-flow__controls-button-zoom-out')}
+          data-slot="button"
           onClick={() => rf.zoomOut()}
           title={t('zoomOut')}
           aria-label={t('zoomOut')}
@@ -232,7 +243,8 @@ const FlowControls = /*#__PURE__*/ memo((props: FlowControlsProps) => {
           <i className="i-codicon:zoom-out" />
         </ControlButton>
         <ControlButton
-          className={`${styles.btnCtrl} react-flow__controls-button-fit-view`}
+          className={cn(buttonVariants({ size: 'icon', variant: 'outline' }), styles.btnCtrl, 'react-flow__controls-button-fit-view')}
+          data-slot="button"
           onClick={() => {
             props.onBeforeFitView?.()
             // Wait for the node description height before fitting the view to avoid overlap.
@@ -251,7 +263,8 @@ const FlowControls = /*#__PURE__*/ memo((props: FlowControlsProps) => {
         </ControlButton>
         {props.onRelayout && (
           <ControlButton
-            className={`${styles.btnCtrl} react-flow__controls-button-optimize`}
+            className={cn(buttonVariants({ size: 'icon', variant: 'outline' }), styles.btnCtrl, 'react-flow__controls-button-optimize')}
+            data-slot="button"
             onClick={() => {
               props.onRelayout?.()
               props.onBeforeFitView?.()

--- a/packages/open-flow/src/designer/browser/styles/_mixins.scss
+++ b/packages/open-flow/src/designer/browser/styles/_mixins.scss
@@ -12,11 +12,8 @@
   --node-container-radius: 6px;
   --node-effect-radius-number: 7;
   --transition-time: 0.2s;
-  --canvas-control-size: 28px;
-  --canvas-control-container-size: 30px;
+  --canvas-control-container-size: 32px;
   --canvas-control-icon-size: 16px;
-  --canvas-control-padding: 5px;
-  --canvas-control-radius: 7px;
 
   --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
   --font-monospace: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;

--- a/packages/open-flow/src/ui/browser/button-group.tsx
+++ b/packages/open-flow/src/ui/browser/button-group.tsx
@@ -1,0 +1,61 @@
+import type { VariantProps } from 'class-variance-authority'
+import type { ComponentProps } from 'react'
+
+import { mergeProps } from '@base-ui/react/merge-props'
+import { useRender } from '@base-ui/react/use-render'
+import { cva } from 'class-variance-authority'
+import { Separator } from './separator.tsx'
+import { cn } from './utils.ts'
+
+const buttonGroupVariants = cva(
+  "flex w-fit items-stretch *:focus-visible:relative *:focus-visible:z-10 has-[>[data-slot=button-group]]:gap-2 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-lg [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
+  {
+    variants: {
+      orientation: {
+        horizontal:
+          '*:data-slot:rounded-r-none [&>[data-slot]:not(:has(~[data-slot]))]:rounded-r-lg! [&>[data-slot]~[data-slot]]:rounded-l-none [&>[data-slot]~[data-slot]]:border-l-0',
+        vertical:
+          'flex-col *:data-slot:rounded-b-none [&>[data-slot]:not(:has(~[data-slot]))]:rounded-b-lg! [&>[data-slot]~[data-slot]]:rounded-t-none [&>[data-slot]~[data-slot]]:border-t-0',
+      },
+    },
+    defaultVariants: {
+      orientation: 'horizontal',
+    },
+  },
+)
+
+function ButtonGroup({ className, orientation, ...props }: ComponentProps<'div'> & VariantProps<typeof buttonGroupVariants>) {
+  return <div role="group" data-slot="button-group" data-orientation={orientation} className={cn(buttonGroupVariants({ orientation }), className)} {...props} />
+}
+
+function ButtonGroupText({ className, render, ...props }: useRender.ComponentProps<'div'>) {
+  return useRender({
+    defaultTagName: 'div',
+    props: mergeProps<'div'>(
+      {
+        className: cn(
+          "flex items-center gap-2 rounded-lg border bg-muted px-2.5 text-sm font-medium [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+          className,
+        ),
+      },
+      props,
+    ),
+    render,
+    state: {
+      slot: 'button-group-text',
+    },
+  })
+}
+
+function ButtonGroupSeparator({ className, orientation = 'vertical', ...props }: ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="button-group-separator"
+      orientation={orientation}
+      className={cn('relative self-stretch bg-input data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto', className)}
+      {...props}
+    />
+  )
+}
+
+export { ButtonGroup, ButtonGroupSeparator, ButtonGroupText, buttonGroupVariants }

--- a/packages/open-flow/src/workbench/browser/runtime/designer/workbenchDesigner.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/designer/workbenchDesigner.tsx
@@ -367,7 +367,7 @@ export const WorkbenchDesigner = forwardRef<WorkbenchDesignerHandle, Props>(func
         }}
         selectedNodeIds={selectedNodeIds}
       />
-      <Badge className="designer-draft-status designer-overlay top-left" variant="secondary">
+      <Badge className="designer-overlay top-left" variant="secondary">
         <span className="status-dot neutral" />
         {t('designer.draftBadge', { kind: t(target?.kind == 'subflow' ? 'common.subflow' : 'common.flow') })}
       </Badge>
@@ -376,24 +376,23 @@ export const WorkbenchDesigner = forwardRef<WorkbenchDesignerHandle, Props>(func
           aria-expanded={blocksOpen}
           disabled={disabled || target == null}
           onClick={(event) => onOpenBlocks(event.currentTarget)}
-          size="sm"
+          size="default"
           title={t('designer.openBlocks')}
           type="button"
-          variant="ghost"
+          variant="outline"
         >
           <Icon data-icon="inline-start" name="plus" /> {t('designer.addNode')}
         </Button>
         {(selectedNodeIds.length > 0 || selectedEdge != null) && (
           <Button
-            className="designer-delete-action"
             disabled={disabled}
             onClick={() => {
               if (selectedNodeIds.length > 0) onDeleteNodes()
               else if (selectedEdge != null) onDeleteEdge(selectedEdge)
             }}
-            size="sm"
+            size="default"
             type="button"
-            variant="ghost"
+            variant="destructive"
           >
             {t('designer.delete')}
           </Button>
@@ -402,10 +401,10 @@ export const WorkbenchDesigner = forwardRef<WorkbenchDesignerHandle, Props>(func
           aria-label={t('designer.toggleInspector')}
           aria-expanded={inspectorOpen}
           onClick={(event) => onToggleInspector(event.currentTarget)}
-          size="icon-sm"
+          size="icon"
           title={t('designer.toggleInspector')}
           type="button"
-          variant="ghost"
+          variant="outline"
         >
           <Icon name="panel" />
         </Button>

--- a/packages/open-flow/src/workbench/browser/runtime/runs/runDrawer.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/runs/runDrawer.tsx
@@ -813,7 +813,7 @@ export function RunDrawer({
         </div>
         <span className="run-meta">{duration(run)}</span>
         {run != null && <code className="run-id">{t('run.runId', { id: run.runId })}</code>}
-        <Button aria-label={t(open ? 'run.collapse' : 'run.expand')} onClick={onToggle} size="icon-sm" variant="ghost">
+        <Button aria-label={t(open ? 'run.collapse' : 'run.expand')} onClick={onToggle} size="icon-xs" variant="ghost">
           <Icon name={open ? 'chevron-down' : 'chevron-up'} />
         </Button>
       </div>

--- a/packages/open-flow/src/workbench/browser/runtime/shell/workspaceHeader.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/shell/workspaceHeader.tsx
@@ -125,7 +125,7 @@ export function WorkspaceHeader({
           nativeButton={false}
           onClick={(event) => followWorkbenchLink(event, onOpenFlow)}
           render={<a href={flowHref} />}
-          size="sm"
+          size="default"
           variant="ghost"
         >
           <Icon data-icon="inline-start" name="flow" />
@@ -193,7 +193,7 @@ export function WorkspaceHeader({
             aria-expanded={runInputRequest?.source == 'draft'}
             disabled={busy != null || invalid || subflow || runInputRequest != null}
             onClick={onRunDraft}
-            size="sm"
+            size="default"
             variant="outline"
           >
             <Icon data-icon="inline-start" name="play" />
@@ -204,7 +204,7 @@ export function WorkspaceHeader({
           <Button
             disabled={busy != null || invalid || subflow || live?.hasUnpublishedChanges == false}
             onClick={() => void store.publications.publish()}
-            size="sm"
+            size="default"
           >
             <Icon data-icon="inline-start" name="publish" />
             {t(busy == 'publish' ? 'workspace.publishing' : 'publication.publishDraft')}
@@ -216,7 +216,7 @@ export function WorkspaceHeader({
               <DropdownMenuTrigger
                 aria-label={t('workspace.moreActions')}
                 render={
-                  <Button size="icon-sm" title={t('workspace.moreActions')} variant="ghost">
+                  <Button size="icon" title={t('workspace.moreActions')} variant="ghost">
                     <Icon name="more" />
                   </Button>
                 }

--- a/packages/open-flow/src/workbench/browser/runtime/styles/canvas.css
+++ b/packages/open-flow/src/workbench/browser/runtime/styles/canvas.css
@@ -25,16 +25,11 @@
   }
 
   .workbench-designer-canvas {
-    --canvas-control-background: var(--surface);
-    --canvas-control-border: var(--border);
-    --canvas-control-foreground: var(--text-secondary);
-    --canvas-control-active-background: var(--subtle);
-    --canvas-control-active-foreground: var(--text);
-    --xy-controls-button-background-color: var(--surface);
-    --xy-controls-button-background-color-hover: var(--subtle);
-    --xy-controls-button-border-color: var(--border);
-    --xy-controls-button-color: var(--text-secondary);
-    --xy-controls-button-color-hover: var(--text);
+    --xy-controls-button-background-color: var(--ui-background);
+    --xy-controls-button-background-color-hover: var(--ui-muted);
+    --xy-controls-button-border-color: var(--ui-border);
+    --xy-controls-button-color: var(--ui-muted-foreground);
+    --xy-controls-button-color-hover: var(--ui-foreground);
 
     width: 100%;
     height: 100%;
@@ -52,51 +47,12 @@
 
   .designer-overlay.top-right {
     right: 15px;
-    gap: 0;
-  }
-
-  .designer-overlay.top-right > [data-slot='button'] {
-    border-radius: 0;
-    background: transparent;
-    background-clip: border-box;
-  }
-
-  .designer-overlay.top-right > [data-slot='button'] + [data-slot='button'] {
-    border-left-color: var(--border);
-  }
-
-  .designer-draft-status {
-    height: 30px;
-    gap: 6px;
-    padding: 0 10px;
-    border-color: var(--border);
-    border-radius: 7px;
-    background: var(--surface);
-    color: var(--text-secondary);
-    font-size: 12px;
-    font-weight: 500;
-    box-shadow: 0 1px 3px rgb(0 0 0 / 16%);
-  }
-
-  .designer-delete-action {
-    color: var(--danger);
-  }
-
-  .designer-delete-action:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--danger) 10%, transparent);
-    color: var(--danger);
   }
 
   .designer-actions {
     display: flex;
-    height: 30px;
     align-items: center;
-    gap: 0;
-    border: 1px solid var(--border);
-    border-radius: 7px;
-    background: var(--surface);
-    box-shadow: 0 1px 3px rgb(0 0 0 / 16%);
-    overflow: hidden;
+    gap: 4px;
   }
 
   .node-icon {

--- a/packages/open-flow/src/workbench/browser/runtime/styles/runs.css
+++ b/packages/open-flow/src/workbench/browser/runtime/styles/runs.css
@@ -139,13 +139,6 @@
     text-overflow: ellipsis;
   }
 
-  .run-summary > [data-slot='button'] {
-    height: 24px;
-    width: 28px;
-    flex: none;
-    border-radius: 0;
-  }
-
   .run-log {
     display: flex;
     min-width: 0;

--- a/packages/open-flow/test/workbench-ui-style-boundaries.test.ts
+++ b/packages/open-flow/test/workbench-ui-style-boundaries.test.ts
@@ -283,6 +283,9 @@ test('keeps Workbench feature CSS from reclaiming shared primitive visuals', asy
   assert.doesNotMatch(resourceBrowser, /rounded-none|border-0/)
   assert.match(runInputPanel, /<Alert className="mb-4" variant="destructive">/)
   assert.doesNotMatch(runInputPanel, /run-input-error/)
+  assert.match(workbenchDesigner, /aria-expanded=\{blocksOpen\}[\s\S]*?size="default"[\s\S]*?title=\{t\('designer\.openBlocks'\)\}[\s\S]*?variant="outline"/)
+  assert.match(workbenchDesigner, /onDeleteNodes\(\)[\s\S]*?size="default"[\s\S]*?variant="destructive"/)
+  assert.match(workbenchDesigner, /aria-label=\{t\('designer\.toggleInspector'\)\}[\s\S]*?size="icon"[\s\S]*?variant="outline"/)
   assert.match(workbenchDesigner, /recommendedOptions\.map[\s\S]*?size="sm"[\s\S]*?variant="outline"/)
   assert.match(contextPanel, /<InputGroup>/)
   assert.doesNotMatch(contextPanel, /block-library-search/)
@@ -293,15 +296,19 @@ test('keeps Workbench feature CSS from reclaiming shared primitive visuals', asy
   assert.doesNotMatch(runs, /border-0/)
   assert.doesNotMatch(runs, /className="run-tabs"/)
   assert.doesNotMatch(runDrawer, /className="run-tabs"/)
+  assert.match(runDrawer, /aria-label=\{t\(open \? 'run\.collapse' : 'run\.expand'\)\}[\s\S]*?size="icon-xs"/)
   assert.match(publications, /className="m-2"[\s\S]*?size="lg"[\s\S]*?variant="outline"/)
   assert.doesNotMatch(workspaceStyles, /\.diagnostics-(?:empty|loading)/)
   assert.doesNotMatch(workspaceStyles, /\.run-input-error/)
   assert.doesNotMatch(workspaceStyles, /\.workspace-title button|\.validation-state:(?:hover|focus)|\.validation-state\.(?:invalid|active)/)
+  assert.doesNotMatch(canvasStyles, /\.designer-overlay\.top-right > \[data-slot='button'\]/)
+  assert.doesNotMatch(canvasStyles, /\.designer-delete-action/)
   assert.doesNotMatch(canvasStyles, /\.canvas-empty-recommendations \[data-slot='button'\]/)
   assert.doesNotMatch(contextPanelStyles, /\.block-library-search/)
   assert.doesNotMatch(contextPanelStyles, /\.block-library \[data-slot='button'\]:hover/)
   assert.doesNotMatch(contextPanelStyles, /\.inspector-form input:not/)
   assert.doesNotMatch(runStyles, /\.run-list-item\.active|\.run-load-more/)
+  assert.doesNotMatch(runStyles, /\.run-summary > \[data-slot='button'\]/)
   assert.doesNotMatch(runStyles, /\.event-locate \{[^}]*?(?:padding|border-radius|background|color):/)
   assert.doesNotMatch(publicationStyles, /\.publication-load-more/)
   assert.doesNotMatch(responsiveStyles, /\.diagnostics-loading/)
@@ -355,9 +362,9 @@ test('keeps responsive control density on component APIs', async () => {
   assert.match(button, /data-variant=\{variant\}/)
   assert.match(tabs, /motion-reduce:transition-none/)
   assert.match(tabs, /motion-reduce:after:transition-none/)
-  assert.match(workspaceHeader, /className="validation-state"[\s\S]*?size="sm"/)
-  assert.match(workspaceHeader, /onClick=\{onRunDraft\}[\s\S]*?size="sm"/)
-  assert.match(workspaceHeader, /store\.publications\.publish\(\)[\s\S]*?size="sm"/)
+  assert.match(workspaceHeader, /className="validation-state"[\s\S]*?size="default"/)
+  assert.match(workspaceHeader, /onClick=\{onRunDraft\}[\s\S]*?size="default"/)
+  assert.match(workspaceHeader, /store\.publications\.publish\(\)[\s\S]*?size="default"/)
   assert.match(workspaceHeader, /className="workspace-tabs" variant="line"/)
   assert.doesNotMatch(responsiveStyles, /\.workspace-actions \[data-slot='button'\]/)
   assert.match(responsiveStyles, /@media \(pointer: coarse\)[\s\S]*?min-height: 40px;/)
@@ -454,22 +461,66 @@ test('keeps Run input values on the WorkbenchRunInputs public contract', async (
 })
 
 test('uses React Flow ownership for canvas chrome without custom toolbar primitives', async () => {
-  const [displayMode, bottomRight, workbenchDesigner, button] = await Promise.all([
-    readFile(new URL('src/designer/browser/graph/ReactFlowContainer/DisplayModeToggle.tsx', packageRoot), 'utf8'),
-    readFile(new URL('src/designer/browser/graph/ReactFlowContainer/BottomRight.tsx', packageRoot), 'utf8'),
-    readFile(new URL('src/workbench/browser/runtime/designer/workbenchDesigner.tsx', packageRoot), 'utf8'),
-    readFile(new URL('src/ui/browser/button.tsx', packageRoot), 'utf8'),
-  ])
+  const [displayMode, displayModeStyles, bottomRight, workbenchDesigner, button, buttonGroup, canvasStyles, reactFlow, reactFlowStyles, designerMixins] =
+    await Promise.all([
+      readFile(new URL('src/designer/browser/graph/ReactFlowContainer/DisplayModeToggle.tsx', packageRoot), 'utf8'),
+      readFile(new URL('src/designer/browser/graph/ReactFlowContainer/DisplayModeToggle.module.scss', packageRoot), 'utf8'),
+      readFile(new URL('src/designer/browser/graph/ReactFlowContainer/BottomRight.tsx', packageRoot), 'utf8'),
+      readFile(new URL('src/workbench/browser/runtime/designer/workbenchDesigner.tsx', packageRoot), 'utf8'),
+      readFile(new URL('src/ui/browser/button.tsx', packageRoot), 'utf8'),
+      readFile(new URL('src/ui/browser/button-group.tsx', packageRoot), 'utf8'),
+      readFile(new URL('src/workbench/browser/runtime/styles/canvas.css', packageRoot), 'utf8'),
+      readFile(new URL('src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.tsx', packageRoot), 'utf8'),
+      readFile(new URL('src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.module.scss', packageRoot), 'utf8'),
+      readFile(new URL('src/designer/browser/styles/_mixins.scss', packageRoot), 'utf8'),
+    ])
 
   assert.match(displayMode, /import \{ Panel \} from '@xyflow\/react'/)
   assert.match(displayMode, /ToggleGroup/)
+  assert.match(displayMode, /size="default"/)
   assert.doesNotMatch(displayMode, /Tabs|CanvasControl/)
   assert.match(bottomRight, /ControlButton, Controls, MiniMap as RFMiniMap/)
   assert.match(bottomRight, /position="bottom-right"/)
   assert.match(bottomRight, /title=\{modeBtnTitle\}/)
-  assert.doesNotMatch(bottomRight, /CanvasControl|DesignerTooltip|ui\/browser\/button/)
+  assert.match(bottomRight, /buttonGroupVariants/)
+  assert.match(bottomRight, /buttonGroupVariants\(\{ orientation: 'horizontal' \}\)/)
+  assert.match(bottomRight, /orientation="horizontal"/)
+  assert.doesNotMatch(bottomRight, /data-orientation=|data-slot="button-group"/)
+  assert.match(bottomRight, /buttonVariants\(\{ size: 'icon', variant: 'outline' \}\)/)
+  assert.doesNotMatch(bottomRight, /CanvasControl|DesignerTooltip/)
   assert.match(workbenchDesigner, /ui\/browser\/badge\.tsx/)
+  assert.match(workbenchDesigner, /<Badge className="designer-overlay top-left" variant="secondary">/)
   assert.doesNotMatch(workbenchDesigner, /designer\/browser\/styles\/(?:dark|light)\.module\.scss|CanvasControl/)
+  assert.doesNotMatch(displayModeStyles, /border:|border-radius:|background:|box-shadow:|color:|font-size:|font-weight:/)
+  assert.doesNotMatch(canvasStyles, /--canvas-control-|\.designer-draft-status/)
+  assert.match(buttonGroup, /vertical:[\s\S]*?rounded-b-none[\s\S]*?rounded-t-none[\s\S]*?border-t-0/)
+  assert.match(reactFlow, /buttonGroupVariants\(\{ orientation: 'vertical' \}\)/)
+  assert.match(reactFlow, /orientation="vertical"/)
+  assert.match(reactFlow, /buttonVariants\(\{ size: 'icon', variant: 'outline' \}\)/)
+  assert.match(reactFlow, /data-slot="button"/)
+  assert.doesNotMatch(reactFlow, /data-orientation=|data-slot="button-group"/)
+  assert.match(reactFlowStyles, /react-flow__controls\.horizontal[\s\S]*?flex-direction: row !important/)
+  assert.match(reactFlowStyles, /:is\(\.horizontal, \.vertical\)[\s\S]*?data-slot='button'[\s\S]*?border-radius: 0 !important/)
+  assert.match(
+    reactFlowStyles,
+    /:is\(\.horizontal, \.vertical\)[\s\S]*?width: var\(--canvas-control-container-size\) !important[\s\S]*?height: var\(--canvas-control-container-size\) !important/,
+  )
+  assert.match(
+    reactFlowStyles,
+    /react-flow__controls\.vertical[\s\S]*?not\(:last-child\)[\s\S]*?border-bottom-color: color-mix\(in srgb, var\(--ui-border\) 55%, transparent\) !important/,
+  )
+  assert.match(
+    reactFlowStyles,
+    /react-flow__controls\.horizontal[\s\S]*?not\(:last-child\)[\s\S]*?border-right-color: color-mix\(in srgb, var\(--ui-border\) 55%, transparent\) !important/,
+  )
+  assert.match(reactFlowStyles, /react-flow__controls\.vertical[\s\S]*?first-child[\s\S]*?border-top-left-radius:[\s\S]*?border-top-right-radius:/)
+  assert.match(reactFlowStyles, /react-flow__controls\.vertical[\s\S]*?last-child[\s\S]*?border-bottom-right-radius:[\s\S]*?border-bottom-left-radius:/)
+  assert.match(reactFlowStyles, /react-flow__controls\.horizontal[\s\S]*?first-child[\s\S]*?border-top-left-radius:[\s\S]*?border-bottom-left-radius:/)
+  assert.match(reactFlowStyles, /react-flow__controls\.horizontal[\s\S]*?last-child[\s\S]*?border-top-right-radius:[\s\S]*?border-bottom-right-radius:/)
+  assert.doesNotMatch(reactFlowStyles, /react-flow__controls-button[^}]*border-radius:/)
+  assert.doesNotMatch(reactFlowStyles, /react-flow__controls-button[^}]*border-radius: 0/)
+  assert.match(designerMixins, /--canvas-control-container-size: 32px/)
+  assert.doesNotMatch(designerMixins, /--canvas-control-size:|--canvas-control-padding:/)
   assert.match(button, /forwardRef<HTMLButtonElement/)
 })
 

--- a/packages/open-flow/test/workbench-ui-style-boundaries.test.ts
+++ b/packages/open-flow/test/workbench-ui-style-boundaries.test.ts
@@ -471,7 +471,7 @@ test('uses React Flow ownership for canvas chrome without custom toolbar primiti
       readFile(new URL('src/ui/browser/button-group.tsx', packageRoot), 'utf8'),
       readFile(new URL('src/workbench/browser/runtime/styles/canvas.css', packageRoot), 'utf8'),
       readFile(new URL('src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.tsx', packageRoot), 'utf8'),
-      readFile(new URL('src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.module.scss', packageRoot), 'utf8'),
+      readFile(new URL('src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.scss', packageRoot), 'utf8'),
       readFile(new URL('src/designer/browser/styles/_mixins.scss', packageRoot), 'utf8'),
     ])
 


### PR DESCRIPTION
## Summary

Align the Workbench and canvas chrome with the shared shadcn/Base UI primitives while preserving the compact Designer styling used inside workflow nodes.

The previous canvas controls mixed shared Button and ToggleGroup components with feature CSS that forced square corners, custom surfaces, and bespoke dimensions. React Flow's own Controls implementation also filters arbitrary data attributes and loads width and height rules after the Tailwind utilities, so several initial style changes did not reach or win on the real DOM elements. Users saw inconsistent sharp and rounded buttons, incorrectly separated command groups, incorrect right-side orientation, and controls that did not visibly resize.

## What changed

- Add the current shadcn `ButtonGroup` primitive to the shared UI layer.
- Use shared Button variants for Workbench header and canvas overlay actions instead of feature-owned button visuals.
- Keep React Flow `Controls` and `ControlButton` behavior, but apply the shared ButtonGroup and Button variant contracts to their rendered elements.
- Use the official React Flow `orientation` prop and the generated `.horizontal` / `.vertical` classes instead of relying on filtered custom data attributes.
- Preserve connected vertical controls on the left and connected horizontal controls on the right, with rounded outer corners and lighter internal separators.
- Standardize canvas chrome controls and the display-mode ToggleGroup on the 32px shadcn default size while explicitly overriding React Flow's later 26px dimensions at the scoped integration boundary.
- Remove obsolete custom canvas-control visual and size overrides, including square child-button rules.
- Keep node, handle, edge, and node-parameter styling unchanged.
- Document the Canvas Content versus Canvas Chrome ownership boundary and add regression coverage for the rendered React Flow contract, direction, size, corner, and separator rules.

## Validation

- `bun run lint`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run test:package`
- Targeted Workbench style-boundary and React Flow control tests
- `git diff --check`

All checks pass. The full suite includes 453 Open Flow tests, 20 command tests, and 144 server tests.
