### PR TITLE
Fix README architecture diagram layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ code, and the deployment remains under your control.
 flowchart LR
   Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
   CLI["oo flow CLI"] -->|"Control API"| Server
+  Server -. "optional" .-> Connector["Connector runtime"]
+  Connector --> Providers["Third-party Providers"]
   Server --> Store["SQLite: Projects, Revisions, Publications, Runs"]
   Server --> Triggers["Trigger scheduler: Cron, Webhook, Poll, Integration"]
   Server --> Runtime["Isolated JavaScript runtime"]
-  Server -. "optional" .-> Connector["Connector runtime"]
-  Connector --> Providers["Third-party Providers"]
 ```
 
 The Workbench and CLI only talk to one selected deployment through the versioned Control API. The

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -61,11 +61,11 @@ code reste du code, et le déploiement reste sous votre contrôle.
 flowchart LR
   Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
   CLI["oo flow CLI"] -->|"Control API"| Server
+  Server -. "optionnel" .-> Connector["Runtime Connector"]
+  Connector --> Providers["Providers tiers"]
   Server --> Store["SQLite : Projects, Revisions, Publications, Runs"]
   Server --> Triggers["Ordonnanceur de Triggers : Cron, Webhook, Poll, Integration"]
   Server --> Runtime["Runtime JavaScript isolé"]
-  Server -. "optionnel" .-> Connector["Runtime Connector"]
-  Connector --> Providers["Providers tiers"]
 ```
 
 Le Workbench et la CLI ne communiquent qu'avec un seul déploiement sélectionné, via la Control API

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -50,11 +50,11 @@ Open Flow は、ノーコードのプロトタイプでは収まらなくなっ�
 flowchart LR
   Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
   CLI["oo flow CLI"] -->|"Control API"| Server
+  Server -. "任意" .-> Connector["Connector ランタイム"]
+  Connector --> Providers["サードパーティ Provider"]
   Server --> Store["SQLite：Project、Revision、Publication、Run"]
   Server --> Triggers["Trigger スケジューラ：Cron、Webhook、Poll、Integration"]
   Server --> Runtime["分離された JavaScript ランタイム"]
-  Server -. "任意" .-> Connector["Connector ランタイム"]
-  Connector --> Providers["サードパーティ Provider"]
 ```
 
 Workbench と CLI は、バージョン管理された Control API を通じて、選択された一つのデプロイメントとだけ通信します。デプロイメント側が検証、実行、永続化、

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -55,11 +55,11 @@ Open Flow는 노코드 프로토타입 수준을 넘어섰지만 불투명한 �
 flowchart LR
   Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
   CLI["oo flow CLI"] -->|"Control API"| Server
+  Server -. "선택 사항" .-> Connector["Connector 런타임"]
+  Connector --> Providers["서드파티 Provider"]
   Server --> Store["SQLite: Project, Revision, Publication, Run"]
   Server --> Triggers["Trigger 스케줄러: Cron, Webhook, Poll, Integration"]
   Server --> Runtime["격리된 JavaScript 런타임"]
-  Server -. "선택 사항" .-> Connector["Connector 런타임"]
-  Connector --> Providers["서드파티 Provider"]
 ```
 
 Workbench와 CLI는 버전 관리되는 Control API를 통해 선택된 하나의 배포와만 통신합니다. 배포는 검증, 실행, 영속화,

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -60,11 +60,11 @@ deployment остаётся под вашим контролем.
 flowchart LR
   Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
   CLI["oo flow CLI"] -->|"Control API"| Server
+  Server -. "опционально" .-> Connector["Среда выполнения Connector"]
+  Connector --> Providers["Сторонние Provider"]
   Server --> Store["SQLite: Project, Revision, Publication, Run"]
   Server --> Triggers["Планировщик Trigger: Cron, Webhook, Poll, Integration"]
   Server --> Runtime["Изолированная среда выполнения JavaScript"]
-  Server -. "опционально" .-> Connector["Среда выполнения Connector"]
-  Connector --> Providers["Сторонние Provider"]
 ```
 
 Workbench и CLI общаются только с одним выбранным deployment через версионированный Control API.

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -46,11 +46,11 @@ Open Flow 适合已经超过简单无代码原型，但又不想变成一堆脚�
 flowchart LR
   Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
   CLI["oo flow CLI"] -->|"Control API"| Server
+  Server -. "可选" .-> Connector["Connector 运行时"]
+  Connector --> Providers["第三方 Provider"]
   Server --> Store["SQLite：Project、Revision、Publication、Run"]
   Server --> Triggers["Trigger 调度：Cron、Webhook、Poll、Integration"]
   Server --> Runtime["隔离的 JavaScript 运行时"]
-  Server -. "可选" .-> Connector["Connector 运行时"]
-  Connector --> Providers["第三方 Provider"]
 ```
 
 Workbench 和 CLI 只通过有版本的 Control API 与当前选定的一个部署通信。部署端负责 validation、执行、持久化和 Trigger 准入。Provider

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -46,11 +46,11 @@ Open Flow 適合已經超出簡單無程式碼原型，但又不想變成一堆�
 flowchart LR
   Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
   CLI["oo flow CLI"] -->|"Control API"| Server
+  Server -. "選用" .-> Connector["Connector 執行環境"]
+  Connector --> Providers["第三方 Provider"]
   Server --> Store["SQLite：Project、Revision、Publication、Run"]
   Server --> Triggers["Trigger 排程：Cron、Webhook、Poll、Integration"]
   Server --> Runtime["隔離的 JavaScript 執行環境"]
-  Server -. "選用" .-> Connector["Connector 執行環境"]
-  Connector --> Providers["第三方 Provider"]
 ```
 
 Workbench 和 CLI 只透過有版本的 Control API 與目前選定的一個部署通訊。部署端負責 validation、執行、持久化和 Trigger 准入。Provider


### PR DESCRIPTION
## Problem

GitHub overlays Mermaid navigation and zoom controls in the lower-right corner of expanded diagrams. The README architecture diagram placed the `Third-party Providers` node in that same corner, so the controls obscured the node and made the connector path difficult to read.

## Root cause

The Connector branch was declared after every other Open Flow Server branch. Mermaid used declaration order when arranging sibling nodes, placing the optional Connector path on the bottom row and its Provider node at the far right.

## Fix

Declare the optional Connector and Provider path before the storage, trigger scheduler, and JavaScript runtime branches. This moves the Provider node to the upper-right area while preserving every node, edge, label, and architecture relationship.

The same layout change is applied to the root README and all six localized README variants so their diagrams remain consistent.

## Validation

- Rendered the updated Mermaid source locally and confirmed the Provider node is on the top row, away from the lower-right controls.
- `bun run check`
- `bun run test` — 98 package test files / 607 tests, 4 command test files / 56 tests, and 25 server test files / 203 tests passed.
- `bun run build`
