### PR TITLE
fix(workbench): stabilize run logs and canvas updates

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,7 @@
     },
     "packages/command": {
       "name": "@oomol-lab/open-flow-command",
-      "version": "0.1.0-alpha.14",
+      "version": "0.1.0-alpha.15",
       "dependencies": {
         "@oomol-lab/open-flow": "workspace:*",
         "@wopjs/cast": "^0.1.16",
@@ -63,7 +63,7 @@
     },
     "packages/open-flow": {
       "name": "@oomol-lab/open-flow",
-      "version": "0.1.0-alpha.14",
+      "version": "0.1.0-alpha.15",
       "devDependencies": {
         "@babel/parser": "8.0.4",
         "@babel/traverse": "8.0.4",

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oomol-lab/open-flow-command",
-  "version": "0.1.0-alpha.14",
+  "version": "0.1.0-alpha.15",
   "description": "Open Flow command runtime and immutable Command Artifact builder.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/open-flow/package.json
+++ b/packages/open-flow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oomol-lab/open-flow",
-  "version": "0.1.0-alpha.14",
+  "version": "0.1.0-alpha.15",
   "description": "Portable contracts and shared browser runtime for Open Flow.",
   "keywords": [
     "ai",

--- a/packages/open-flow/src/designer/browser/base/rfHelpers.ts
+++ b/packages/open-flow/src/designer/browser/base/rfHelpers.ts
@@ -181,7 +181,8 @@ export function applyNodeChanges<TRFNode extends RFNode = RFNode>(
         break
       }
       case 'dimensions': {
-        const update = { ...nodeStore.$.rfNode.value }
+        const current = nodeStore.$.rfNode.value
+        const update = { ...current }
         if (isSize(change.dimensions)) {
           update.measured = change.dimensions
           if (change.setAttributes) {
@@ -194,7 +195,15 @@ export function applyNodeChanges<TRFNode extends RFNode = RFNode>(
           update.resizing = change.resizing
         }
 
-        nodeStore.$$.rfNode.set(update)
+        if (
+          current.measured?.width != update.measured?.width ||
+          current.measured?.height != update.measured?.height ||
+          current.width != update.width ||
+          current.height != update.height ||
+          current.resizing != update.resizing
+        ) {
+          nodeStore.$$.rfNode.set(update)
+        }
         break
       }
       case 'replace': {

--- a/packages/open-flow/src/designer/browser/stores/designer/designer.store.test.ts
+++ b/packages/open-flow/src/designer/browser/stores/designer/designer.store.test.ts
@@ -150,6 +150,21 @@ describe('DesignerStore graph projection', () => {
     expect(next.nodes).toEqual([node.$.rfNode.value])
     setup.dispose()
   })
+
+  it('does not republish nodes for an unchanged measurement', async () => {
+    const setup = createTestSetup()
+    const node = setup.createNode('node' as NodeId)
+    setup.nodes.set(node.nodeId, node)
+    const change = { dimensions: { height: 120, width: 240 }, id: node.rfNodeId, type: 'dimensions' as const }
+
+    await setup.store.handleNodesChange([change])
+    const measured = setup.store.$.renderedRFGraph.value
+    expect(measured.nodes[0]?.measured).toEqual(change.dimensions)
+    await setup.store.handleNodesChange([change])
+
+    expect(setup.store.$.renderedRFGraph.value).toBe(measured)
+    setup.dispose()
+  })
 })
 
 describe('DesignerStore display mode', () => {

--- a/packages/open-flow/src/workbench/browser/runtime/flowWorkspace.test.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/flowWorkspace.test.tsx
@@ -1,0 +1,89 @@
+import type { ReactElement } from 'react'
+import type { NavigationStore } from './navigation.ts'
+import type { WorkbenchStore } from './stores/workbenchStore.ts'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import FlowWorkspace from './flowWorkspace.tsx'
+
+const mocks = vi.hoisted(() => ({
+  setOpen: vi.fn(),
+  setVisible: vi.fn(),
+  stateCall: 0,
+}))
+
+vi.mock('react', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react')>()),
+  useEffect: vi.fn(),
+  useRef: vi.fn(() => ({ current: undefined })),
+  useState: vi.fn(() => (mocks.stateCall++ == 0 ? [false, mocks.setVisible] : [false, mocks.setOpen])),
+}))
+
+vi.mock('use-value-enhancer', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('use-value-enhancer')>()),
+  useVal: (value: { readonly value: unknown }) => value.value,
+}))
+
+vi.mock('val-i18n-react', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('val-i18n-react')>()),
+  useTranslate: () => (key: string) => key,
+}))
+
+vi.mock('./designer/workbenchDesigner.tsx', () => ({ WorkbenchDesigner: () => null }))
+
+const value = <T,>(current: T): { readonly value: T } => ({ value: current })
+
+function renderWorkspace() {
+  const navigation = {
+    $: { view: value('design') },
+    open: vi.fn(),
+    openFlows: vi.fn(),
+    openMainFlow: vi.fn(),
+  } as unknown as NavigationStore
+  const store = {
+    requestDraftRun: vi.fn().mockResolvedValue('started'),
+    requestLiveRun: vi.fn().mockResolvedValue('started'),
+    runRequests: {
+      $: { submitting: value(undefined) },
+      dismissInputs: vi.fn(),
+    },
+    runs: { $: { externalRunId: value(undefined) } },
+    workspace: {
+      $: {
+        draft: value({ revisionId: 'revision' }),
+        flowId: value('flow'),
+        workspaceLoadFailed: value(false),
+        workspaceLoading: value(false),
+      },
+    },
+  } as unknown as WorkbenchStore
+  const element = FlowWorkspace({
+    hrefFor: () => '/',
+    navigation,
+    store,
+    theme: 'light',
+  })
+  const main = element.props.children as ReactElement
+  const header = (main.props.children as ReactElement[])[0]! as ReactElement<{
+    readonly onRunDraft: () => void
+    readonly onRunLive: () => void
+  }>
+  return { header, navigation, store }
+}
+
+describe('FlowWorkspace run drawer', () => {
+  beforeEach(() => {
+    mocks.setOpen.mockReset()
+    mocks.setVisible.mockReset()
+    mocks.stateCall = 0
+  })
+
+  it.each(['onRunDraft', 'onRunLive'] as const)('opens the log panel after %s starts', async (action) => {
+    const { header } = renderWorkspace()
+
+    header.props[action]()
+    await Promise.resolve()
+
+    expect(mocks.setVisible).toHaveBeenCalledWith(true)
+    expect(mocks.setOpen).toHaveBeenCalledWith(true)
+  })
+})

--- a/packages/open-flow/src/workbench/browser/runtime/flowWorkspace.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/flowWorkspace.tsx
@@ -396,10 +396,10 @@ export default function FlowWorkspace({
   }
   const runDraft = async (): Promise<void> => {
     navigation.open('design')
-    if ((await store.requestDraftRun()) == 'started') revealRun(false)
+    if ((await store.requestDraftRun()) == 'started') revealRun()
   }
   const runLive = async (): Promise<void> => {
-    if ((await store.requestLiveRun()) == 'started') revealRun(false)
+    if ((await store.requestLiveRun()) == 'started') revealRun()
   }
   const locateRunEvent = (sequence: number): void => {
     if (store.locateRunEvent(sequence)) revealRun()

--- a/packages/open-flow/src/workbench/browser/runtime/runs/runDrawer.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/runs/runDrawer.tsx
@@ -6,14 +6,13 @@ import type { JsonValue, Run, RunEvent, RunResult } from '../api.ts'
 import type { IconName } from '../icons.tsx'
 import type { RunEventFilter } from './runStore.ts'
 
-import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useLang, useTranslate } from 'val-i18n-react'
 import { OverlayScrollbar } from '../../../../designer/browser/components/overlayScrollbar.tsx'
 import { collapseAllNested, CompactValue, JSONViewer } from '../../../../designer/browser/jsonViewer/index.ts'
 import { Badge } from '../../../../ui/browser/badge.tsx'
 import { Button } from '../../../../ui/browser/button.tsx'
 import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuGroup, DropdownMenuTrigger } from '../../../../ui/browser/dropdown-menu.tsx'
-import { ToggleGroup, ToggleGroupItem } from '../../../../ui/browser/toggle-group.tsx'
 import { Icon } from '../icons.tsx'
 import { eventSubject } from '../workspace.ts'
 import { downloadRunLog } from './runLogExport.ts'
@@ -95,7 +94,6 @@ interface Props {
 type EventObservation = 'expired' | 'truncated'
 type EventCategory = Exclude<RunEventFilter, 'all'>
 
-const eventFilters: readonly RunEventFilter[] = ['all', 'lifecycle', 'progress', 'log', 'output', 'artifact']
 const eventCategories: readonly EventCategory[] = ['lifecycle', 'progress', 'log', 'output', 'artifact']
 
 function eventObservation(events: readonly RunEvent[], historyComplete: boolean): EventObservation | undefined {
@@ -128,12 +126,12 @@ function eventCategory(event: RunEvent): EventCategory {
   }
 }
 
-function filterEvents(events: readonly RunEvent[], filter: RunEventFilter): readonly RunEvent[] {
-  return filter == 'all' ? events : events.filter((event) => eventCategory(event) == filter)
-}
-
 function filterEventsBy(events: readonly RunEvent[], filters: readonly RunEventFilter[]): readonly RunEvent[] {
   return events.filter((event) => filters.includes(eventCategory(event)))
+}
+
+export function initialRunLogFilters(filter: RunEventFilter): readonly RunEventFilter[] {
+  return filter == 'all' ? eventCategories.filter((candidate) => candidate != 'progress') : [filter]
 }
 
 interface TimelineEvent {
@@ -160,47 +158,7 @@ function timelineEvents(events: readonly RunEvent[]): readonly TimelineEvent[] {
   return result
 }
 
-export function RunEventFilters({
-  events,
-  filter,
-  onChange,
-}: {
-  readonly events: readonly RunEvent[]
-  readonly filter: RunEventFilter
-  readonly onChange: (filter: RunEventFilter) => void
-}): ReactElement | null {
-  const t = useTranslate()
-  if (events.length == 0) return null
-  const groupedEvents = timelineEvents(events)
-  const counts = new Map<EventCategory, number>()
-  for (const { event } of groupedEvents) {
-    const category = eventCategory(event)
-    counts.set(category, (counts.get(category) ?? 0) + 1)
-  }
-  return (
-    <ToggleGroup
-      aria-label={t('run.filterEvents')}
-      className="event-filters"
-      onValueChange={(next) => {
-        if (next[0] != null) onChange(next[0] as RunEventFilter)
-      }}
-      size="sm"
-      value={[filter]}
-    >
-      {eventFilters.map((candidate) => {
-        const count = candidate == 'all' ? groupedEvents.length : (counts.get(candidate) ?? 0)
-        return (
-          <ToggleGroupItem className="event-filter" key={candidate} value={candidate}>
-            {t(`run.filter.${candidate}`)}
-            <span>{count}</span>
-          </ToggleGroupItem>
-        )
-      })}
-    </ToggleGroup>
-  )
-}
-
-function RunLogFilters({
+export function RunLogFilters({
   container,
   events,
   filters,
@@ -357,26 +315,22 @@ function nodeTitleIndex(events: readonly RunEvent[]): ReadonlyMap<string, string
   return titles
 }
 
-export function RunDetails({
+export function RunLog({
   events,
   eventsExpiresAt,
-  eventFilter,
   eventNodes,
+  filters,
   historyComplete,
   observationFailed,
   onLocateEvent,
   onRetryObservation,
-  panelId,
   result,
   run,
   submitting,
-  tab,
-  tabId,
 }: Pick<
   Props,
   | 'events'
   | 'eventsExpiresAt'
-  | 'eventFilter'
   | 'eventNodes'
   | 'historyComplete'
   | 'observationFailed'
@@ -386,154 +340,6 @@ export function RunDetails({
   | 'run'
   | 'submitting'
 > & {
-  readonly panelId: string
-  readonly tab: 'output' | 'timeline'
-  readonly tabId: string
-}): ReactElement {
-  const language = useLang()
-  const t = useTranslate()
-  const eventList = useRef<OverlayScrollbarRef>(null)
-  const followedRun = useRef<string>()
-  const followEvents = useRef(true)
-  const nodeTitles = useMemo(() => nodeTitleIndex(events), [events])
-  const observation = eventObservation(events, historyComplete)
-  const visibleEvents = timelineEvents(filterEvents(events, eventFilter))
-  const lastEventSequence = events.at(-1)?.sequence
-
-  const eventScrollbarEvents = useMemo<EventListeners>(
-    () => ({
-      initialized(instance) {
-        const list = instance.elements().scrollOffsetElement
-        list.scrollTop = list.scrollHeight
-      },
-      scroll(instance) {
-        const list = instance.elements().scrollOffsetElement
-        followEvents.current = list.scrollHeight - list.scrollTop - list.clientHeight <= eventFollowThreshold
-      },
-    }),
-    [],
-  )
-
-  useEffect(() => {
-    if (followedRun.current != run?.runId) {
-      followedRun.current = run?.runId
-      followEvents.current = true
-    }
-    const instance = eventList.current?.osInstance()
-    if (tab == 'timeline' && followEvents.current && instance != null) {
-      instance.update()
-      const list = instance.elements().scrollOffsetElement
-      list.scrollTop = list.scrollHeight
-    }
-  }, [eventFilter, historyComplete, lastEventSequence, run?.runId, tab])
-
-  let content: ReactElement
-  if (submitting)
-    content = (
-      <div aria-live="polite" className="run-empty">
-        {t('run.submitting')}
-      </div>
-    )
-  else if (tab == 'output')
-    content =
-      result == null ? (
-        <div className="run-empty">{t('run.outputPending')}</div>
-      ) : (
-        <OverlayScrollbar className="run-output-scroll run-content-scroll" defer={false} tabIndex={-1}>
-          <RunResultView result={result} />
-        </OverlayScrollbar>
-      )
-  else if (run == null) content = <div className="run-empty">{t('run.timelineEmpty')}</div>
-  else
-    content = (
-      <OverlayScrollbar className="event-list run-content-scroll" defer={false} events={eventScrollbarEvents} ref={eventList} tabIndex={-1}>
-        <div className="event-table" role="table">
-          <div className="event-row event-heading" role="row">
-            <span>{t('run.step')}</span>
-            <span>{t('run.event')}</span>
-            <span>{t('run.eventDetails')}</span>
-            <span>{t('run.time')}</span>
-          </div>
-          {observation != null && (
-            <div aria-live="polite" className="event-row event-observation" role="row">
-              <span role="cell">
-                <Icon name="alert" size={14} />
-                {observation == 'expired'
-                  ? t('run.historyExpired')
-                  : eventsExpiresAt == null
-                    ? t('run.eventsTruncatedNotice')
-                    : t('run.eventsTruncatedUntil', { date: new Date(eventsExpiresAt).toLocaleString(language) })}
-              </span>
-            </div>
-          )}
-          {visibleEvents.map(({ event, events: groupedEvents }) => {
-            const subject = eventSubject(event, t, nodeTitles)
-            const nodeId = eventNodes.get(event.sequence)
-            return (
-              <Fragment key={event.sequence}>
-                <div className="event-row" role="row">
-                  {nodeId == null ? (
-                    <span className="event-subject">
-                      <Icon data-icon="inline-start" name={eventIcon(event)} />
-                      {subject}
-                    </span>
-                  ) : (
-                    <Button
-                      aria-label={t('run.locateNode', { name: subject })}
-                      className="event-subject event-locate"
-                      onClick={() => onLocateEvent(event.sequence)}
-                      size="xs"
-                      title={t('run.locateNode', { name: subject })}
-                      type="button"
-                      variant="ghost"
-                    >
-                      <Icon name={eventIcon(event)} />
-                      <span>{subject}</span>
-                      <Icon data-icon="inline-end" name="fit" />
-                    </Button>
-                  )}
-                  <code>{event.kind}</code>
-                  <span className="event-summary">{eventSummary(event, t)}</span>
-                  <time dateTime={event.createdAt}>{eventTime(event.createdAt, language)}</time>
-                </div>
-                <RunEventDetails events={groupedEvents} />
-              </Fragment>
-            )
-          })}
-          {events.length == 0 ? (
-            <div className="run-empty">{t('run.waiting')}</div>
-          ) : (
-            visibleEvents.length == 0 && <div className="run-empty">{t('run.noFilteredEvents')}</div>
-          )}
-        </div>
-      </OverlayScrollbar>
-    )
-  return (
-    <div aria-labelledby={tabId} className="run-tab-panel" id={panelId} role="tabpanel" tabIndex={0}>
-      {observationFailed && (
-        <div className="run-observation-error" role="alert">
-          <span>{t('run.observationFailed')}</span>
-          <Button onClick={onRetryObservation} size="sm" type="button" variant="secondary">
-            {t('empty.retry')}
-          </Button>
-        </div>
-      )}
-      {content}
-    </div>
-  )
-}
-
-function RunLog({
-  events,
-  eventsExpiresAt,
-  filters,
-  historyComplete,
-  observationFailed,
-  onRetryObservation,
-  result,
-  run,
-  submitting,
-}: Pick<Props, 'events' | 'eventsExpiresAt' | 'historyComplete' | 'observationFailed' | 'onRetryObservation' | 'result' | 'run' | 'submitting'> & {
   readonly filters: readonly RunEventFilter[]
 }): ReactElement {
   const language = useLang()
@@ -599,6 +405,7 @@ function RunLog({
           )}
           {visibleEvents.map(({ event, events: groupedEvents }) => {
             const subject = eventSubject(event, t, nodeTitles)
+            const nodeId = eventNodes.get(event.sequence)
             return (
               <li className={`run-log-event ${eventTone(event)}`} key={event.sequence}>
                 <span className="run-log-icon" title={event.kind}>
@@ -612,6 +419,19 @@ function RunLog({
                     <strong>{subject}</strong>
                     <Icon className="run-log-chevron" name="chevron-left" size={11} />
                     <span>{eventSummary(event, t)}</span>
+                    {nodeId != null && (
+                      <Button
+                        aria-label={t('run.locateNode', { name: subject })}
+                        className="run-log-locate"
+                        onClick={() => onLocateEvent(event.sequence)}
+                        size="icon-xs"
+                        title={t('run.locateNode', { name: subject })}
+                        type="button"
+                        variant="ghost"
+                      >
+                        <Icon name="fit" />
+                      </Button>
+                    )}
                   </div>
                   <RunEventDetails events={groupedEvents} />
                 </div>
@@ -672,10 +492,12 @@ export function RunDrawer({
   events,
   eventsExpiresAt,
   eventFilter,
+  eventNodes,
   historyComplete,
   onCancel,
   onClose,
   onEventFilterChange,
+  onLocateEvent,
   onRetryObservation,
   onToggle,
   observationFailed,
@@ -689,9 +511,7 @@ export function RunDrawer({
   const drawer = useRef<HTMLElement>(null)
   const resize = useRef<{ height: number; pointerId: number; y: number }>()
   const [resized, setResized] = useState<{ height: number; runId: string | undefined }>()
-  const [filters, setFilters] = useState<readonly RunEventFilter[]>(() =>
-    eventFilter == 'all' ? eventCategories.filter((filter) => filter != 'progress') : [eventFilter],
-  )
+  const [filters, setFilters] = useState<readonly RunEventFilter[]>(() => initialRunLogFilters(eventFilter))
   const groupedTimelineEvents = timelineEvents(events)
   const summaryOutputs = terminalOutputs(result) ?? latestOutputs(events)
   const timelineHeight = Math.max(
@@ -809,9 +629,11 @@ export function RunDrawer({
           <RunLog
             events={events}
             eventsExpiresAt={eventsExpiresAt}
+            eventNodes={eventNodes}
             filters={filters}
             historyComplete={historyComplete}
             observationFailed={observationFailed}
+            onLocateEvent={onLocateEvent}
             onRetryObservation={onRetryObservation}
             result={result}
             run={run}

--- a/packages/open-flow/src/workbench/browser/runtime/runs/runsView.test.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/runs/runsView.test.tsx
@@ -1,0 +1,71 @@
+import type { Run, RunResult } from '../api.ts'
+import type { WorkbenchStore } from '../stores/workbenchStore.ts'
+
+import { renderToStaticMarkup } from 'react-dom/server'
+import { I18nProvider } from 'val-i18n-react'
+import { val } from 'value-enhancer'
+import { describe, expect, it, vi } from 'vitest'
+import { createI18n } from '../i18n.ts'
+import { RunsView } from './runsView.tsx'
+
+describe('RunsView timeline', () => {
+  it('shows the shared inline terminal error while keeping the output view', () => {
+    const finishedAt = '2026-08-27T10:00:01.000Z'
+    const run: Run = {
+      createdAt: '2026-08-27T10:00:00.000Z',
+      finishedAt,
+      flowId: 'flow',
+      revisionId: 'revision',
+      runId: 'run',
+      source: 'draft',
+      status: 'failed',
+      version: 1,
+    }
+    const result: RunResult = {
+      error: { code: 'binding.unresolved', message: 'Variable API_TOKEN could not be resolved.' },
+      finishedAt,
+      runId: run.runId,
+      status: 'failed',
+      version: 1,
+    }
+    const store = {
+      $: { runEventNodes: val<ReadonlyMap<number, string>>(new Map()) },
+      runs: {
+        $: {
+          cancelingRunId: val<string | undefined>(),
+          eventFilter: val('all' as const),
+          events: val([]),
+          eventsExpiresAt: val<string | undefined>(),
+          historyComplete: val(true),
+          loadFailed: val(false),
+          loading: val(false),
+          loadMoreFailed: val(false),
+          loadingMore: val(false),
+          nextCursor: val<string | undefined>(),
+          observationFailed: val(false),
+          result: val(result),
+          run: val(run),
+          runs: val([run]),
+        },
+        cancel: vi.fn(),
+        loadMore: vi.fn(),
+        retryLoad: vi.fn(),
+        retryObservation: vi.fn(),
+        select: vi.fn(),
+        setEventFilter: vi.fn(),
+      },
+      workspace: { $: { revision: val(undefined) } },
+    } as unknown as WorkbenchStore
+
+    const markup = renderToStaticMarkup(
+      <I18nProvider i18n={createI18n('en')}>
+        <RunsView onLocateEvent={() => undefined} store={store} />
+      </I18nProvider>,
+    )
+
+    expect(markup).toContain('binding.unresolved')
+    expect(markup).toContain('Variable API_TOKEN could not be resolved.')
+    expect(markup).toContain('Timeline')
+    expect(markup).toContain('Output')
+  })
+})

--- a/packages/open-flow/src/workbench/browser/runtime/runs/runsView.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/runs/runsView.tsx
@@ -6,12 +6,14 @@ import type { WorkbenchStore } from '../stores/workbenchStore.ts'
 import { useEffect, useRef, useState } from 'react'
 import { useVal } from 'use-value-enhancer'
 import { useLang, useTranslate } from 'val-i18n-react'
+import { OverlayScrollbar } from '../../../../designer/browser/components/overlayScrollbar.tsx'
 import { Badge } from '../../../../ui/browser/badge.tsx'
 import { Button } from '../../../../ui/browser/button.tsx'
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '../../../../ui/browser/empty.tsx'
 import { Tabs, TabsList, TabsTrigger } from '../../../../ui/browser/tabs.tsx'
 import { Icon } from '../icons.tsx'
-import { duration, RunDetails, RunEventFilters, RunLogButton, runLabel, statusClass } from './runDrawer.tsx'
+import { duration, initialRunLogFilters, RunLog, RunLogButton, RunLogFilters, runLabel, statusClass } from './runDrawer.tsx'
+import { RunResultView } from './runOutput.tsx'
 import { canCancelRun } from './runStore.ts'
 
 function sourceLabel(run: Run, t: TFunction): string {
@@ -53,6 +55,7 @@ export function RunsView({ onLocateEvent, store }: { readonly onLocateEvent: (se
   const [narrow, setNarrow] = useState(false)
   const [narrowDetailOpen, setNarrowDetailOpen] = useState(false)
   const [tab, setTab] = useState<'output' | 'timeline'>('timeline')
+  const [filters, setFilters] = useState(() => initialRunLogFilters(eventFilter))
   const triggerRun = run?.source == 'trigger' && 'triggerNodeId' in run ? (run as TriggerRun) : undefined
   const triggerName =
     triggerRun != null && revision?.revision.revisionId == triggerRun.revisionId ? revision.trigger(triggerRun.triggerNodeId)?.name : undefined
@@ -202,24 +205,55 @@ export function RunsView({ onLocateEvent, store }: { readonly onLocateEvent: (se
                     </TabsTrigger>
                   </TabsList>
                 </Tabs>
-                {tab == 'timeline' && <RunEventFilters events={events} filter={eventFilter} onChange={(filter) => store.runs.setEventFilter(filter)} />}
+                {tab == 'timeline' && (
+                  <div className="run-toolbar-actions">
+                    <RunLogFilters
+                      container={root.current}
+                      events={events}
+                      filters={filters}
+                      onChange={(next) => {
+                        setFilters(next)
+                        store.runs.setEventFilter(next.length == 1 ? next[0]! : 'all')
+                      }}
+                    />
+                  </div>
+                )}
               </div>
-              <RunDetails
-                events={events}
-                eventsExpiresAt={eventsExpiresAt}
-                eventFilter={eventFilter}
-                eventNodes={eventNodes}
-                historyComplete={historyComplete}
-                observationFailed={observationFailed}
-                onLocateEvent={onLocateEvent}
-                onRetryObservation={() => store.runs.retryObservation()}
-                panelId={`run-history-${tab}-panel`}
-                result={result}
-                run={run}
-                submitting={false}
-                tab={tab}
-                tabId={`run-history-${tab}-tab`}
-              />
+              {tab == 'timeline' ? (
+                <div aria-labelledby="run-history-timeline-tab" className="run-tab-panel" id="run-history-timeline-panel" role="tabpanel" tabIndex={0}>
+                  <RunLog
+                    events={events}
+                    eventsExpiresAt={eventsExpiresAt}
+                    eventNodes={eventNodes}
+                    filters={filters}
+                    historyComplete={historyComplete}
+                    observationFailed={observationFailed}
+                    onLocateEvent={onLocateEvent}
+                    onRetryObservation={() => store.runs.retryObservation()}
+                    result={result}
+                    run={run}
+                    submitting={false}
+                  />
+                </div>
+              ) : (
+                <div aria-labelledby="run-history-output-tab" className="run-tab-panel" id="run-history-output-panel" role="tabpanel" tabIndex={0}>
+                  {observationFailed && (
+                    <div className="run-observation-error" role="alert">
+                      <span>{t('run.observationFailed')}</span>
+                      <Button onClick={() => store.runs.retryObservation()} size="sm" type="button" variant="secondary">
+                        {t('empty.retry')}
+                      </Button>
+                    </div>
+                  )}
+                  {result == null ? (
+                    <div className="run-empty">{t('run.outputPending')}</div>
+                  ) : (
+                    <OverlayScrollbar className="run-output-scroll run-content-scroll" defer={false} tabIndex={-1}>
+                      <RunResultView result={result} />
+                    </OverlayScrollbar>
+                  )}
+                </div>
+              )}
             </div>
           </>
         )}

--- a/packages/open-flow/src/workbench/browser/runtime/styles/responsive.css
+++ b/packages/open-flow/src/workbench/browser/runtime/styles/responsive.css
@@ -246,29 +246,6 @@
       min-width: 720px;
     }
 
-    .event-row {
-      min-height: 52px;
-      grid-template-columns: minmax(0, 1fr) auto;
-      align-items: start;
-      gap: 4px 12px;
-      padding: 8px 12px;
-    }
-
-    .event-subject,
-    .event-summary {
-      grid-column: 1;
-    }
-
-    .event-row > code,
-    .event-row > time {
-      grid-column: 2;
-      text-align: right;
-    }
-
-    .event-summary {
-      white-space: normal;
-    }
-
     .runs-view.narrow {
       display: block;
       overflow: auto;

--- a/packages/open-flow/src/workbench/browser/runtime/styles/runs.css
+++ b/packages/open-flow/src/workbench/browser/runtime/styles/runs.css
@@ -228,6 +228,11 @@
     color: var(--ui-muted-foreground);
   }
 
+  .run-log-locate {
+    flex: none;
+    margin-left: 3px;
+  }
+
   .run-log-chevron {
     flex: none;
     color: var(--ui-muted-foreground);
@@ -325,7 +330,7 @@
     overflow: hidden;
   }
 
-  .run-tab-panel > .event-list,
+  .run-tab-panel > .run-log,
   .run-tab-panel > .run-empty,
   .run-tab-panel > .run-output-scroll {
     min-height: 0;
@@ -368,108 +373,14 @@
     padding: 0 11px;
   }
 
-  .event-filters {
+  .run-toolbar-actions {
     display: flex;
     min-width: 0;
-    align-items: center;
-    gap: 2px;
-    padding: 4px 12px 4px 8px;
-    overflow: hidden;
-  }
-
-  .event-filter span {
-    min-width: 12px;
-    color: inherit;
-    font-variant-numeric: tabular-nums;
-    opacity: 0.72;
-    text-align: right;
-  }
-
-  .event-list {
-    min-height: 0;
-    overflow: hidden;
-  }
-
-  .event-table {
-    min-width: 0;
-  }
-
-  .event-row {
-    display: grid;
-    min-height: 36px;
-    grid-template-columns: minmax(160px, 1.4fr) minmax(150px, 1fr) minmax(120px, 0.8fr) 96px;
-    align-items: center;
-    gap: 16px;
-    padding: 0 18px;
-    border-bottom: 1px solid var(--ui-border);
-    font-size: 11px;
-  }
-
-  .event-heading {
-    position: sticky;
-    z-index: 1;
-    top: 0;
-    min-height: 32px;
-    background: var(--ui-card);
-    color: var(--ui-muted-foreground);
-    font-weight: 500;
-  }
-
-  .event-observation {
-    background: var(--warning-surface);
-    color: var(--warning-foreground);
-  }
-
-  .event-observation > span {
-    display: flex;
-    grid-column: 1 / -1;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .event-subject {
-    display: flex;
-    min-width: 0;
-    align-items: center;
-    gap: 8px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .event-locate {
-    width: 100%;
-    overflow: hidden;
-    text-align: left;
-  }
-
-  .event-locate > span {
-    overflow: hidden;
     flex: 1;
-    text-overflow: ellipsis;
-  }
-
-  .event-locate > svg:last-child {
-    flex: 0 0 auto;
-    opacity: 0.6;
-  }
-
-  .event-row code,
-  .event-row time {
+    align-items: center;
+    justify-content: flex-end;
+    padding: 0 8px;
     overflow: hidden;
-    color: var(--ui-muted-foreground);
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 10px;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .event-row time {
-    font-variant-numeric: tabular-nums;
-  }
-
-  .event-summary {
-    color: var(--ui-muted-foreground);
   }
 
   .event-detail {

--- a/packages/open-flow/test/workbench-ui-style-boundaries.test.ts
+++ b/packages/open-flow/test/workbench-ui-style-boundaries.test.ts
@@ -410,7 +410,8 @@ test('keeps responsive control density on component APIs', async () => {
   )
   assert.doesNotMatch(responsiveStyles, /@media \(max-width:|legacy viewport|must win/)
   assert.doesNotMatch(runStyles, /@media \(max-width:/)
-  assert.match(responsiveStyles, /@container open-flow-workbench \(width <= 720px\)[\s\S]*?\.event-row/)
+  assert.match(runStyles, /\.run-log-event/)
+  assert.doesNotMatch(responsiveStyles, /\.run-log-event/)
 })
 
 test('keeps Workbench feedback on semantic theme surfaces', async () => {
@@ -479,7 +480,7 @@ test('keeps repeated feature selectors consolidated at their owner', async () =>
   ])
 
   assert.equal((canvasStyles.match(/  \.canvas-empty \{/g) ?? []).length, 1)
-  assert.equal((runStyles.match(/  \.event-subject \{/g) ?? []).length, 1)
+  assert.equal((runStyles.match(/  \.run-log-event \{/g) ?? []).length, 1)
 })
 
 test('keeps Run input values on the WorkbenchRunInputs public contract', async () => {


### PR DESCRIPTION
## Summary

- reveal the bottom run log drawer when draft or live runs start
- reuse the bottom drawer run-log presentation in run history
- avoid republishing unchanged node measurements to React Flow
- bump the package version to 0.1.0-alpha.15

## Verification

- bun run check
- bun run test
- bun run build
- bun run test:package