### PR TITLE
fix(designer): avoid remount update loop

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,7 @@
     },
     "packages/command": {
       "name": "@oomol-lab/open-flow-command",
-      "version": "0.1.0-alpha.15",
+      "version": "0.1.0-alpha.16",
       "dependencies": {
         "@oomol-lab/open-flow": "workspace:*",
         "@wopjs/cast": "^0.1.16",
@@ -63,7 +63,7 @@
     },
     "packages/open-flow": {
       "name": "@oomol-lab/open-flow",
-      "version": "0.1.0-alpha.15",
+      "version": "0.1.0-alpha.16",
       "devDependencies": {
         "@babel/parser": "8.0.4",
         "@babel/traverse": "8.0.4",

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oomol-lab/open-flow-command",
-  "version": "0.1.0-alpha.15",
+  "version": "0.1.0-alpha.16",
   "description": "Open Flow command runtime and immutable Command Artifact builder.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/open-flow/package.json
+++ b/packages/open-flow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oomol-lab/open-flow",
-  "version": "0.1.0-alpha.15",
+  "version": "0.1.0-alpha.16",
   "description": "Portable contracts and shared browser runtime for Open Flow.",
   "keywords": [
     "ai",

--- a/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.test.tsx
+++ b/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.test.tsx
@@ -200,6 +200,20 @@ describe('FlowDesignerView model synchronization', () => {
     }
   })
 
+  it('does not publish unchanged Variable projections while mounting', () => {
+    const value = model([task([{ handle: 'value', jsonSchema: { type: 'string' }, variableCompatible: true }])])
+    const view = FlowDesignerView(props(value)) as React.ReactElement<FlowDesignerProps>
+    const store = view.props.flowDesignerStore
+    const inputs = store.$.variableInputs.value
+    const names = store.$.variableNames.value
+
+    FlowDesignerView(props(value))
+
+    expect(store.$.variableInputs.value).toBe(inputs)
+    expect(store.$.variableNames.value).toBe(names)
+    store.dispose()
+  })
+
   it('does not clear an input value after the model replaces it with a connection', async () => {
     const onChangeInput = vi.fn()
     const initial = task([{ handle: 'value', jsonSchema: {}, value: null }])

--- a/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.tsx
+++ b/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.tsx
@@ -643,10 +643,24 @@ class FlowDesignerViewAdapter {
   #syncModel(model: FlowDesignerViewModel): void {
     const runStatus = model.runStatus == 'running' ? FLOW_RUN_STATUS.Running : FLOW_RUN_STATUS.Idle
     if (this.#runStatus.value != runStatus) this.#runStatus.set(runStatus)
-    this.#variableInputs.set(variableInputs(model.nodes))
-    this.#variableNames.set(model.variableNames ?? [])
-    this.#variableNamesLoaded.set(model.variableNamesLoaded ?? false)
-    this.#variableNamesLoading.set(model.variableNamesLoading ?? false)
+    const inputs = variableInputs(model.nodes)
+    const currentInputs = this.#variableInputs.value
+    if (
+      inputs.size != currentInputs.size ||
+      [...inputs].some(([key, input]) => {
+        const current = currentInputs.get(key)
+        return current == null || current.compatible != input.compatible || current.enabled != input.enabled || current.name != input.name
+      })
+    ) {
+      this.#variableInputs.set(inputs)
+    }
+    const names = model.variableNames ?? []
+    const currentNames = this.#variableNames.value
+    if (names.length != currentNames.length || names.some((name, index) => name != currentNames[index])) this.#variableNames.set(names)
+    const namesLoaded = model.variableNamesLoaded ?? false
+    if (this.#variableNamesLoaded.value != namesLoaded) this.#variableNamesLoaded.set(namesLoaded)
+    const namesLoading = model.variableNamesLoading ?? false
+    if (this.#variableNamesLoading.value != namesLoading) this.#variableNamesLoading.set(namesLoading)
     if (
       this.#modelViewport == null ||
       this.#modelViewport.x != model.viewport.x ||


### PR DESCRIPTION
## Summary\n- avoid republishing unchanged Variable projections during designer reconciliation\n- prevent the Runs-to-Design remount path from synchronously notifying external-store subscribers during commit\n- bump the published packages to 0.1.0-alpha.16\n\n## Verification\n- bun run check\n- bun run test\n- bun run build\n- bun run test:package