### PR TITLE
feat(workbench): allow hosts to disable variables

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,7 @@
     },
     "packages/command": {
       "name": "@oomol-lab/open-flow-command",
-      "version": "0.1.0-alpha.13",
+      "version": "0.1.0-alpha.14",
       "dependencies": {
         "@oomol-lab/open-flow": "workspace:*",
         "@wopjs/cast": "^0.1.16",
@@ -63,7 +63,7 @@
     },
     "packages/open-flow": {
       "name": "@oomol-lab/open-flow",
-      "version": "0.1.0-alpha.13",
+      "version": "0.1.0-alpha.14",
       "devDependencies": {
         "@babel/parser": "8.0.4",
         "@babel/traverse": "8.0.4",

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oomol-lab/open-flow-command",
-  "version": "0.1.0-alpha.13",
+  "version": "0.1.0-alpha.14",
   "description": "Open Flow command runtime and immutable Command Artifact builder.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/open-flow/package.json
+++ b/packages/open-flow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oomol-lab/open-flow",
-  "version": "0.1.0-alpha.13",
+  "version": "0.1.0-alpha.14",
   "description": "Portable contracts and shared browser runtime for Open Flow.",
   "keywords": [
     "ai",

--- a/packages/open-flow/scripts/check-npm-package.ts
+++ b/packages/open-flow/scripts/check-npm-package.ts
@@ -377,7 +377,7 @@ async function verifyConsumer(versions: { readonly react: string; readonly react
         '  request: async () => Response.json({}), subscribeFlow: () => () => undefined, subscribeFlowCatalog: () => () => undefined,',
         '}',
         "const workbench = createElement(OpenFlowWorkbench, { host, hrefFor: () => '/teams/team-a', language: 'en', location, onNavigate: () => undefined,",
-        "  preferences: { getItem: () => null, setItem: () => undefined }, sessionKey: 'team-a', theme: 'light' })",
+        "  preferences: { getItem: () => null, setItem: () => undefined }, sessionKey: 'team-a', theme: 'light', variables: false })",
         "const sessionGate = createElement(OpenFlowSessionGate, { action: 'Sign in', description: 'Use the operator token.', onSubmit: () => undefined, title: 'Open Flow', token: '', tokenLabel: 'Operator token' })",
         'const task: Task<{ value: string }, { value: string }> = async (inputs) => inputs',
         'void connector',

--- a/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.test.tsx
+++ b/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.test.tsx
@@ -253,6 +253,20 @@ describe('FlowDesignerView model synchronization', () => {
     store.dispose()
   })
 
+  it('hides disabled Variable inputs while preserving existing bindings for clearing', () => {
+    const unbound = model([task([{ handle: 'value', jsonSchema: { type: 'string' }, variableCompatible: true, variableEnabled: false }])])
+    const bound = model([task([{ handle: 'value', jsonSchema: { type: 'string' }, variable: 'API_TOKEN', variableCompatible: true, variableEnabled: false }])])
+    const view = FlowDesignerView(props(unbound)) as React.ReactElement<FlowDesignerProps>
+    const store = view.props.flowDesignerStore
+
+    expect(store.$.variableInputs.value.size).toBe(0)
+
+    FlowDesignerView(props(bound))
+
+    expect(store.$.variableInputs.value.get('target\0value')).toEqual({ compatible: true, enabled: false, name: 'API_TOKEN' })
+    store.dispose()
+  })
+
   it('treats a valid Variable binding as an input source', () => {
     const validate = captureIdleValidation()
     const value: FlowDesignerViewModel = {

--- a/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.tsx
+++ b/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.tsx
@@ -65,6 +65,7 @@ export interface FlowDesignerViewInput {
   readonly value?: unknown
   readonly variable?: string
   readonly variableCompatible?: boolean
+  readonly variableEnabled?: boolean
 }
 
 export interface FlowDesignerViewOutput {
@@ -408,15 +409,18 @@ interface ViewCallbacks {
   readonly onOpenVariables: FlowDesignerViewProps['onOpenVariables']
 }
 
-function variableInputs(nodes: readonly FlowDesignerViewNode[]): ReadonlyMap<string, { readonly compatible: boolean; readonly name?: string }> {
-  const inputs = new Map<string, { readonly compatible: boolean; readonly name?: string }>()
+function variableInputs(
+  nodes: readonly FlowDesignerViewNode[],
+): ReadonlyMap<string, { readonly compatible: boolean; readonly enabled?: false; readonly name?: string }> {
+  const inputs = new Map<string, { readonly compatible: boolean; readonly enabled?: false; readonly name?: string }>()
   for (const node of nodes) {
     if (node.kind == 'comment') continue
     for (const input of node.inputs) {
       if (!('handle' in input)) continue
-      if (input.variableCompatible || input.variable != null) {
+      if ((input.variableEnabled !== false && input.variableCompatible) || input.variable != null) {
         inputs.set(`${node.id}\0${input.handle}`, {
           compatible: input.variableCompatible ?? false,
+          ...(input.variableEnabled === false ? { enabled: false as const } : {}),
           ...(input.variable == null ? {} : { name: input.variable }),
         })
       }
@@ -438,7 +442,7 @@ class FlowDesignerViewAdapter {
   #pendingDisconnects = new Map<string, FlowDesignerViewEdge>()
   #runStatus: Val<FlowRunStatus>
   #selectedNodeIds = new Set<string>()
-  #variableInputs: Val<ReadonlyMap<string, { readonly compatible: boolean; readonly name?: string }>>
+  #variableInputs: Val<ReadonlyMap<string, { readonly compatible: boolean; readonly enabled?: false; readonly name?: string }>>
   #variableNames: Val<readonly string[]>
   #variableNamesLoaded: Val<boolean>
   #variableNamesLoading: Val<boolean>

--- a/packages/open-flow/src/designer/browser/graph/NodeSection/InputSection.tsx
+++ b/packages/open-flow/src/designer/browser/graph/NodeSection/InputSection.tsx
@@ -118,6 +118,7 @@ export const InputSection: React.FC<InputSectionProps> = /* @__PURE__ */ memo(({
                 loading: variableNamesLoading,
                 names: variableNames,
                 name: variable.name,
+                enabled: variable.enabled !== false,
                 onChange: (name) => designerStore.onChangeInputVariable?.(nodeStore.nodeId, handle.name, name),
                 onOpen: () => designerStore.onOpenVariables?.(),
               }

--- a/packages/open-flow/src/designer/browser/i18n/locales/en.json
+++ b/packages/open-flow/src/designer/browser/i18n/locales/en.json
@@ -249,6 +249,8 @@
     "selectVariable": "Choose Variable",
     "variableMissing": "{{name}} (missing)",
     "variableMissingHelp": "Deployment Variable {{name}} no longer exists.",
+    "variableUnavailable": "{{name}} (unavailable)",
+    "variableUnavailableHelp": "Deployment Variables are currently unavailable.",
     "variablesLoading": "Loading Variables…",
     "unknown": "Unknown"
   },

--- a/packages/open-flow/src/designer/browser/i18n/locales/fr.json
+++ b/packages/open-flow/src/designer/browser/i18n/locales/fr.json
@@ -249,6 +249,8 @@
     "selectVariable": "Choisir une Variable",
     "variableMissing": "{{name}} (manquante)",
     "variableMissingHelp": "La Variable de deployment {{name}} n’existe plus.",
+    "variableUnavailable": "{{name}} (indisponible)",
+    "variableUnavailableHelp": "Les Variables de deployment ne sont actuellement pas disponibles.",
     "variablesLoading": "Chargement des Variables…",
     "unknown": "Inconnu"
   },

--- a/packages/open-flow/src/designer/browser/i18n/locales/ja.json
+++ b/packages/open-flow/src/designer/browser/i18n/locales/ja.json
@@ -249,6 +249,8 @@
     "selectVariable": "Variable を選択",
     "variableMissing": "{{name}}（見つかりません）",
     "variableMissingHelp": "Deployment Variable {{name}} は存在しません。",
+    "variableUnavailable": "{{name}}（現在利用できません）",
+    "variableUnavailableHelp": "Deployment Variable は現在利用できません。",
     "variablesLoading": "Variable を読み込み中…",
     "unknown": "不明"
   },

--- a/packages/open-flow/src/designer/browser/i18n/locales/ko.json
+++ b/packages/open-flow/src/designer/browser/i18n/locales/ko.json
@@ -249,6 +249,8 @@
     "selectVariable": "Variable 선택",
     "variableMissing": "{{name}} (누락됨)",
     "variableMissingHelp": "현재 deployment에 Variable {{name}}이(가) 더 이상 없습니다.",
+    "variableUnavailable": "{{name}} (현재 사용할 수 없음)",
+    "variableUnavailableHelp": "현재 deployment Variable을 사용할 수 없습니다.",
     "variablesLoading": "Variable 불러오는 중…",
     "unknown": "알 수 없음"
   },

--- a/packages/open-flow/src/designer/browser/i18n/locales/ru.json
+++ b/packages/open-flow/src/designer/browser/i18n/locales/ru.json
@@ -249,6 +249,8 @@
     "selectVariable": "Выбрать Variable",
     "variableMissing": "{{name}} (отсутствует)",
     "variableMissingHelp": "Deployment Variable {{name}} больше не существует.",
+    "variableUnavailable": "{{name}} (недоступна)",
+    "variableUnavailableHelp": "Deployment Variables сейчас недоступны.",
     "variablesLoading": "Загрузка Variables…",
     "unknown": "Неизвестно"
   },

--- a/packages/open-flow/src/designer/browser/i18n/locales/zh-CN.json
+++ b/packages/open-flow/src/designer/browser/i18n/locales/zh-CN.json
@@ -249,6 +249,8 @@
     "selectVariable": "选择 Variable",
     "variableMissing": "{{name}}（已缺失）",
     "variableMissingHelp": "当前 deployment 中已不存在 Variable {{name}}。",
+    "variableUnavailable": "{{name}}（暂不可用）",
+    "variableUnavailableHelp": "当前 deployment 暂不支持 Variable。",
     "variablesLoading": "正在加载 Variable…",
     "unknown": "未知"
   },

--- a/packages/open-flow/src/designer/browser/i18n/locales/zh-TW.json
+++ b/packages/open-flow/src/designer/browser/i18n/locales/zh-TW.json
@@ -249,6 +249,8 @@
     "selectVariable": "選擇 Variable",
     "variableMissing": "{{name}}（已遺失）",
     "variableMissingHelp": "目前 deployment 中已不存在 Variable {{name}}。",
+    "variableUnavailable": "{{name}}（暫時無法使用）",
+    "variableUnavailableHelp": "目前 deployment 暫不支援 Variable。",
     "variablesLoading": "正在載入 Variable…",
     "unknown": "未知"
   },

--- a/packages/open-flow/src/designer/browser/jsonSchema/handleEditor.tsx
+++ b/packages/open-flow/src/designer/browser/jsonSchema/handleEditor.tsx
@@ -91,6 +91,7 @@ export interface HandleEditorProps {
   onDragStart?: (ev: React.DragEvent<HTMLElement>) => void
   onDragOver?: (ev: React.DragEvent<HTMLElement>) => void
   readonly variable?: {
+    readonly enabled: boolean
     readonly loaded: boolean
     readonly loading: boolean
     readonly name?: string
@@ -321,7 +322,12 @@ function RootField(props: RootFieldProps) {
     }
     previousVariableName.current = name
   }, [props.variable?.name])
-  const variableOption: IBasicOption = { icon: 'i-carbon:value-variable', label: t('preset.deploymentVariable'), value: deploymentVariableType }
+  const variableOption: IBasicOption = {
+    icon: 'i-carbon:value-variable',
+    isDisabled: props.variable?.enabled === false,
+    label: t('preset.deploymentVariable'),
+    value: deploymentVariableType,
+  }
   const literalOption = optionOf(t, props.type)
   const typeOptions: readonly (WidgetSelectOption | IBasicOption)[] =
     props.variable == null ? options : props.store.context.canEditSchema ? [...options, variableOption] : [literalOption, variableOption]
@@ -404,6 +410,7 @@ function RootField(props: RootFieldProps) {
 
 function VariableBinding({
   disabled,
+  enabled,
   loaded,
   loading,
   name,
@@ -412,17 +419,22 @@ function VariableBinding({
   onOpen,
 }: NonNullable<HandleEditorProps['variable']> & { readonly disabled: boolean }) {
   const t = useTranslate()
-  const missing = loaded && name != null && !names.includes(name)
+  const unavailable = !enabled
+  const missing = !unavailable && loaded && name != null && !names.includes(name)
   const options: IBasicOption[] = [
+    ...(unavailable && name != null ? [{ label: t('handleEditor.variableUnavailable', { name }), value: name }] : []),
     ...(missing ? [{ label: t('handleEditor.variableMissing', { name }), value: name }] : []),
     ...names.map((value) => ({ label: value, value })),
   ]
   const value = name == null ? null : (options.find((option) => option.value == name) ?? null)
   return (
-    <DesignerTooltip placement="top" title={missing ? t('handleEditor.variableMissingHelp', { name }) : undefined}>
+    <DesignerTooltip
+      placement="top"
+      title={unavailable ? t('handleEditor.variableUnavailableHelp') : missing ? t('handleEditor.variableMissingHelp', { name }) : undefined}
+    >
       <div className={styles.inlineValue}>
         <Select<IBasicOption>
-          disabled={disabled}
+          disabled={disabled || unavailable}
           isClearable
           isSuffix
           onChange={(option) => onChange(option?.value)}
@@ -430,7 +442,7 @@ function VariableBinding({
           options={options}
           placeholder={loading ? t('handleEditor.variablesLoading') : t('handleEditor.selectVariable')}
           value={value}
-          variant={missing ? 'danger' : 'default'}
+          variant={missing || unavailable ? 'danger' : 'default'}
         />
       </div>
     </DesignerTooltip>

--- a/packages/open-flow/src/designer/browser/stores/designer/designer.store.ts
+++ b/packages/open-flow/src/designer/browser/stores/designer/designer.store.ts
@@ -185,7 +185,7 @@ export interface DesignerStore$ extends ToReadonly$Group<DesignerStore$$> {
   readonly runStatus: ReadonlyVal<FlowRunStatus>
 
   readonly nodeMiniMapPhase: ReadonlyVal<NodeMiniMapPhase>
-  readonly variableInputs: ReadonlyVal<ReadonlyMap<string, { readonly compatible: boolean; readonly name?: string }>>
+  readonly variableInputs: ReadonlyVal<ReadonlyMap<string, { readonly compatible: boolean; readonly enabled?: false; readonly name?: string }>>
   readonly variableNames: ReadonlyVal<readonly string[]>
   readonly variableNamesLoaded: ReadonlyVal<boolean>
   readonly variableNamesLoading: ReadonlyVal<boolean>
@@ -208,7 +208,7 @@ export interface DesignerStoreProps {
   readonly runStatus: ReadonlyVal<FlowRunStatus>
   readonly designerUIStore: DesignerUIStore
   readonly focused$?: ReadonlyVal<boolean>
-  readonly variableInputs?: ReadonlyVal<ReadonlyMap<string, { readonly compatible: boolean; readonly name?: string }>>
+  readonly variableInputs?: ReadonlyVal<ReadonlyMap<string, { readonly compatible: boolean; readonly enabled?: false; readonly name?: string }>>
   readonly variableNames?: ReadonlyVal<readonly string[]>
   readonly variableNamesLoaded?: ReadonlyVal<boolean>
   readonly variableNamesLoading?: ReadonlyVal<boolean>

--- a/packages/open-flow/src/workbench/browser/runtime/openFlowWorkbench.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/openFlowWorkbench.tsx
@@ -185,6 +185,7 @@ export interface OpenFlowWorkbenchProps {
   readonly preferences: WorkbenchPreferences
   readonly sessionKey: string
   readonly theme: WorkbenchTheme
+  readonly variables?: boolean
 }
 
 type SessionProps = Omit<OpenFlowWorkbenchProps, 'sessionKey'>
@@ -201,6 +202,7 @@ function Session({
   onNavigate,
   preferences,
   theme,
+  variables = true,
 }: SessionProps): ReactElement {
   const navigate = useRef(onNavigate)
   navigate.current = onNavigate
@@ -216,6 +218,7 @@ function Session({
       () => crypto.randomUUID(),
       workbenchI18n,
       host,
+      variables,
     )
     return {
       i18n: workbenchI18n,

--- a/packages/open-flow/src/workbench/browser/runtime/stores/workbenchStore.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/workbenchStore.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest'
+import { WorkbenchClient } from '../api.ts'
+import { WorkbenchStore } from './workbenchStore.ts'
+
+describe('WorkbenchStore Variables', () => {
+  it('does not request Variable names when the host disables Variables', async () => {
+    const request = vi.fn(async () => {
+      throw new Error('Unexpected request.')
+    })
+    const store = new WorkbenchStore(
+      new WorkbenchClient(request),
+      { getItem: () => null, setItem: () => undefined },
+      () => 'identity',
+      undefined,
+      undefined,
+      false,
+    )
+
+    try {
+      await store.refreshVariableNames()
+
+      expect(request).not.toHaveBeenCalled()
+      expect(store.$.variableNamesLoading.value).toBe(false)
+    } finally {
+      store.dispose()
+    }
+  })
+})

--- a/packages/open-flow/src/workbench/browser/runtime/stores/workbenchStore.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/workbenchStore.ts
@@ -73,6 +73,7 @@ export class WorkbenchStore {
   readonly #externalRuns = new Latest()
   readonly #i18n: I18n
   readonly #notice: Val<Notice | undefined> = val()
+  readonly #variables: boolean
   readonly #variableNames = val<readonly string[]>([])
   readonly #variableNamesLoaded = val(false)
   readonly #variableNamesLoading = val(false)
@@ -93,9 +94,11 @@ export class WorkbenchStore {
     identity: () => string = () => crypto.randomUUID(),
     i18n: I18n = createI18n(),
     host: Pick<WorkbenchHost, 'openExternalPage'> = blockedExternalPages,
+    variables = true,
   ) {
     this.#client = client
     this.#i18n = i18n
+    this.#variables = variables
     const setNotice = (notice: Notice | undefined): void => {
       if (!this.#disposed) this.#notice.set(notice)
     }
@@ -154,6 +157,7 @@ export class WorkbenchStore {
         variableNames,
         variableNamesLoaded,
         variableNamesLoading,
+        this.#variables,
       )
       designerCache.set(key, { graph, inputs })
       return graph
@@ -220,7 +224,7 @@ export class WorkbenchStore {
   }
 
   public async refreshVariableNames(): Promise<void> {
-    if (this.#disposed) return
+    if (this.#disposed || !this.#variables) return
     const current = this.#variableRefresh.begin()
     this.#variableNamesLoading.set(true)
     try {

--- a/packages/open-flow/src/workbench/browser/runtime/workspace.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/workspace.test.ts
@@ -51,6 +51,14 @@ describe('Designer port projection', () => {
       { collapsed: true, group: 'Other' },
       expect.objectContaining({ handle: 'result-a' }),
     ])
+
+    const disabled = designerGraph(draft, { kind: 'flow' }, {}, [], {}, {}, undefined, undefined, [], [], false, false, false).nodes[0]
+    if (disabled == null || disabled.kind == 'comment') throw new Error('Expected a Task node.')
+    expect(disabled.inputs).toEqual([
+      { group: 'Request' },
+      expect.objectContaining({ handle: 'second', variableEnabled: false }),
+      expect.objectContaining({ handle: 'first', variableEnabled: false }),
+    ])
   })
 })
 

--- a/packages/open-flow/src/workbench/browser/runtime/workspace.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/workspace.ts
@@ -80,6 +80,7 @@ interface NodeProjectionContext {
   readonly runNodes: ReadonlyMap<string, FlowDesignerViewNodeRun>
   readonly t: TFunction | undefined
   readonly target: DesignerTarget
+  readonly variables: boolean
 }
 
 export function connectionCatalog(connections: readonly ConnectorConnection[]): ConnectionCatalog {
@@ -481,7 +482,7 @@ function layoutNodes(
   return { depth, ordered }
 }
 
-function designerInputs(nodeId: string, node: GraphNode, ports: NodePorts, revision: RevisionView): readonly FlowDesignerViewInput[] {
+function designerInputs(nodeId: string, node: GraphNode, ports: NodePorts, revision: RevisionView, variables: boolean): readonly FlowDesignerViewInput[] {
   if (!('inputs' in node)) return []
   const inputs: FlowDesignerViewInput[] = []
   for (const [handle, definition] of ports.inputs) {
@@ -508,6 +509,7 @@ function designerInputs(nodeId: string, node: GraphNode, ports: NodePorts, revis
       ...(sources.length > 0 ? { sources } : {}),
       ...(binding?.kind == 'variable' ? { variable: binding.target } : {}),
       variableCompatible: variableInputCompatible(definition.jsonSchema as JsonValue),
+      variableEnabled: variables,
     })
   }
   return inputs
@@ -666,7 +668,7 @@ function triggerDesignerNode(triggerId: string, trigger: TriggerNode, position: 
 
 function semanticDesignerNode(nodeId: string, resolved: ResolvedNode, ports: NodePorts, position: Point, context: NodeProjectionContext): DesignerNode {
   const node = resolved.node
-  const inputs = groupedInputs(resolved, designerInputs(nodeId, node, ports, context.revision))
+  const inputs = groupedInputs(resolved, designerInputs(nodeId, node, ports, context.revision, context.variables))
   const outputs = groupedOutputs(resolved, designerOutputs(ports))
   const task = resolved.kind == 'task' ? resolved.definition : undefined
   const connector = task != null && 'executor' in task && task.executor.kind == 'connector' ? task.executor : undefined
@@ -737,6 +739,7 @@ export function designerGraph(
   variableNames: readonly string[] = [],
   variableNamesLoaded = false,
   variableNamesLoading = false,
+  variables = true,
 ): DesignerGraph {
   const revision = draft == null ? undefined : revisionView(draft)
   const graph = revision == null || target == null ? undefined : revision.graph(target)
@@ -757,6 +760,7 @@ export function designerGraph(
     runNodes: projectedRun.nodes,
     t,
     target,
+    variables,
   }
   const rows = new Map<number, number>()
   const nodes: DesignerNode[] = []


### PR DESCRIPTION
## Summary
- add a default-enabled Workbench Variables capability
- hide new Variable bindings and skip Variable requests when a host disables the capability
- keep existing bindings visible as unavailable so authors can clear them
- prepare @oomol-lab/open-flow 0.1.0-alpha.14

## Verification
- bun run check
- bun run test
- bun run build
- bun run test:package