### PR TITLE
fix(workbench): inline TypeScript worker

### DIFF
--- a/packages/open-flow/scripts/check-npm-package.ts
+++ b/packages/open-flow/scripts/check-npm-package.ts
@@ -278,6 +278,14 @@ const workbenchJavaScript = entries.filter(
   (entry) => entry.header.name.startsWith('package/dist/browser/') && entry.header.name.endsWith('.js') && entry.data != null,
 )
 assert.ok(workbenchJavaScript.some((entry) => /from ['"]react-dom['"]/.test(new TextDecoder().decode(entry.data!))))
+assert.equal(
+  entryNames.some((name) => /^package\/dist\/browser\/assets\/typeScriptWorker-.+\.js$/.test(name)),
+  false,
+)
+assert.equal(
+  workbenchJavaScript.some((entry) => /\/assets\/typeScriptWorker-.+\.js/.test(new TextDecoder().decode(entry.data!))),
+  false,
+)
 for (const entry of workbenchJavaScript) {
   assertNoReactRequire(new TextDecoder().decode(entry.data!), entry.header.name)
 }

--- a/packages/open-flow/src/browser-assets.d.ts
+++ b/packages/open-flow/src/browser-assets.d.ts
@@ -23,3 +23,7 @@ declare module '*?raw' {
   const source: string
   export default source
 }
+declare module '*?worker&inline' {
+  const Worker: new () => Worker
+  export default Worker
+}

--- a/packages/open-flow/src/workbench/browser/typeScriptSession.ts
+++ b/packages/open-flow/src/workbench/browser/typeScriptSession.ts
@@ -3,6 +3,8 @@ import type { Extension } from '@codemirror/state'
 
 import { javascript } from '@codemirror/lang-javascript'
 import { LSPClient, languageServerExtensions } from '@codemirror/lsp-client'
+// oxlint-disable-next-line import/default
+import TypeScriptWorker from './typeScriptWorker.ts?worker&inline'
 
 let sessionPromise: ReturnType<typeof createSession> | undefined
 const typeScriptLanguage = javascript({ typescript: true }).language
@@ -52,7 +54,7 @@ function createTransport(worker: Worker): Transport {
 }
 
 async function createSession() {
-  const worker = new Worker(new URL('./typeScriptWorker.ts', import.meta.url), { type: 'module' })
+  const worker = new TypeScriptWorker()
   const client = new LSPClient({ extensions: languageServerExtensions(), highlightLanguage, sanitizeHTML: openLinksInNewTab, timeout: 60_000 })
   await client.connect(createTransport(worker))
   return { client, worker }


### PR DESCRIPTION
## Summary

- inline the TypeScript language worker in its lazy Workbench chunk
- prevent the published package from emitting a host-root `/assets/typeScriptWorker-*.js` URL
- extend the npm package check to reject standalone or root-relative TypeScript worker assets

## Root cause

The Workbench library build emitted the worker under `dist/browser/assets`, but compiled its loader to `/assets/typeScriptWorker-*.js`. A consuming Vite application retained that URL without copying the package-private worker into its own output, so deployed hosts returned 404.

## Verification

- `bun run check`
- `bun run test`
- `bun run build`
- `bun run test:package`

## Follow-up after merge

This PR intentionally does not publish a package or modify the Console repository.

1. Publish the next `@oomol-lab/open-flow` alpha from the merged commit.
2. Upgrade the exact package version in `console.oomol.com`.
3. Run the Console production build and verify its output contains no `/assets/typeScriptWorker-*.js` reference.
4. Deploy the Console and verify TypeScript completion and hover in the Open Flow code editor.