### PR TITLE
style(workbench): refine resource lists

### DIFF
--- a/packages/open-flow/src/workbench/browser/runtime/shell/hostMenu.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/shell/hostMenu.tsx
@@ -20,7 +20,7 @@ export function HostMenu({ action, onAction, title }: { readonly action: string;
         <DropdownMenuTrigger
           aria-label={action}
           render={
-            <Button size="icon" title={action} variant="ghost">
+            <Button size="icon" title={action} variant="outline">
               <Icon name="more" />
             </Button>
           }

--- a/packages/open-flow/src/workbench/browser/runtime/shell/resourceBrowser.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/shell/resourceBrowser.tsx
@@ -182,6 +182,22 @@ function FlowItem({ busy, flow, href, onSelect, store }: FlowItemProps): ReactEl
   )
 }
 
+function FlowSkeleton(): ReactElement {
+  return (
+    <div aria-hidden="true" className="resource-list-row resource-skeleton-row flow-columns">
+      <span className="resource-primary-cell">
+        <Skeleton className="size-8 shrink-0" />
+        <span className="resource-skeleton-copy">
+          <Skeleton className="h-3.5 w-36" />
+          <Skeleton className="h-2.5 w-48 max-w-full" />
+        </span>
+      </span>
+      <Skeleton className="h-3 w-28" />
+      <Skeleton className="h-3 w-16" />
+    </div>
+  )
+}
+
 interface FlowBrowserProps extends LanguageSelectProps {
   readonly hrefForFlow: (flow: Flow) => string
   readonly hostAction?: string | undefined
@@ -281,7 +297,7 @@ export function FlowBrowser({
           </div>
           <div className="resource-list">
             {loading ? (
-              Array.from({ length: 5 }, (_, index) => <Skeleton className="h-14" key={index} />)
+              Array.from({ length: 5 }, (_, index) => <FlowSkeleton key={index} />)
             ) : loadFailed ? (
               <Empty className="min-h-64" role="alert">
                 <EmptyHeader>
@@ -320,9 +336,11 @@ export function FlowBrowser({
             )}
           </div>
           {nextCursor != null && (
-            <Button className="mt-3 w-full" disabled={loadingMore} onClick={() => void store.workspace.loadMoreFlows()} variant="outline">
-              {t(loadingMore ? 'resource.loadingMore' : loadMoreFailed ? 'resource.retryLoadMore' : 'resource.loadMore')}
-            </Button>
+            <div className="resource-list-footer">
+              <Button disabled={loadingMore} onClick={() => void store.workspace.loadMoreFlows()} variant="outline">
+                {t(loadingMore ? 'resource.loadingMore' : loadMoreFailed ? 'resource.retryLoadMore' : 'resource.loadMore')}
+              </Button>
+            </div>
           )}
         </section>
         {creating && (

--- a/packages/open-flow/src/workbench/browser/runtime/styles/publications.css
+++ b/packages/open-flow/src/workbench/browser/runtime/styles/publications.css
@@ -582,10 +582,10 @@
     position: sticky;
     z-index: 1;
     top: 0;
-    height: 34px;
-    background: var(--ui-card);
+    height: 40px;
+    background: var(--ui-background);
     color: var(--ui-muted-foreground);
-    font-size: 10px;
+    font-size: 12px;
     font-weight: 500;
   }
 
@@ -611,7 +611,7 @@
 
   .publication-table td {
     color: var(--ui-muted-foreground);
-    font-size: 11px;
+    font-size: 12px;
   }
 
   .publication-table td > code,
@@ -636,7 +636,7 @@
     gap: 7px;
     margin: 0 0 4px;
     color: var(--ui-foreground);
-    font-size: 11px;
+    font-size: 12px;
     font-weight: 500;
   }
 

--- a/packages/open-flow/src/workbench/browser/runtime/styles/resource-browser.css
+++ b/packages/open-flow/src/workbench/browser/runtime/styles/resource-browser.css
@@ -76,8 +76,8 @@
   }
 
   .resource-list-section {
+    min-width: 0;
     margin-top: 20px;
-    overflow: hidden;
     border: 1px solid var(--ui-border);
     border-radius: var(--ui-radius);
     background: var(--ui-background);

--- a/packages/open-flow/src/workbench/browser/runtime/styles/resource-browser.css
+++ b/packages/open-flow/src/workbench/browser/runtime/styles/resource-browser.css
@@ -77,9 +77,10 @@
 
   .resource-list-section {
     margin-top: 20px;
+    overflow: hidden;
     border: 1px solid var(--ui-border);
     border-radius: var(--ui-radius);
-    background: var(--ui-card);
+    background: var(--ui-background);
   }
 
   .resource-list-title {
@@ -89,7 +90,8 @@
     justify-content: space-between;
     flex-wrap: wrap;
     gap: 16px;
-    padding: 12px;
+    min-height: 56px;
+    padding: 8px 16px;
   }
 
   .resource-list-heading {
@@ -142,23 +144,22 @@
   }
 
   .flow-columns {
-    grid-template-columns: minmax(220px, 1fr) minmax(140px, 180px) 120px;
+    grid-template-columns: minmax(240px, 1fr) minmax(140px, 180px) 108px;
   }
 
   .resource-list-columns {
-    min-height: 30px;
-    padding: 0 12px;
+    min-height: 40px;
+    padding: 0 56px 0 16px;
     border-top: 1px solid var(--ui-border);
     color: var(--ui-muted-foreground);
-    background: color-mix(in srgb, var(--ui-muted) 55%, transparent);
-    font-size: 11px;
+    font-size: 12px;
     font-weight: 500;
   }
 
   .resource-list-row {
     width: 100%;
-    min-height: 56px;
-    padding: 8px 12px;
+    min-height: 60px;
+    padding: 8px 16px;
     border-bottom: 1px solid var(--ui-border);
     text-align: left;
   }
@@ -191,19 +192,19 @@
 
   .resource-primary-cell strong {
     color: var(--ui-foreground);
-    font-size: 13px;
+    font-size: 14px;
     font-weight: 600;
   }
 
   .resource-primary-cell code {
     color: var(--ui-muted-foreground);
-    font-size: 10px;
+    font-size: 11px;
   }
 
   .resource-icon {
     display: inline-grid;
-    width: 30px;
-    height: 30px;
+    width: 32px;
+    height: 32px;
     place-items: center;
     flex: 0 0 auto;
     border: 1px solid var(--ui-border);
@@ -217,7 +218,7 @@
   .resource-status {
     min-width: 0;
     color: var(--ui-muted-foreground);
-    font-size: 11px;
+    font-size: 12px;
   }
 
   .resource-list-row time {
@@ -258,6 +259,7 @@
     grid-column: 2;
     grid-row: 1;
     align-self: center;
+    justify-self: center;
     opacity: 0;
   }
 
@@ -307,5 +309,29 @@
   .resource-row-confirm small {
     color: var(--ui-muted-foreground);
     font-size: 11px;
+  }
+
+  .resource-skeleton-row {
+    padding-right: 56px;
+  }
+
+  .resource-skeleton-copy {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .resource-skeleton-row:last-child {
+    border-bottom: 0;
+  }
+
+  .resource-list-footer {
+    display: flex;
+    min-height: 56px;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 16px;
+    border-top: 1px solid var(--ui-border);
   }
 }

--- a/packages/open-flow/src/workbench/browser/runtime/styles/responsive.css
+++ b/packages/open-flow/src/workbench/browser/runtime/styles/responsive.css
@@ -116,7 +116,7 @@
 
     .resource-page-actions {
       width: 100%;
-      justify-content: space-between;
+      justify-content: flex-end;
     }
 
     .resource-heading h1 {


### PR DESCRIPTION
## Summary

The Workbench Flow catalog looked heavier and less consistent than the surrounding Console-style resource lists. Its header was unusually compact while the loading state rendered as full-width gray bars, the list surface used the muted card color, pagination sat outside the list structure, and narrow layouts spread page actions across the full row. The host menu also appeared as an unframed ellipsis beside framed controls.

This change refines the catalog as a stable management list. It uses a white table surface, a clearer header and row hierarchy, more consistent spacing and typography, structured skeleton rows that preserve the final column layout, and an integrated pagination footer. The publication history table receives the same readable header treatment. The host menu now uses the shared outline icon-button treatment, and narrow page actions remain a compact right-aligned group instead of being distributed with `space-between`.

These changes keep resource, publication, Run, and Event behaviors intact. They only adjust Workbench composition and styles; no Control API, persistence, runtime, or Designer Canvas Content behavior changes.

## Validation

- `bun run lint`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run test:package`

All checks passed, including 93 Open Flow test files with 462 tests, 3 Command test files with 20 tests, 22 Server test files with 152 tests, the public npm package contract, React 18/19 consumers, and Command Artifact smoke tests.
