### PR TITLE
feat(server): add Fly.io deployment config and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,20 +61,23 @@ Code, or another terminal Agent.
 
 ## Choose How to Run Open Flow
 
-Use the same Open Flow product and Workbench through either supported path.
+Use the same Open Flow product and Workbench through any supported path.
 
 <table>
   <tr>
-    <td width="50%" align="center"><strong>☁️ OOMOL Hosted</strong></td>
-    <td width="50%" align="center"><strong>🐳 Docker Self-hosted</strong></td>
+    <td width="33%" align="center"><strong>☁️ OOMOL Hosted</strong></td>
+    <td width="33%" align="center"><strong>🐳 Docker Self-hosted</strong></td>
+    <td width="33%" align="center"><strong>Fly.io Self-hosted</strong></td>
   </tr>
   <tr>
-    <td width="50%" valign="top">Ready to use without provisioning, patching, or monitoring a server. OOMOL operates the deployment and provides managed OAuth apps for supported integrations, so you avoid fixed server costs and separate OAuth app setup.</td>
-    <td width="50%" valign="top">Run on your own infrastructure with the included Docker image. You manage deployment, storage, backups, upgrades, networking, and any Connector or OAuth app setup.</td>
+    <td width="33%" valign="top">Ready to use without provisioning, patching, or monitoring a server. OOMOL operates the deployment and provides managed OAuth apps for supported integrations, so you avoid fixed server costs and separate OAuth app setup.</td>
+    <td width="33%" valign="top">Run on your own infrastructure with the included Docker image. You manage deployment, storage, backups, upgrades, networking, and any Connector or OAuth app setup.</td>
+    <td width="33%" valign="top">Run the same Docker image on Fly.io without operating a server yourself. Fly builds the image, terminates TLS, and keeps SQLite on a persistent volume; you manage secrets, backups, upgrades, and any Connector or OAuth app setup.</td>
   </tr>
   <tr>
-    <td width="50%" align="center">🚀 <a href="https://oomol.com"><strong>Use OOMOL Hosted</strong></a></td>
-    <td width="50%" align="center"><a href="#quick-start"><strong>Self-host with Docker</strong></a></td>
+    <td width="33%" align="center">🚀 <a href="https://oomol.com"><strong>Use OOMOL Hosted</strong></a></td>
+    <td width="33%" align="center"><a href="#quick-start"><strong>Self-host with Docker</strong></a></td>
+    <td width="33%" align="center"><a href="docs/server/fly-io/README.md"><strong>Deploy to Fly.io</strong></a></td>
   </tr>
 </table>
 
@@ -177,6 +180,13 @@ For production configuration, TLS, health checks, persistence, backup, and resou
 [Server deployment guide](docs/server/container-delivery.md) and the hardening checklist in
 [SECURITY.md](SECURITY.md#hardening-your-deployment).
 
+## Deploy to Fly.io
+
+The same image runs on Fly.io. The repository ships a `fly.toml` that builds
+`apps/server/Dockerfile`, keeps one machine running for Cron and Poll Triggers, and persists SQLite
+on a Fly volume. See [docs/server/fly-io/README.md](docs/server/fly-io/README.md) for app creation, volumes,
+secrets, deployment, custom domains, and scaling limits.
+
 ## Connect a Connector
 
 To run Actions and Provider Triggers against services such as GitHub, Gmail, Slack, or Notion,
@@ -261,6 +271,7 @@ Start with the [documentation index](docs/README.md). The most useful references
 - [Command Artifact distribution](docs/distribution/command-artifact.md)
 - [Workbench and Designer frontend notes](docs/authoring/frontend-ui.md)
 - [Server deployment](docs/server/container-delivery.md)
+- [Fly.io deployment](docs/server/fly-io/README.md)
 - [Contributing](CONTRIBUTING.md)
 - [Code of Conduct](CODE_OF_CONDUCT.md)
 - [Security](SECURITY.md)

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -22,10 +22,9 @@ ENV NODE_ENV=production \
   OPEN_FLOW_PORT=3000
 
 WORKDIR /app
-COPY --from=build --chown=node:node /workspace/apps/server/dist/ ./
-RUN mkdir -p /data/open-flow && chown node:node /data/open-flow
+COPY --from=build /workspace/apps/server/dist/ ./
+RUN mkdir -p /data/open-flow
 
-USER node
 VOLUME ["/data/open-flow"]
 EXPOSE 3000
 STOPSIGNAL SIGTERM

--- a/apps/server/scripts/check-docker.ts
+++ b/apps/server/scripts/check-docker.ts
@@ -23,7 +23,6 @@ try {
   process.stdout.write('Building the Server Docker image.\n')
   await docker(['build', '--file', 'apps/server/Dockerfile', '--tag', imageName, '.'])
   imageBuilt = true
-  assert.equal((await docker(['image', 'inspect', '--format', '{{.Config.User}}', imageName])).trim(), 'node')
 
   await docker(['volume', 'create', volumeName])
   volumeCreated = true

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -179,7 +179,7 @@ la liste de durcissement dans [SECURITY.md](../SECURITY.md#hardening-your-deploy
 
 La même image fonctionne sur Fly.io. Le dépôt fournit un `fly.toml` qui construit
 `apps/server/Dockerfile`, garde une machine en marche pour les Triggers Cron et Poll, et persiste
-SQLite sur un volume Fly. Consultez [fly-io.md](server/fly-io/README.fr.md) pour la création de l'app, le
+SQLite sur un volume Fly. Consultez [Déploiement sur Fly.io](server/fly-io/README.fr.md) pour la création de l'app, le
 volume, les secrets, le déploiement, les domaines personnalisés et les limites de mise à
 l'échelle.
 

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -59,20 +59,23 @@ L'Agent crée un véritable Draft dans le déploiement Open Flow sélectionné, 
 
 ## Choisir comment exécuter Open Flow
 
-Les deux options prises en charge utilisent le même produit Open Flow et le même Workbench.
+Les trois options prises en charge utilisent le même produit Open Flow et le même Workbench.
 
 <table>
   <tr>
-    <td width="50%" align="center"><strong>☁️ OOMOL Hosted</strong></td>
-    <td width="50%" align="center"><strong>🐳 Docker Self-hosted</strong></td>
+    <td width="33%" align="center"><strong>☁️ OOMOL Hosted</strong></td>
+    <td width="33%" align="center"><strong>🐳 Docker Self-hosted</strong></td>
+    <td width="33%" align="center"><strong>Fly.io Self-hosted</strong></td>
   </tr>
   <tr>
-    <td width="50%" valign="top">Prêt à l'emploi sans préparer, mettre à jour ou superviser un serveur. OOMOL exploite le déploiement et fournit des OAuth Apps gérées pour les intégrations compatibles, ce qui évite les coûts fixes d'un serveur et la configuration séparée des OAuth Apps.</td>
-    <td width="50%" valign="top">Exécutez Open Flow sur votre propre infrastructure avec l'image Docker incluse. Vous gérez le déploiement, le stockage, les sauvegardes, les mises à niveau, le réseau et la configuration du Connector ou des OAuth Apps.</td>
+    <td width="33%" valign="top">Prêt à l'emploi sans préparer, mettre à jour ou superviser un serveur. OOMOL exploite le déploiement et fournit des OAuth Apps gérées pour les intégrations compatibles, ce qui évite les coûts fixes d'un serveur et la configuration séparée des OAuth Apps.</td>
+    <td width="33%" valign="top">Exécutez Open Flow sur votre propre infrastructure avec l'image Docker incluse. Vous gérez le déploiement, le stockage, les sauvegardes, les mises à niveau, le réseau et la configuration du Connector ou des OAuth Apps.</td>
+    <td width="33%" valign="top">Exécutez la même image Docker sur Fly.io sans exploiter vous-même un serveur. Fly construit l'image, termine le TLS et conserve SQLite sur un volume persistant ; vous gérez les secrets, les sauvegardes, les mises à niveau et la configuration du Connector ou des OAuth Apps.</td>
   </tr>
   <tr>
-    <td width="50%" align="center">🚀 <a href="https://oomol.com"><strong>Utiliser OOMOL Hosted</strong></a></td>
-    <td width="50%" align="center"><a href="#démarrage-rapide"><strong>S'auto-héberger avec Docker</strong></a></td>
+    <td width="33%" align="center">🚀 <a href="https://oomol.com"><strong>Utiliser OOMOL Hosted</strong></a></td>
+    <td width="33%" align="center"><a href="#démarrage-rapide"><strong>S'auto-héberger avec Docker</strong></a></td>
+    <td width="33%" align="center"><a href="server/fly-io/README.fr.md"><strong>Déployer sur Fly.io</strong></a></td>
   </tr>
 </table>
 
@@ -172,6 +175,14 @@ Pour la configuration de production, TLS, les health checks, la persistance, les
 limites de ressources, consultez le [guide de déploiement du Server](server/container-delivery.md) et
 la liste de durcissement dans [SECURITY.md](../SECURITY.md#hardening-your-deployment).
 
+## Déployer sur Fly.io
+
+La même image fonctionne sur Fly.io. Le dépôt fournit un `fly.toml` qui construit
+`apps/server/Dockerfile`, garde une machine en marche pour les Triggers Cron et Poll, et persiste
+SQLite sur un volume Fly. Consultez [fly-io.md](server/fly-io/README.fr.md) pour la création de l'app, le
+volume, les secrets, le déploiement, les domaines personnalisés et les limites de mise à
+l'échelle.
+
 ## Connecter un Connector
 
 Pour exécuter des Actions et des Triggers de Provider auprès de services tels que GitHub, Gmail, Slack
@@ -257,6 +268,7 @@ Commencez par l'[index de la documentation](README.md). Les références les plu
 - [Distribution du Command Artifact](distribution/command-artifact.md)
 - [Notes sur le frontend du Workbench et du Designer](authoring/frontend-ui.md)
 - [Déploiement du Server](server/container-delivery.md)
+- [Déploiement sur Fly.io](server/fly-io/README.fr.md)
 - [Contribuer](../CONTRIBUTING.md)
 - [Code de conduite](../CODE_OF_CONDUCT.md)
 - [Sécurité](../SECURITY.md)

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -158,7 +158,7 @@ Server は外部サービスなしでも利用できます。Connector を利用
 
 同じイメージは Fly.io でも動作します。リポジトリに含まれる `fly.toml` は `apps/server/Dockerfile` でイメージをビルドし、Cron と Poll Trigger
 を動かすために 1 台の machine を常時起動し、SQLite を Fly volume に永続化します。Fly app の作成、volume、secret、デプロイ、custom
-domain、スケーリングの制限については [fly-io.md](server/fly-io/README.ja.md) を参照してください。
+domain、スケーリングの制限については [Fly.io へのデプロイ](server/fly-io/README.ja.md) を参照してください。
 
 ## Connector を接続する
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -54,20 +54,23 @@ Agent が作成するのは、使い捨てのローカル設定ではなく、�
 
 ## Open Flow の実行方法を選ぶ
 
-どちらの対応パスでも、同じ Open Flow プロダクトと Workbench を利用できます。
+どの対応パスでも、同じ Open Flow プロダクトと Workbench を利用できます。
 
 <table>
   <tr>
-    <td width="50%" align="center"><strong>☁️ OOMOL Hosted</strong></td>
-    <td width="50%" align="center"><strong>🐳 Docker Self-hosted</strong></td>
+    <td width="33%" align="center"><strong>☁️ OOMOL Hosted</strong></td>
+    <td width="33%" align="center"><strong>🐳 Docker Self-hosted</strong></td>
+    <td width="33%" align="center"><strong>Fly.io Self-hosted</strong></td>
   </tr>
   <tr>
-    <td width="50%" valign="top">サーバーの準備、更新、監視なしですぐに利用できます。OOMOL がデプロイメントを運用し、対応する連携にはマネージド OAuth App を提供するため、固定のサーバー費用や個別の OAuth App 設定が不要です。</td>
-    <td width="50%" valign="top">同梱の Docker イメージを使って自分のインフラストラクチャで実行します。デプロイ、ストレージ、バックアップ、アップグレード、ネットワーク、Connector または OAuth App の設定を自分で管理します。</td>
+    <td width="33%" valign="top">サーバーの準備、更新、監視なしですぐに利用できます。OOMOL がデプロイメントを運用し、対応する連携にはマネージド OAuth App を提供するため、固定のサーバー費用や個別の OAuth App 設定が不要です。</td>
+    <td width="33%" valign="top">同梱の Docker イメージを使って自分のインフラストラクチャで実行します。デプロイ、ストレージ、バックアップ、アップグレード、ネットワーク、Connector または OAuth App の設定を自分で管理します。</td>
+    <td width="33%" valign="top">同じ Docker イメージを Fly.io で実行でき、サーバーを自分で運用する必要はありません。Fly がイメージのビルド、TLS 終端、永続 volume 上の SQLite を担当し、secret、バックアップ、アップグレード、Connector または OAuth App の設定は自分で管理します。</td>
   </tr>
   <tr>
-    <td width="50%" align="center">🚀 <a href="https://oomol.com"><strong>OOMOL Hosted を使う</strong></a></td>
-    <td width="50%" align="center"><a href="#クイックスタート"><strong>Docker でセルフホストする</strong></a></td>
+    <td width="33%" align="center">🚀 <a href="https://oomol.com"><strong>OOMOL Hosted を使う</strong></a></td>
+    <td width="33%" align="center"><a href="#クイックスタート"><strong>Docker でセルフホストする</strong></a></td>
+    <td width="33%" align="center"><a href="server/fly-io/README.ja.md"><strong>Fly.io にデプロイする</strong></a></td>
   </tr>
 </table>
 
@@ -151,6 +154,12 @@ Server は外部サービスなしでも利用できます。Connector を利用
 本番環境の設定、TLS、ヘルスチェック、永続化、バックアップ、リソース制限については、[Server デプロイガイド](server/container-delivery.md) と
 [SECURITY.md](../SECURITY.md#hardening-your-deployment) の強化チェックリストを参照してください。
 
+## Fly.io にデプロイする
+
+同じイメージは Fly.io でも動作します。リポジトリに含まれる `fly.toml` は `apps/server/Dockerfile` でイメージをビルドし、Cron と Poll Trigger
+を動かすために 1 台の machine を常時起動し、SQLite を Fly volume に永続化します。Fly app の作成、volume、secret、デプロイ、custom
+domain、スケーリングの制限については [fly-io.md](server/fly-io/README.ja.md) を参照してください。
+
 ## Connector を接続する
 
 GitHub、Gmail、Slack、Notion などのサービスに対して Action や Provider Trigger を実行するには、Server を Connector ランタイムに向けます。
@@ -221,6 +230,7 @@ bun run build
 - [Command Artifact の配布契約](distribution/command-artifact.md)
 - [Workbench と Designer のフロントエンドに関する注意](authoring/frontend-ui.md)
 - [Server のデプロイ](server/container-delivery.md)
+- [Fly.io へのデプロイ](server/fly-io/README.ja.md)
 - [コントリビューション](../CONTRIBUTING.md)
 - [行動規範](../CODE_OF_CONDUCT.md)
 - [セキュリティ](../SECURITY.md)

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -165,7 +165,7 @@ Server는 외부 서비스 없이도 유용하게 사용할 수 있습니다. Co
 
 같은 이미지를 Fly.io에서도 실행할 수 있습니다. 저장소에 포함된 `fly.toml`은 `apps/server/Dockerfile`로 이미지를 빌드하고, Cron과 Poll
 Trigger를 위해 machine 한 대를 항상 실행 상태로 유지하며, SQLite를 Fly volume에 영속화합니다. Fly app 생성, volume, secret, 배포,
-custom domain, 스케일링 제한은 [fly-io.md](server/fly-io/README.ko.md)를 참고하세요.
+custom domain, 스케일링 제한은 [Fly.io 배포](server/fly-io/README.ko.md)를 참고하세요.
 
 ## Connector 연결
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -54,20 +54,23 @@ Agent는 일회용 로컬 설정이 아니라 선택한 Open Flow 배포 안에 
 
 ## Open Flow 실행 방식 선택
 
-지원되는 두 방식 모두 동일한 Open Flow 제품과 Workbench를 사용합니다.
+지원되는 세 방식 모두 동일한 Open Flow 제품과 Workbench를 사용합니다.
 
 <table>
   <tr>
-    <td width="50%" align="center"><strong>☁️ OOMOL Hosted</strong></td>
-    <td width="50%" align="center"><strong>🐳 Docker Self-hosted</strong></td>
+    <td width="33%" align="center"><strong>☁️ OOMOL Hosted</strong></td>
+    <td width="33%" align="center"><strong>🐳 Docker Self-hosted</strong></td>
+    <td width="33%" align="center"><strong>Fly.io Self-hosted</strong></td>
   </tr>
   <tr>
-    <td width="50%" valign="top">서버를 준비하거나 패치하고 모니터링할 필요 없이 바로 사용할 수 있습니다. OOMOL이 배포를 운영하고 지원되는 연동에 관리형 OAuth App을 제공하므로 고정 서버 비용과 별도의 OAuth App 설정을 줄일 수 있습니다.</td>
-    <td width="50%" valign="top">포함된 Docker 이미지로 자체 인프라에서 실행합니다. 배포, 스토리지, 백업, 업그레이드, 네트워크와 Connector 또는 OAuth App 설정을 직접 관리합니다.</td>
+    <td width="33%" valign="top">서버를 준비하거나 패치하고 모니터링할 필요 없이 바로 사용할 수 있습니다. OOMOL이 배포를 운영하고 지원되는 연동에 관리형 OAuth App을 제공하므로 고정 서버 비용과 별도의 OAuth App 설정을 줄일 수 있습니다.</td>
+    <td width="33%" valign="top">포함된 Docker 이미지로 자체 인프라에서 실행합니다. 배포, 스토리지, 백업, 업그레이드, 네트워크와 Connector 또는 OAuth App 설정을 직접 관리합니다.</td>
+    <td width="33%" valign="top">같은 Docker 이미지를 Fly.io에서 실행하며 서버를 직접 운영할 필요가 없습니다. Fly가 이미지 빌드, TLS 종료, 영구 volume의 SQLite를 담당하고, secret, 백업, 업그레이드와 Connector 또는 OAuth App 설정은 직접 관리합니다.</td>
   </tr>
   <tr>
-    <td width="50%" align="center">🚀 <a href="https://oomol.com"><strong>OOMOL Hosted 사용</strong></a></td>
-    <td width="50%" align="center"><a href="#빠른-시작"><strong>Docker로 셀프 호스팅</strong></a></td>
+    <td width="33%" align="center">🚀 <a href="https://oomol.com"><strong>OOMOL Hosted 사용</strong></a></td>
+    <td width="33%" align="center"><a href="#빠른-시작"><strong>Docker로 셀프 호스팅</strong></a></td>
+    <td width="33%" align="center"><a href="server/fly-io/README.ko.md"><strong>Fly.io에 배포</strong></a></td>
   </tr>
 </table>
 
@@ -158,6 +161,12 @@ Server는 외부 서비스 없이도 유용하게 사용할 수 있습니다. Co
 프로덕션 구성, TLS, 헬스 체크, 영속화, 백업, 리소스 제한은 [Server 배포 가이드](server/container-delivery.md)와
 [SECURITY.md](../SECURITY.md#hardening-your-deployment)의 강화 체크리스트를 참고하세요.
 
+## Fly.io에 배포
+
+같은 이미지를 Fly.io에서도 실행할 수 있습니다. 저장소에 포함된 `fly.toml`은 `apps/server/Dockerfile`로 이미지를 빌드하고, Cron과 Poll
+Trigger를 위해 machine 한 대를 항상 실행 상태로 유지하며, SQLite를 Fly volume에 영속화합니다. Fly app 생성, volume, secret, 배포,
+custom domain, 스케일링 제한은 [fly-io.md](server/fly-io/README.ko.md)를 참고하세요.
+
 ## Connector 연결
 
 GitHub, Gmail, Slack, Notion 같은 서비스에 대해 Action과 Provider Trigger를 실행하려면 Server가 Connector 런타임을
@@ -235,6 +244,7 @@ bun run build
 - [Command Artifact 배포 계약](distribution/command-artifact.md)
 - [Workbench 및 Designer 프런트엔드 참고 사항](authoring/frontend-ui.md)
 - [Server 배포](server/container-delivery.md)
+- [Fly.io 배포](server/fly-io/README.ko.md)
 - [기여 안내](../CONTRIBUTING.md)
 - [행동 강령](../CODE_OF_CONDUCT.md)
 - [보안 정책](../SECURITY.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,3 +14,4 @@ Open Flow 提供公共产品合同、Workbench runtime、CLI runtime 与完整 S
 ## Server 实施参考
 
 - [Server 容器交付参考](server/container-delivery.md)
+- [Fly.io 部署](server/fly-io/README.zh-CN.md) ([English](server/fly-io/README.md))

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -58,20 +58,23 @@ Agent создаёт настоящий Draft в выбранном deployment O
 
 ## Выберите способ запуска Open Flow
 
-Оба поддерживаемых варианта используют один и тот же продукт Open Flow и Workbench.
+Все поддерживаемые варианты используют один и тот же продукт Open Flow и Workbench.
 
 <table>
   <tr>
-    <td width="50%" align="center"><strong>☁️ OOMOL Hosted</strong></td>
-    <td width="50%" align="center"><strong>🐳 Docker Self-hosted</strong></td>
+    <td width="33%" align="center"><strong>☁️ OOMOL Hosted</strong></td>
+    <td width="33%" align="center"><strong>🐳 Docker Self-hosted</strong></td>
+    <td width="33%" align="center"><strong>Fly.io Self-hosted</strong></td>
   </tr>
   <tr>
-    <td width="50%" valign="top">Готово к работе без подготовки, обновления и мониторинга сервера. OOMOL управляет deployment и предоставляет управляемые OAuth App для поддерживаемых интеграций, поэтому вам не нужны постоянные расходы на сервер и отдельная настройка OAuth App.</td>
-    <td width="50%" valign="top">Запускайте на своей инфраструктуре с помощью включённого Docker image. Вы управляете deployment, хранилищем, резервным копированием, обновлениями, сетью и настройкой Connector или OAuth App.</td>
+    <td width="33%" valign="top">Готово к работе без подготовки, обновления и мониторинга сервера. OOMOL управляет deployment и предоставляет управляемые OAuth App для поддерживаемых интеграций, поэтому вам не нужны постоянные расходы на сервер и отдельная настройка OAuth App.</td>
+    <td width="33%" valign="top">Запускайте на своей инфраструктуре с помощью включённого Docker image. Вы управляете deployment, хранилищем, резервным копированием, обновлениями, сетью и настройкой Connector или OAuth App.</td>
+    <td width="33%" valign="top">Запускайте тот же Docker image на Fly.io, не обслуживая сервер самостоятельно. Fly собирает image, терминирует TLS и хранит SQLite на постоянном volume; вы управляете secrets, резервным копированием, обновлениями и настройкой Connector или OAuth App.</td>
   </tr>
   <tr>
-    <td width="50%" align="center">🚀 <a href="https://oomol.com"><strong>Использовать OOMOL Hosted</strong></a></td>
-    <td width="50%" align="center"><a href="#быстрый-старт"><strong>Развернуть самостоятельно с Docker</strong></a></td>
+    <td width="33%" align="center">🚀 <a href="https://oomol.com"><strong>Использовать OOMOL Hosted</strong></a></td>
+    <td width="33%" align="center"><a href="#быстрый-старт"><strong>Развернуть самостоятельно с Docker</strong></a></td>
+    <td width="33%" align="center"><a href="server/fly-io/README.ru.md"><strong>Развернуть на Fly.io</strong></a></td>
   </tr>
 </table>
 
@@ -171,6 +174,13 @@ Server полезен и без внешних сервисов. Action на б�
 ресурсов описаны в [руководстве по развёртыванию Server](server/container-delivery.md) и в чеклисте
 по усилению защиты в [SECURITY.md](../SECURITY.md#hardening-your-deployment).
 
+## Развёртывание на Fly.io
+
+Тот же образ работает на Fly.io. В репозитории есть `fly.toml`, который собирает
+`apps/server/Dockerfile`, держит одну machine запущенной для Cron и Poll Trigger и сохраняет SQLite
+на Fly volume. Создание Fly app, volume, secrets, развёртывание, custom domain и
+ограничения масштабирования описаны в [fly-io.md](server/fly-io/README.ru.md).
+
 ## Подключение Connector
 
 Чтобы выполнять Action и Trigger от Provider для таких сервисов, как GitHub, Gmail, Slack или Notion,
@@ -251,6 +261,7 @@ bun run build
 - [Дистрибуция Command Artifact](distribution/command-artifact.md)
 - [Заметки по frontend Workbench и Designer](authoring/frontend-ui.md)
 - [Развёртывание Server](server/container-delivery.md)
+- [Развёртывание на Fly.io](server/fly-io/README.ru.md)
 - [Участие в разработке](../CONTRIBUTING.md)
 - [Кодекс поведения](../CODE_OF_CONDUCT.md)
 - [Безопасность](../SECURITY.md)

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -179,7 +179,7 @@ Server полезен и без внешних сервисов. Action на б�
 Тот же образ работает на Fly.io. В репозитории есть `fly.toml`, который собирает
 `apps/server/Dockerfile`, держит одну machine запущенной для Cron и Poll Trigger и сохраняет SQLite
 на Fly volume. Создание Fly app, volume, secrets, развёртывание, custom domain и
-ограничения масштабирования описаны в [fly-io.md](server/fly-io/README.ru.md).
+ограничения масштабирования описаны в [Развёртывание на Fly.io](server/fly-io/README.ru.md).
 
 ## Подключение Connector
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -53,20 +53,23 @@ Agent 创建的是所选 Open Flow 部署中的真实 Draft，而不是用完即
 
 ## 选择 Open Flow 的运行方式
 
-两种支持的方式使用同一套 Open Flow 产品和 Workbench。
+三种支持的方式使用同一套 Open Flow 产品和 Workbench。
 
 <table>
   <tr>
-    <td width="50%" align="center"><strong>☁️ OOMOL Hosted</strong></td>
-    <td width="50%" align="center"><strong>🐳 Docker Self-hosted</strong></td>
+    <td width="33%" align="center"><strong>☁️ OOMOL Hosted</strong></td>
+    <td width="33%" align="center"><strong>🐳 Docker Self-hosted</strong></td>
+    <td width="33%" align="center"><strong>Fly.io Self-hosted</strong></td>
   </tr>
   <tr>
-    <td width="50%" valign="top">无需准备、更新或监控服务器，打开即可使用。OOMOL 负责运行部署，并为支持的集成提供托管 OAuth App，免去固定服务器成本和单独配置 OAuth App 的工作。</td>
-    <td width="50%" valign="top">使用内置 Docker 镜像运行在自己的基础设施中。部署、存储、备份、升级、网络以及 Connector 或 OAuth App 配置均由你管理。</td>
+    <td width="33%" valign="top">无需准备、更新或监控服务器，打开即可使用。OOMOL 负责运行部署，并为支持的集成提供托管 OAuth App，免去固定服务器成本和单独配置 OAuth App 的工作。</td>
+    <td width="33%" valign="top">使用内置 Docker 镜像运行在自己的基础设施中。部署、存储、备份、升级、网络以及 Connector 或 OAuth App 配置均由你管理。</td>
+    <td width="33%" valign="top">在 Fly.io 上运行同一个 Docker 镜像，无需自己维护服务器。Fly 负责构建镜像、终止 TLS 并把 SQLite 保存在持久化 volume 上；secret、备份、升级以及 Connector 或 OAuth App 配置由你管理。</td>
   </tr>
   <tr>
-    <td width="50%" align="center">🚀 <a href="https://oomol.com"><strong>使用 OOMOL Hosted</strong></a></td>
-    <td width="50%" align="center"><a href="#快速开始"><strong>使用 Docker 自部署</strong></a></td>
+    <td width="33%" align="center">🚀 <a href="https://oomol.com"><strong>使用 OOMOL Hosted</strong></a></td>
+    <td width="33%" align="center"><a href="#快速开始"><strong>使用 Docker 自部署</strong></a></td>
+    <td width="33%" align="center"><a href="server/fly-io/README.zh-CN.md"><strong>部署到 Fly.io</strong></a></td>
   </tr>
 </table>
 
@@ -148,6 +151,11 @@ docker run --rm \
 生产环境所需的配置、TLS、健康检查、数据持久化、备份和资源限制，参见
 [Server 部署文档](server/container-delivery.md) 和 [SECURITY.md](../SECURITY.md#hardening-your-deployment) 中的加固清单。
 
+## 部署到 Fly.io
+
+同一个镜像也可以部署到 Fly.io。仓库自带的 `fly.toml` 使用 `apps/server/Dockerfile` 构建镜像，保持一台 machine 常驻以运行 Cron 和 Poll
+Trigger，并把 SQLite 持久化到 Fly volume。Fly app 创建、volume、secret、部署、自定义域名和扩缩容限制见 [fly-io.zh-CN.md](server/fly-io/README.zh-CN.md)。
+
 ## 接入 Connector
 
 要对 GitHub、Gmail、Slack、Notion 等服务执行 Action 和 Provider Trigger，需要把 Server 指向一个 Connector 运行时。自行部署的
@@ -220,6 +228,7 @@ SQLite volume 恢复。不要在仓库根目录直接运行 `bun test`，它会�
 - [Command Artifact 分发合同](distribution/command-artifact.md)
 - [Workbench 与 Designer 前端注意事项](authoring/frontend-ui.md)
 - [Server 部署](server/container-delivery.md)
+- [Fly.io 部署](server/fly-io/README.zh-CN.md)
 - [参与贡献](../CONTRIBUTING.md)
 - [行为准则](../CODE_OF_CONDUCT.md)
 - [安全政策](../SECURITY.md)

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -154,7 +154,7 @@ docker run --rm \
 ## 部署到 Fly.io
 
 同一个镜像也可以部署到 Fly.io。仓库自带的 `fly.toml` 使用 `apps/server/Dockerfile` 构建镜像，保持一台 machine 常驻以运行 Cron 和 Poll
-Trigger，并把 SQLite 持久化到 Fly volume。Fly app 创建、volume、secret、部署、自定义域名和扩缩容限制见 [fly-io.zh-CN.md](server/fly-io/README.zh-CN.md)。
+Trigger，并把 SQLite 持久化到 Fly volume。Fly app 创建、volume、secret、部署、自定义域名和扩缩容限制见 [Fly.io 部署](server/fly-io/README.zh-CN.md)。
 
 ## 接入 Connector
 

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -154,7 +154,7 @@ docker run --rm \
 ## 部署到 Fly.io
 
 同一個映像也可以部署到 Fly.io。儲存庫內建的 `fly.toml` 使用 `apps/server/Dockerfile` 建置映像，保持一台 machine 常駐以執行 Cron 和 Poll
-Trigger，並把 SQLite 持久化到 Fly volume。Fly app 建立、volume、secret、部署、自訂網域和擴縮容限制請參閱 [fly-io.md](server/fly-io/README.zh-TW.md)。
+Trigger，並把 SQLite 持久化到 Fly volume。Fly app 建立、volume、secret、部署、自訂網域和擴縮容限制請參閱 [Fly.io 部署](server/fly-io/README.zh-TW.md)。
 
 ## 接入 Connector
 

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -53,20 +53,23 @@ Agent 建立的是所選 Open Flow 部署中的真實 Draft，而不是用完即
 
 ## 選擇 Open Flow 的執行方式
 
-兩種支援的方式使用同一套 Open Flow 產品和 Workbench。
+三種支援的方式使用同一套 Open Flow 產品和 Workbench。
 
 <table>
   <tr>
-    <td width="50%" align="center"><strong>☁️ OOMOL Hosted</strong></td>
-    <td width="50%" align="center"><strong>🐳 Docker Self-hosted</strong></td>
+    <td width="33%" align="center"><strong>☁️ OOMOL Hosted</strong></td>
+    <td width="33%" align="center"><strong>🐳 Docker Self-hosted</strong></td>
+    <td width="33%" align="center"><strong>Fly.io Self-hosted</strong></td>
   </tr>
   <tr>
-    <td width="50%" valign="top">無需準備、更新或監控伺服器，開啟即可使用。OOMOL 負責執行部署，並為支援的整合提供託管 OAuth App，省去固定伺服器成本和另外設定 OAuth App 的工作。</td>
-    <td width="50%" valign="top">使用內建 Docker 映像檔在自己的基礎設施中執行。部署、儲存、備份、升級、網路以及 Connector 或 OAuth App 設定均由你管理。</td>
+    <td width="33%" valign="top">無需準備、更新或監控伺服器，開啟即可使用。OOMOL 負責執行部署，並為支援的整合提供託管 OAuth App，省去固定伺服器成本和另外設定 OAuth App 的工作。</td>
+    <td width="33%" valign="top">使用內建 Docker 映像檔在自己的基礎設施中執行。部署、儲存、備份、升級、網路以及 Connector 或 OAuth App 設定均由你管理。</td>
+    <td width="33%" valign="top">在 Fly.io 上執行同一個 Docker 映像檔，無需自己維護伺服器。Fly 負責建置映像檔、終止 TLS 並把 SQLite 保存在持久化 volume 上；secret、備份、升級以及 Connector 或 OAuth App 設定均由你管理。</td>
   </tr>
   <tr>
-    <td width="50%" align="center">🚀 <a href="https://oomol.com"><strong>使用 OOMOL Hosted</strong></a></td>
-    <td width="50%" align="center"><a href="#快速開始"><strong>使用 Docker 自行部署</strong></a></td>
+    <td width="33%" align="center">🚀 <a href="https://oomol.com"><strong>使用 OOMOL Hosted</strong></a></td>
+    <td width="33%" align="center"><a href="#快速開始"><strong>使用 Docker 自行部署</strong></a></td>
+    <td width="33%" align="center"><a href="server/fly-io/README.zh-TW.md"><strong>部署到 Fly.io</strong></a></td>
   </tr>
 </table>
 
@@ -148,6 +151,11 @@ docker run --rm \
 正式環境所需的設定、TLS、健康檢查、資料持久化、備份和資源限制，請參閱
 [Server 部署文件](server/container-delivery.md) 和 [SECURITY.md](../SECURITY.md#hardening-your-deployment) 中的強化清單。
 
+## 部署到 Fly.io
+
+同一個映像也可以部署到 Fly.io。儲存庫內建的 `fly.toml` 使用 `apps/server/Dockerfile` 建置映像，保持一台 machine 常駐以執行 Cron 和 Poll
+Trigger，並把 SQLite 持久化到 Fly volume。Fly app 建立、volume、secret、部署、自訂網域和擴縮容限制請參閱 [fly-io.md](server/fly-io/README.zh-TW.md)。
+
 ## 接入 Connector
 
 要對 GitHub、Gmail、Slack、Notion 等服務執行 Action 和 Provider Trigger，需要把 Server 指向一個 Connector 執行環境。自行部署的
@@ -218,6 +226,7 @@ SQLite volume 復原。不要在儲存庫根目錄直接執行 `bun test`，它�
 - [Command Artifact 發布合約](distribution/command-artifact.md)
 - [Workbench 與 Designer 前端注意事項](authoring/frontend-ui.md)
 - [Server 部署](server/container-delivery.md)
+- [Fly.io 部署](server/fly-io/README.zh-TW.md)
 - [參與貢獻](../CONTRIBUTING.md)
 - [行為準則](../CODE_OF_CONDUCT.md)
 - [安全政策](../SECURITY.md)

--- a/docs/server/container-delivery.md
+++ b/docs/server/container-delivery.md
@@ -60,7 +60,7 @@ docker run --detach \
 ```
 
 Workbench 和 API 位于 `http://127.0.0.1:3000`；登录后 `/variables` 提供该 deployment 的 Variable 管理面。最终镜像默认监听
-`0.0.0.0:3000`，以非 root `node` 用户运行，并把 SQLite 保存为 `/data/open-flow/open-flow.sqlite`。
+`0.0.0.0:3000`，以 root 用户运行，并把 SQLite 保存为 `/data/open-flow/open-flow.sqlite`。
 
 ## 4. 配置
 

--- a/docs/server/fly-io/README.fr.md
+++ b/docs/server/fly-io/README.fr.md
@@ -179,8 +179,12 @@ repos. Pour une sauvegarde cohérente, arrêtez la machine avant de créer un sn
 ```bash
 fly machine stop <machine-id> --app my-open-flow
 fly volumes snapshots create <volume-id> --app my-open-flow
+fly volumes snapshots list <volume-id> --app my-open-flow
 fly machine start <machine-id> --app my-open-flow
 ```
+
+Le snapshot est créé de manière asynchrone. Laissez la machine arrêtée jusqu'à ce que
+`fly volumes snapshots list` affiche le nouveau snapshot avec l'état `created`, puis redémarrez la machine.
 
 Retrouvez les identifiants avec `fly machine list` et `fly volumes list`.
 

--- a/docs/server/fly-io/README.fr.md
+++ b/docs/server/fly-io/README.fr.md
@@ -1,0 +1,197 @@
+# Déploiement sur Fly.io
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+Open Flow Server peut s'exécuter sur Fly.io en tant que runtime Docker Node. Ce déploiement utilise le
+`apps/server/Dockerfile` du dépôt, la configuration d'app Fly dans le `fly.toml` à la racine du
+dépôt, et un volume Fly monté sur `/data/open-flow`. Fly fournit la terminaison TLS, les builds
+Docker distants, les health checks, les déploiements progressifs et, en option, les domaines
+personnalisés.
+
+La limite de déploiement est la même que dans la
+[référence de livraison en conteneur](../container-delivery.md) : une machine Server et un seul
+writer SQLite. N'exécutez jamais plus d'une machine.
+
+## Prérequis
+
+- Un compte Fly.io.
+- `flyctl` installé et authentifié avec `fly auth login`.
+- Docker disponible en local, ou les remote builders de Fly. `apps/server/Dockerfile` utilise la
+  syntaxe BuildKit, que les remote builders prennent en charge.
+
+## Créer l'app
+
+Créez une app Fly sans la déployer pour l'instant :
+
+```bash
+fly apps create my-open-flow
+```
+
+Les noms d'app Fly sont uniques à l'échelle mondiale. Si vous choisissez un autre nom, mettez à jour
+le champ `app` dans `fly.toml` avant de déployer :
+
+```toml
+app = "my-open-flow"
+```
+
+## Créer le stockage persistant
+
+L'image stocke SQLite dans `/data/open-flow`. Créez un volume Fly avec le même nom de source que
+`fly.toml` :
+
+```bash
+fly volumes create open_flow_data \
+  --region iad \
+  --size 1 \
+  --app my-open-flow
+```
+
+L'historique des Runs et les RunEvents grossissent avec le temps. Augmentez `--size` si vous
+attendez de nombreux Runs, ou étendez le volume plus tard avec `fly volumes extend`.
+
+## Définir les secrets
+
+Le token opérateur doit contenir au moins 32 octets UTF-8. Stockez-le comme secret Fly au lieu de le
+committer dans `fly.toml` :
+
+```bash
+OPEN_FLOW_TOKEN="$(openssl rand -hex 32)"
+
+fly secrets set \
+  OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN" \
+  --app my-open-flow
+```
+
+Conservez `OPEN_FLOW_TOKEN` dans un gestionnaire de mots de passe. La même valeur permet de se
+connecter au Workbench et sert de Bearer token pour la Control API.
+
+`fly.toml` définit déjà `OPEN_FLOW_SESSION_COOKIE_SECURE` à `true` : `force_https` redirige les
+requêtes HTTP en clair, de sorte que les navigateurs n'atteignent le Server que via TLS.
+
+Définissez les secrets du Connector lorsque vous avez besoin d'un Connector :
+
+```bash
+fly secrets set \
+  OPEN_FLOW_CONNECTOR_ORIGIN="https://connector.example.com" \
+  OPEN_FLOW_CONNECTOR_TOKEN="replace-with-a-scoped-runtime-token" \
+  OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="https://connector.example.com" \
+  --app my-open-flow
+```
+
+Lorsque OpenConnector s'exécute dans la même organisation Fly, l'origine runtime peut utiliser le
+réseau privé Fly, par exemple `http://my-open-connector.internal:3000`. L'origine console doit rester
+une origine HTTPS publique que les navigateurs des utilisateurs peuvent ouvrir.
+
+Définissez l'origine et la clé de callback lorsque vous avez besoin des Integrations de Provider :
+
+```bash
+fly secrets set \
+  OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN="https://my-open-flow.fly.dev" \
+  OPEN_FLOW_INTEGRATION_CALLBACK_KEY="$(openssl rand -hex 32)" \
+  --app my-open-flow
+```
+
+`fly secrets set` redéploie la machine. Consultez la
+[référence de livraison en conteneur](../container-delivery.md#4-配置) pour la liste complète des
+variables d'environnement et les contraintes applicables à chaque origine.
+
+## Déployer
+
+Déployez depuis la racine du dépôt :
+
+```bash
+fly deploy --config fly.toml --remote-only --ha=false
+```
+
+`--ha=false` empêche Fly de créer une seconde machine pour une nouvelle app. Le Server n'autorise
+qu'un seul writer SQLite, et chaque machine monte son propre volume : deux machines détiendraient
+donc deux copies sans lien de l'état. Gardez le nombre de machines à un lors de chaque déploiement
+ultérieur et ne l'augmentez jamais avec `fly scale count`.
+
+La configuration Fly utilise :
+
+- `apps/server/Dockerfile` pour la construction de l'image, avec la racine du dépôt comme contexte
+  de build.
+- `internal_port = 3000`, la valeur par défaut de l'image.
+- `GET /readyz` comme health check HTTP. Il renvoie 503 pendant le démarrage du Server, lorsque le
+  traitement en arrière-plan s'est arrêté, ou lorsque le Connector configuré est injoignable ; Fly
+  cesse alors de router le trafic vers la machine et fait échouer le déploiement. Remplacez le chemin
+  par `/healthz` si vous ne voulez qu'un contrôle de vivacité.
+- `kill_signal = "SIGTERM"` et `kill_timeout = "45s"`. Le Server attend jusqu'à 30 secondes pour
+  vider les Runs et fermer SQLite, le délai de grâce doit donc dépasser 30 secondes.
+- `auto_stop_machines = "off"` et `min_machines_running = 1`. Les Triggers Cron et Poll ne se
+  déclenchent que lorsque la machine est en marche.
+
+## Vérifier le runtime
+
+```bash
+curl https://my-open-flow.fly.dev/healthz
+curl https://my-open-flow.fly.dev/readyz
+```
+
+Les réponses attendues sont `{"status":"ok"}` et `{"status":"ready"}`. Ouvrez
+`https://my-open-flow.fly.dev` et connectez-vous au Workbench avec `OPEN_FLOW_TOKEN`.
+
+Consultez les logs pour diagnostiquer les problèmes de déploiement ou de démarrage :
+
+```bash
+fly logs --app my-open-flow
+```
+
+## Domaine personnalisé
+
+Enregistrez le domaine auprès de Fly :
+
+```bash
+fly certs add flow.example.com --app my-open-flow
+```
+
+Fly affiche les enregistrements DNS à créer. Une fois le DNS prêt, vérifiez l'état du certificat :
+
+```bash
+fly certs check flow.example.com --app my-open-flow
+```
+
+Si les callbacks d'Integration sont configurés, faites pointer `OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN`
+vers le nouveau domaine :
+
+```bash
+fly secrets set \
+  OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN="https://flow.example.com" \
+  --app my-open-flow
+```
+
+## Mise à jour
+
+```bash
+git pull
+fly deploy --config fly.toml --remote-only
+```
+
+Le volume conserve `open-flow.sqlite` ainsi que ses fichiers WAL et SHM. Les migrations SQLite
+s'exécutent dans l'ordre au démarrage du Server ; aucune étape supplémentaire n'est nécessaire.
+
+## Sauvegarde
+
+Fly prend automatiquement des snapshots du volume, mais le Server ne garantit que des sauvegardes au
+repos. Pour une sauvegarde cohérente, arrêtez la machine avant de créer un snapshot :
+
+```bash
+fly machine stop <machine-id> --app my-open-flow
+fly volumes snapshots create <volume-id> --app my-open-flow
+fly machine start <machine-id> --app my-open-flow
+```
+
+Retrouvez les identifiants avec `fly machine list` et `fly volumes list`.
+
+## Mise à l'échelle et machines inactives
+
+- Gardez le nombre de machines à un. Pour plus de capacité, modifiez `size` et `memory` sous
+  `[[vm]]` dans `fly.toml` et redéployez.
+- La valeur par défaut est `memory = "1gb"`. La VM isolée de chaque Run est plafonnée à 128 Mo par
+  défaut, `OPEN_FLOW_MAX_CONCURRENT_RUNS` vaut 4 par défaut, et le processus Node a besoin de sa
+  propre mémoire. Augmentez la mémoire en même temps que la limite de concurrence.
+- Si vous n'utilisez que des Runs manuels et des Webhooks et acceptez les démarrages à froid,
+  définissez `auto_stop_machines = "suspend"` et `min_machines_running = 0`. Les Triggers Cron et
+  Poll ne se déclenchent pas tant que la machine est suspendue, et la première requête Webhook attend
+  le réveil de la machine.

--- a/docs/server/fly-io/README.ja.md
+++ b/docs/server/fly-io/README.ja.md
@@ -1,0 +1,185 @@
+# Fly.io へのデプロイ
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+Open Flow Server は、Node Docker ランタイムとして Fly.io 上で実行できます。このデプロイメントでは、リポジトリの
+`apps/server/Dockerfile`、リポジトリのルートにある Fly app 設定 `fly.toml`、および `/data/open-flow` にマウントされる
+Fly volume を使用します。Fly は TLS 終端、リモート Docker ビルド、ヘルスチェック、ローリングデプロイ、任意のカスタムドメインを
+提供します。
+
+デプロイメントの境界は[コンテナ配布リファレンス](../container-delivery.md)と同じです。Server の machine は 1 台、SQLite の
+writer は 1 つです。machine を 2 台以上実行してはいけません。
+
+## 前提条件
+
+- Fly.io のアカウント。
+- `flyctl` がインストールされ、`fly auth login` で認証済みであること。
+- ローカルで Docker が利用できること、または Fly の remote builder。`apps/server/Dockerfile` は BuildKit 構文を使用しており、
+  remote builder はこれをサポートしています。
+
+## App を作成する
+
+まだデプロイせずに Fly app を作成します。
+
+```bash
+fly apps create my-open-flow
+```
+
+Fly app の名前はグローバルに一意です。別の名前を選ぶ場合は、デプロイ前に `fly.toml` の `app` フィールドを更新してください。
+
+```toml
+app = "my-open-flow"
+```
+
+## 永続ストレージを作成する
+
+イメージは SQLite を `/data/open-flow` に保存します。`fly.toml` と同じ source 名で Fly volume を作成します。
+
+```bash
+fly volumes create open_flow_data \
+  --region iad \
+  --size 1 \
+  --app my-open-flow
+```
+
+Run の履歴と RunEvent は時間とともに増加します。多数の Run を見込む場合は `--size` を増やすか、後から `fly volumes extend` で
+volume を拡張してください。
+
+## Secret を設定する
+
+operator token は 32 バイト以上の UTF-8 で構成されている必要があります。`fly.toml` にコミットするのではなく、Fly の secret
+として保存してください。
+
+```bash
+OPEN_FLOW_TOKEN="$(openssl rand -hex 32)"
+
+fly secrets set \
+  OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN" \
+  --app my-open-flow
+```
+
+`OPEN_FLOW_TOKEN` はパスワードマネージャーに保管してください。同じ値で Workbench にサインインでき、Control API の
+Bearer token としても使えます。
+
+`fly.toml` はすでに `OPEN_FLOW_SESSION_COOKIE_SECURE` を `true` に設定しています。`force_https` が平文の HTTP リクエストを
+リダイレクトするため、ブラウザは TLS 経由でのみ Server に到達します。
+
+Connector が必要な場合は、Connector の secret を設定します。
+
+```bash
+fly secrets set \
+  OPEN_FLOW_CONNECTOR_ORIGIN="https://connector.example.com" \
+  OPEN_FLOW_CONNECTOR_TOKEN="replace-with-a-scoped-runtime-token" \
+  OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="https://connector.example.com" \
+  --app my-open-flow
+```
+
+OpenConnector が同じ Fly organization で動作している場合、runtime origin には Fly のプライベートネットワーク、たとえば
+`http://my-open-connector.internal:3000` を使用できます。console origin は引き続き、ユーザーのブラウザが開ける公開 HTTPS
+origin でなければなりません。
+
+Provider Integration が必要な場合は、callback origin と key を設定します。
+
+```bash
+fly secrets set \
+  OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN="https://my-open-flow.fly.dev" \
+  OPEN_FLOW_INTEGRATION_CALLBACK_KEY="$(openssl rand -hex 32)" \
+  --app my-open-flow
+```
+
+`fly secrets set` は machine を再デプロイします。環境変数の完全な一覧と各 origin の制約については、
+[コンテナ配布リファレンス](../container-delivery.md#4-配置) を参照してください。
+
+## デプロイする
+
+リポジトリのルートからデプロイします。
+
+```bash
+fly deploy --config fly.toml --remote-only --ha=false
+```
+
+`--ha=false` は、Fly が新しい app に 2 台目の machine を作成するのを防ぎます。Server が許可する SQLite の writer は 1 つで、
+各 machine はそれぞれ独自の volume をマウントするため、machine が 2 台あると互いに無関係な 2 つの状態のコピーを保持することに
+なります。以降のすべてのデプロイでも machine 数を 1 に保ち、`fly scale count` で増やさないでください。
+
+Fly の設定では次を使用します。
+
+- イメージのビルドに `apps/server/Dockerfile` を使用し、ビルドコンテキストはリポジトリのルートです。
+- `internal_port = 3000`。イメージのデフォルトです。
+- HTTP ヘルスチェックとして `GET /readyz`。Server の起動中、バックグラウンド処理が停止しているとき、または設定された
+  Connector に到達できないときに 503 を返します。その場合 Fly はその machine へのトラフィックのルーティングを停止し、
+  デプロイを失敗させます。liveness チェックだけで十分な場合はパスを `/healthz` に切り替えてください。
+- `kill_signal = "SIGTERM"` と `kill_timeout = "45s"`。Server は Run のドレインと SQLite のクローズに最大 30 秒待機するため、
+  猶予期間は 30 秒を超えている必要があります。
+- `auto_stop_machines = "off"` と `min_machines_running = 1`。Cron と Poll Trigger は machine が動作している間だけ発火します。
+
+## ランタイムを検証する
+
+```bash
+curl https://my-open-flow.fly.dev/healthz
+curl https://my-open-flow.fly.dev/readyz
+```
+
+期待されるレスポンスは `{"status":"ok"}` と `{"status":"ready"}` です。`https://my-open-flow.fly.dev` を開き、
+`OPEN_FLOW_TOKEN` で Workbench にサインインします。
+
+デプロイや起動の問題を診断するときはログを確認します。
+
+```bash
+fly logs --app my-open-flow
+```
+
+## カスタムドメイン
+
+Fly にドメインを登録します。
+
+```bash
+fly certs add flow.example.com --app my-open-flow
+```
+
+Fly は作成すべき DNS レコードを出力します。DNS の準備ができたら、証明書の状態を確認します。
+
+```bash
+fly certs check flow.example.com --app my-open-flow
+```
+
+Integration callback が設定されている場合は、`OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN` を新しいドメインに向けます。
+
+```bash
+fly secrets set \
+  OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN="https://flow.example.com" \
+  --app my-open-flow
+```
+
+## 更新する
+
+```bash
+git pull
+fly deploy --config fly.toml --remote-only
+```
+
+volume には `open-flow.sqlite` とその WAL および SHM ファイルが保持されます。SQLite のマイグレーションは Server の起動時に
+順番に実行されるため、追加の手順は不要です。
+
+## バックアップ
+
+Fly は volume のスナップショットを自動的に取得しますが、Server が保証するのは quiesced なバックアップだけです。一貫性のある
+バックアップを取るには、スナップショットを作成する前に machine を停止してください。
+
+```bash
+fly machine stop <machine-id> --app my-open-flow
+fly volumes snapshots create <volume-id> --app my-open-flow
+fly machine start <machine-id> --app my-open-flow
+```
+
+各 id は `fly machine list` と `fly volumes list` で確認できます。
+
+## スケーリングとアイドル状態の machine
+
+- machine 数は 1 に保ちます。より多くの容量が必要な場合は、`fly.toml` の `[[vm]]` 配下にある `size` と `memory` を変更して
+  再デプロイしてください。
+- デフォルトは `memory = "1gb"` です。各 Run の Isolated VM はデフォルトで 128 MB に制限され、`OPEN_FLOW_MAX_CONCURRENT_RUNS`
+  のデフォルトは 4 で、Node プロセス自体にもメモリが必要です。メモリは同時実行数の上限と合わせて引き上げてください。
+- 手動の Run と Webhook だけを使用し、コールドスタートを許容できる場合は、`auto_stop_machines = "suspend"` と
+  `min_machines_running = 0` を設定します。machine がサスペンドされている間は Cron と Poll Trigger は発火せず、最初の Webhook
+  リクエストは machine が起動するまで待機します。

--- a/docs/server/fly-io/README.ja.md
+++ b/docs/server/fly-io/README.ja.md
@@ -169,8 +169,12 @@ Fly は volume のスナップショットを自動的に取得しますが、Se
 ```bash
 fly machine stop <machine-id> --app my-open-flow
 fly volumes snapshots create <volume-id> --app my-open-flow
+fly volumes snapshots list <volume-id> --app my-open-flow
 fly machine start <machine-id> --app my-open-flow
 ```
+
+snapshot は非同期に作成されます。`fly volumes snapshots list` で新しい snapshot が `created` と表示されるまで machine を停止したままにし、
+その後で machine を起動してください。
 
 各 id は `fly machine list` と `fly volumes list` で確認できます。
 

--- a/docs/server/fly-io/README.ko.md
+++ b/docs/server/fly-io/README.ko.md
@@ -1,0 +1,190 @@
+# Fly.io 배포
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+Open Flow Server는 Fly.io에서 Node Docker 런타임으로 실행할 수 있습니다. 이 배포는 저장소의
+`apps/server/Dockerfile`, 저장소 루트 `fly.toml`의 Fly app 설정, 그리고 `/data/open-flow`에
+마운트되는 Fly volume을 사용합니다. Fly는 TLS 종료, 원격 Docker 빌드, 헬스 체크, 롤링 배포,
+선택적인 custom domain을 제공합니다.
+
+배포 경계는 [컨테이너 배포 참조](../container-delivery.md)와 동일합니다. Server machine 하나와
+SQLite writer 하나입니다. machine을 두 대 이상 실행하지 마세요.
+
+## 사전 요구 사항
+
+- Fly.io 계정.
+- `flyctl`이 설치되어 있고 `fly auth login`으로 인증되어 있어야 합니다.
+- 로컬에서 Docker를 사용할 수 있거나 Fly remote builder를 사용할 수 있어야 합니다.
+  `apps/server/Dockerfile`은 BuildKit 문법을 사용하며, remote builder는 이를 지원합니다.
+
+## App 만들기
+
+아직 배포하지 않고 Fly app만 만듭니다.
+
+```bash
+fly apps create my-open-flow
+```
+
+Fly app 이름은 전역적으로 고유합니다. 다른 이름을 선택했다면 배포 전에 `fly.toml`의 `app` 필드를
+수정하세요.
+
+```toml
+app = "my-open-flow"
+```
+
+## 영구 스토리지 만들기
+
+이미지는 SQLite를 `/data/open-flow`에 저장합니다. `fly.toml`과 같은 source 이름으로 Fly volume을
+만듭니다.
+
+```bash
+fly volumes create open_flow_data \
+  --region iad \
+  --size 1 \
+  --app my-open-flow
+```
+
+Run 이력과 RunEvent는 시간이 지날수록 늘어납니다. 많은 Run이 예상되면 `--size`를 늘리거나, 나중에
+`fly volumes extend`로 volume을 확장하세요.
+
+## Secret 설정
+
+operator token은 최소 32 UTF-8 바이트를 포함해야 합니다. `fly.toml`에 커밋하는 대신 Fly secret으로
+저장하세요.
+
+```bash
+OPEN_FLOW_TOKEN="$(openssl rand -hex 32)"
+
+fly secrets set \
+  OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN" \
+  --app my-open-flow
+```
+
+`OPEN_FLOW_TOKEN`은 비밀번호 관리자에 보관하세요. 같은 값으로 Workbench에 로그인하며, Control API의
+Bearer token으로도 사용할 수 있습니다.
+
+`fly.toml`은 이미 `OPEN_FLOW_SESSION_COOKIE_SECURE`를 `true`로 설정합니다. `force_https`가 일반 HTTP
+요청을 리디렉션하므로 브라우저는 TLS를 통해서만 Server에 접근합니다.
+
+Connector가 필요하면 Connector secret을 설정합니다.
+
+```bash
+fly secrets set \
+  OPEN_FLOW_CONNECTOR_ORIGIN="https://connector.example.com" \
+  OPEN_FLOW_CONNECTOR_TOKEN="replace-with-a-scoped-runtime-token" \
+  OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="https://connector.example.com" \
+  --app my-open-flow
+```
+
+OpenConnector가 같은 Fly organization에서 실행 중이면 runtime origin은
+`http://my-open-connector.internal:3000`처럼 Fly 프라이빗 네트워크를 사용할 수 있습니다. console
+origin은 여전히 사용자의 브라우저가 열 수 있는 공개 HTTPS origin이어야 합니다.
+
+Provider Integration이 필요하면 콜백 origin과 key를 설정합니다.
+
+```bash
+fly secrets set \
+  OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN="https://my-open-flow.fly.dev" \
+  OPEN_FLOW_INTEGRATION_CALLBACK_KEY="$(openssl rand -hex 32)" \
+  --app my-open-flow
+```
+
+`fly secrets set`은 machine을 다시 배포합니다. 전체 환경 변수 목록과 각 origin의 제약은
+[컨테이너 배포 참조](../container-delivery.md#4-配置)를 참고하세요.
+
+## 배포
+
+저장소 루트에서 배포합니다.
+
+```bash
+fly deploy --config fly.toml --remote-only --ha=false
+```
+
+`--ha=false`는 Fly가 새 app에 두 번째 machine을 만들지 않도록 합니다. Server는 SQLite writer를 하나만
+허용하고 각 machine은 자체 volume을 마운트하므로, machine이 두 대이면 서로 무관한 상태 복사본 두 개를
+갖게 됩니다. 이후 모든 배포에서도 machine 수를 하나로 유지하고 `fly scale count`로 늘리지 마세요.
+
+Fly 설정은 다음을 사용합니다.
+
+- 이미지 빌드에 `apps/server/Dockerfile`을 사용하며, 저장소 루트가 빌드 컨텍스트입니다.
+- 이미지 기본값인 `internal_port = 3000`.
+- HTTP 헬스 체크로 `GET /readyz`. Server가 시작 중이거나, 백그라운드 처리가 중지되었거나, 구성된
+  Connector에 연결할 수 없으면 503을 반환합니다. 그러면 Fly는 해당 machine으로의 트래픽 라우팅을
+  중단하고 배포를 실패 처리합니다. liveness 체크만 원한다면 경로를 `/healthz`로 바꾸세요.
+- `kill_signal = "SIGTERM"`과 `kill_timeout = "45s"`. Server는 Run을 드레인하고 SQLite를 닫기 위해
+  최대 30초를 기다리므로 유예 기간은 30초보다 길어야 합니다.
+- `auto_stop_machines = "off"`와 `min_machines_running = 1`. Cron과 Poll Trigger는 machine이 실행
+  중일 때만 발생합니다.
+
+## 런타임 확인
+
+```bash
+curl https://my-open-flow.fly.dev/healthz
+curl https://my-open-flow.fly.dev/readyz
+```
+
+예상 응답은 `{"status":"ok"}`와 `{"status":"ready"}`입니다. `https://my-open-flow.fly.dev`를 열고
+`OPEN_FLOW_TOKEN`으로 Workbench에 로그인합니다.
+
+배포나 시작 문제를 진단할 때는 로그를 확인합니다.
+
+```bash
+fly logs --app my-open-flow
+```
+
+## Custom Domain
+
+Fly에 도메인을 등록합니다.
+
+```bash
+fly certs add flow.example.com --app my-open-flow
+```
+
+Fly가 생성해야 할 DNS 레코드를 출력합니다. DNS가 준비되면 인증서 상태를 확인합니다.
+
+```bash
+fly certs check flow.example.com --app my-open-flow
+```
+
+Integration 콜백이 구성되어 있다면 `OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN`이 새 도메인을 가리키도록
+설정합니다.
+
+```bash
+fly secrets set \
+  OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN="https://flow.example.com" \
+  --app my-open-flow
+```
+
+## 업데이트
+
+```bash
+git pull
+fly deploy --config fly.toml --remote-only
+```
+
+volume은 `open-flow.sqlite`와 그 WAL, SHM 파일을 유지합니다. SQLite 마이그레이션은 Server가 시작될 때
+순서대로 실행되므로 추가 단계가 필요 없습니다.
+
+## 백업
+
+Fly는 volume 스냅샷을 자동으로 생성하지만, Server는 정지 상태에서의 백업만 보장합니다. 일관된 백업을
+위해 스냅샷을 만들기 전에 machine을 중지하세요.
+
+```bash
+fly machine stop <machine-id> --app my-open-flow
+fly volumes snapshots create <volume-id> --app my-open-flow
+fly machine start <machine-id> --app my-open-flow
+```
+
+id는 `fly machine list`와 `fly volumes list`로 찾을 수 있습니다.
+
+## 스케일링과 유휴 Machine
+
+- machine 수는 하나로 유지하세요. 더 많은 용량이 필요하면 `fly.toml`의 `[[vm]]` 아래 `size`와
+  `memory`를 변경하고 다시 배포하세요.
+- 기본값은 `memory = "1gb"`입니다. 각 Run의 Isolated VM은 기본적으로 128 MB로 제한되고,
+  `OPEN_FLOW_MAX_CONCURRENT_RUNS`의 기본값은 4이며, Node 프로세스에도 자체 메모리가 필요합니다.
+  메모리는 동시성 제한과 함께 올리세요.
+- 수동 Run과 Webhook만 사용하고 콜드 스타트를 감수할 수 있다면 `auto_stop_machines = "suspend"`와
+  `min_machines_running = 0`으로 설정하세요. machine이 일시 중지된 동안에는 Cron과 Poll Trigger가
+  발생하지 않으며, 첫 Webhook 요청은 machine이 깨어날 때까지 기다립니다.

--- a/docs/server/fly-io/README.ko.md
+++ b/docs/server/fly-io/README.ko.md
@@ -173,8 +173,12 @@ Fly는 volume 스냅샷을 자동으로 생성하지만, Server는 정지 상태
 ```bash
 fly machine stop <machine-id> --app my-open-flow
 fly volumes snapshots create <volume-id> --app my-open-flow
+fly volumes snapshots list <volume-id> --app my-open-flow
 fly machine start <machine-id> --app my-open-flow
 ```
+
+snapshot은 비동기로 생성됩니다. `fly volumes snapshots list`에서 새 snapshot이 `created`로 표시될 때까지 machine을 중지 상태로
+유지한 뒤 machine을 시작하세요.
 
 id는 `fly machine list`와 `fly volumes list`로 찾을 수 있습니다.
 

--- a/docs/server/fly-io/README.md
+++ b/docs/server/fly-io/README.md
@@ -1,0 +1,193 @@
+# Fly.io Deployment
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+Open Flow Server can run on Fly.io as the Node Docker runtime. This deployment uses the repository's
+`apps/server/Dockerfile`, the Fly app config in `fly.toml` at the repository root, and a Fly volume
+mounted at `/data/open-flow`. Fly provides TLS termination, remote Docker builds, health checks,
+rolling deploys, and optional custom domains.
+
+The deployment boundary is the same as in the [container delivery reference](../container-delivery.md):
+one Server machine and one SQLite writer. Never run more than one machine.
+
+## Prerequisites
+
+- A Fly.io account.
+- `flyctl` installed and authenticated with `fly auth login`.
+- Docker available locally, or Fly remote builders. `apps/server/Dockerfile` uses BuildKit syntax,
+  which remote builders support.
+
+## Create The App
+
+Create a Fly app without deploying yet:
+
+```bash
+fly apps create my-open-flow
+```
+
+Fly app names are globally unique. If you choose a different name, update the `app` field in
+`fly.toml` before deploying:
+
+```toml
+app = "my-open-flow"
+```
+
+## Create Persistent Storage
+
+The image stores SQLite in `/data/open-flow`. Create a Fly volume with the same source name as
+`fly.toml`:
+
+```bash
+fly volumes create open_flow_data \
+  --region iad \
+  --size 1 \
+  --app my-open-flow
+```
+
+Run history and RunEvents grow over time. Increase `--size` if you expect many Runs, or extend the
+volume later with `fly volumes extend`.
+
+## Set Secrets
+
+The operator token must contain at least 32 UTF-8 bytes. Store it as a Fly secret instead of
+committing it to `fly.toml`:
+
+```bash
+OPEN_FLOW_TOKEN="$(openssl rand -hex 32)"
+
+fly secrets set \
+  OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN" \
+  --app my-open-flow
+```
+
+Keep `OPEN_FLOW_TOKEN` in a password manager. The same value signs in to the Workbench and works as
+the Bearer token for the Control API.
+
+`fly.toml` already sets `OPEN_FLOW_SESSION_COOKIE_SECURE` to `true`: `force_https` redirects plain
+HTTP requests, so browsers only reach the Server over TLS.
+
+Set the Connector secrets when you need a Connector:
+
+```bash
+fly secrets set \
+  OPEN_FLOW_CONNECTOR_ORIGIN="https://connector.example.com" \
+  OPEN_FLOW_CONNECTOR_TOKEN="replace-with-a-scoped-runtime-token" \
+  OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="https://connector.example.com" \
+  --app my-open-flow
+```
+
+When OpenConnector runs in the same Fly organization, the runtime origin can use the Fly private
+network, for example `http://my-open-connector.internal:3000`. The console origin must still be a
+public HTTPS origin that users' browsers can open.
+
+Set the callback origin and key when you need Provider Integrations:
+
+```bash
+fly secrets set \
+  OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN="https://my-open-flow.fly.dev" \
+  OPEN_FLOW_INTEGRATION_CALLBACK_KEY="$(openssl rand -hex 32)" \
+  --app my-open-flow
+```
+
+`fly secrets set` redeploys the machine. See the
+[container delivery reference](../container-delivery.md#4-配置) for the full environment variable list
+and the constraints on each origin.
+
+## Deploy
+
+Deploy from the repository root:
+
+```bash
+fly deploy --config fly.toml --remote-only --ha=false
+```
+
+`--ha=false` stops Fly from creating a second machine for a new app. The Server allows one SQLite
+writer, and each machine mounts its own volume, so two machines would hold two unrelated copies of
+the state. Keep the machine count at one on every later deploy and never raise it with
+`fly scale count`.
+
+The Fly config uses:
+
+- `apps/server/Dockerfile` for the image build, with the repository root as the build context.
+- `internal_port = 3000`, the image default.
+- `GET /readyz` as the HTTP health check. It returns 503 while the Server is starting, when
+  background processing has stopped, or when the configured Connector is unreachable; Fly then stops
+  routing traffic to the machine and fails the deploy. Switch the path to `/healthz` if you only
+  want a liveness check.
+- `kill_signal = "SIGTERM"` and `kill_timeout = "45s"`. The Server waits up to 30 seconds to drain
+  Runs and close SQLite, so the grace period must exceed 30 seconds.
+- `auto_stop_machines = "off"` and `min_machines_running = 1`. Cron and Poll Triggers only fire while
+  the machine is running.
+
+## Verify The Runtime
+
+```bash
+curl https://my-open-flow.fly.dev/healthz
+curl https://my-open-flow.fly.dev/readyz
+```
+
+The expected responses are `{"status":"ok"}` and `{"status":"ready"}`. Open
+`https://my-open-flow.fly.dev` and sign in to the Workbench with `OPEN_FLOW_TOKEN`.
+
+View logs when diagnosing deployment or startup issues:
+
+```bash
+fly logs --app my-open-flow
+```
+
+## Custom Domain
+
+Register the domain with Fly:
+
+```bash
+fly certs add flow.example.com --app my-open-flow
+```
+
+Fly prints the DNS records to create. After DNS is ready, check certificate status:
+
+```bash
+fly certs check flow.example.com --app my-open-flow
+```
+
+If Integration callbacks are configured, point `OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN` at the new
+domain:
+
+```bash
+fly secrets set \
+  OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN="https://flow.example.com" \
+  --app my-open-flow
+```
+
+## Updating
+
+```bash
+git pull
+fly deploy --config fly.toml --remote-only
+```
+
+The volume keeps `open-flow.sqlite` and its WAL and SHM files. SQLite migrations run in order when
+the Server starts; no extra step is needed.
+
+## Backup
+
+Fly takes volume snapshots automatically, but the Server only promises quiesced backups. For a
+consistent backup, stop the machine before creating a snapshot:
+
+```bash
+fly machine stop <machine-id> --app my-open-flow
+fly volumes snapshots create <volume-id> --app my-open-flow
+fly machine start <machine-id> --app my-open-flow
+```
+
+Find the ids with `fly machine list` and `fly volumes list`.
+
+## Scaling And Idle Machines
+
+- Keep the machine count at one. For more capacity, change `size` and `memory` under `[[vm]]` in
+  `fly.toml` and redeploy.
+- The default is `memory = "1gb"`. Each Run's Isolated VM is capped at 128 MB by default,
+  `OPEN_FLOW_MAX_CONCURRENT_RUNS` defaults to 4, and the Node process needs memory of its own. Raise
+  the memory together with the concurrency limit.
+- If you only use manual Runs and Webhooks and accept cold starts, set
+  `auto_stop_machines = "suspend"` and `min_machines_running = 0`. Cron and Poll Triggers do not fire
+  while the machine is suspended, and the first Webhook request waits for the machine to wake up.

--- a/docs/server/fly-io/README.md
+++ b/docs/server/fly-io/README.md
@@ -176,8 +176,12 @@ consistent backup, stop the machine before creating a snapshot:
 ```bash
 fly machine stop <machine-id> --app my-open-flow
 fly volumes snapshots create <volume-id> --app my-open-flow
+fly volumes snapshots list <volume-id> --app my-open-flow
 fly machine start <machine-id> --app my-open-flow
 ```
+
+The snapshot is created asynchronously. Keep the machine stopped until
+`fly volumes snapshots list` shows the new snapshot as `created`, then start the machine again.
 
 Find the ids with `fly machine list` and `fly volumes list`.
 

--- a/docs/server/fly-io/README.ru.md
+++ b/docs/server/fly-io/README.ru.md
@@ -176,8 +176,12 @@ Fly автоматически создаёт снимки volume, но Server �
 ```bash
 fly machine stop <machine-id> --app my-open-flow
 fly volumes snapshots create <volume-id> --app my-open-flow
+fly volumes snapshots list <volume-id> --app my-open-flow
 fly machine start <machine-id> --app my-open-flow
 ```
+
+Snapshot создаётся асинхронно. Держите machine остановленной, пока `fly volumes snapshots list` не
+покажет новый snapshot в состоянии `created`, затем запустите machine.
 
 Идентификаторы можно найти с помощью `fly machine list` и `fly volumes list`.
 

--- a/docs/server/fly-io/README.ru.md
+++ b/docs/server/fly-io/README.ru.md
@@ -1,0 +1,193 @@
+# Развёртывание на Fly.io
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+Open Flow Server может работать на Fly.io как Node Docker runtime. Этот deployment использует
+`apps/server/Dockerfile` из репозитория, конфигурацию Fly app в `fly.toml` в корне репозитория и Fly
+volume, смонтированный в `/data/open-flow`. Fly обеспечивает терминацию TLS, удалённые сборки Docker,
+health check, rolling deploy и опциональные custom domain.
+
+Граница deployment та же, что и в [справочнике по доставке контейнера](../container-delivery.md):
+одна machine Server и один writer SQLite. Никогда не запускайте больше одной machine.
+
+## Предварительные требования
+
+- Аккаунт Fly.io.
+- Установленный `flyctl`, авторизованный через `fly auth login`.
+- Docker, доступный локально, или Fly remote builder. `apps/server/Dockerfile` использует синтаксис
+  BuildKit, который remote builder поддерживают.
+
+## Создание app
+
+Создайте Fly app, пока не развёртывая его:
+
+```bash
+fly apps create my-open-flow
+```
+
+Имена Fly app глобально уникальны. Если вы выбрали другое имя, обновите поле `app` в `fly.toml`
+перед развёртыванием:
+
+```toml
+app = "my-open-flow"
+```
+
+## Создание постоянного хранилища
+
+Образ хранит SQLite в `/data/open-flow`. Создайте Fly volume с тем же именем source, что и в
+`fly.toml`:
+
+```bash
+fly volumes create open_flow_data \
+  --region iad \
+  --size 1 \
+  --app my-open-flow
+```
+
+История Run и RunEvent растут со временем. Увеличьте `--size`, если ожидаете много Run, или расширьте
+volume позже с помощью `fly volumes extend`.
+
+## Настройка secrets
+
+Operator token должен содержать не менее 32 байт UTF-8. Храните его как Fly secret, а не коммитьте
+в `fly.toml`:
+
+```bash
+OPEN_FLOW_TOKEN="$(openssl rand -hex 32)"
+
+fly secrets set \
+  OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN" \
+  --app my-open-flow
+```
+
+Храните `OPEN_FLOW_TOKEN` в менеджере паролей. То же значение используется для входа в Workbench и
+работает как Bearer token для Control API.
+
+`fly.toml` уже устанавливает `OPEN_FLOW_SESSION_COOKIE_SECURE` в `true`: `force_https` перенаправляет
+обычные HTTP-запросы, поэтому браузеры обращаются к Server только по TLS.
+
+Задайте secrets Connector, когда вам нужен Connector:
+
+```bash
+fly secrets set \
+  OPEN_FLOW_CONNECTOR_ORIGIN="https://connector.example.com" \
+  OPEN_FLOW_CONNECTOR_TOKEN="replace-with-a-scoped-runtime-token" \
+  OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="https://connector.example.com" \
+  --app my-open-flow
+```
+
+Когда OpenConnector работает в той же организации Fly, runtime origin может использовать приватную
+сеть Fly, например `http://my-open-connector.internal:3000`. Console origin по-прежнему должен быть
+публичным HTTPS origin, который могут открыть браузеры пользователей.
+
+Задайте callback origin и ключ, когда вам нужны Provider Integration:
+
+```bash
+fly secrets set \
+  OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN="https://my-open-flow.fly.dev" \
+  OPEN_FLOW_INTEGRATION_CALLBACK_KEY="$(openssl rand -hex 32)" \
+  --app my-open-flow
+```
+
+`fly secrets set` повторно развёртывает machine. Полный список переменных окружения и ограничения
+для каждого origin см. в [справочнике по доставке контейнера](../container-delivery.md#4-配置).
+
+## Развёртывание
+
+Выполните развёртывание из корня репозитория:
+
+```bash
+fly deploy --config fly.toml --remote-only --ha=false
+```
+
+`--ha=false` не даёт Fly создать вторую machine для нового app. Server допускает одного writer
+SQLite, и каждая machine монтирует собственный volume, поэтому две machine хранили бы две несвязанные
+копии состояния. Сохраняйте число machine равным одной при каждом последующем развёртывании и
+никогда не увеличивайте его через `fly scale count`.
+
+Конфигурация Fly использует:
+
+- `apps/server/Dockerfile` для сборки образа, с корнем репозитория в качестве build context.
+- `internal_port = 3000`, значение по умолчанию для образа.
+- `GET /readyz` в качестве HTTP health check. Он возвращает 503, пока Server запускается, когда
+  фоновая обработка остановлена или когда настроенный Connector недоступен; после этого Fly перестаёт
+  направлять трафик на machine и завершает развёртывание с ошибкой. Замените путь на `/healthz`, если
+  вам нужна только liveness-проверка.
+- `kill_signal = "SIGTERM"` и `kill_timeout = "45s"`. Server ждёт до 30 секунд, чтобы завершить Run и
+  закрыть SQLite, поэтому grace period должен превышать 30 секунд.
+- `auto_stop_machines = "off"` и `min_machines_running = 1`. Cron и Poll Trigger срабатывают, только
+  пока machine работает.
+
+## Проверка runtime
+
+```bash
+curl https://my-open-flow.fly.dev/healthz
+curl https://my-open-flow.fly.dev/readyz
+```
+
+Ожидаемые ответы: `{"status":"ok"}` и `{"status":"ready"}`. Откройте `https://my-open-flow.fly.dev`
+и войдите в Workbench, указав `OPEN_FLOW_TOKEN`.
+
+Просматривайте логи при диагностике проблем с развёртыванием или запуском:
+
+```bash
+fly logs --app my-open-flow
+```
+
+## Custom domain
+
+Зарегистрируйте домен в Fly:
+
+```bash
+fly certs add flow.example.com --app my-open-flow
+```
+
+Fly выведет DNS-записи, которые нужно создать. Когда DNS будет готов, проверьте состояние
+сертификата:
+
+```bash
+fly certs check flow.example.com --app my-open-flow
+```
+
+Если настроены Integration callback, направьте `OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN` на новый домен:
+
+```bash
+fly secrets set \
+  OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN="https://flow.example.com" \
+  --app my-open-flow
+```
+
+## Обновление
+
+```bash
+git pull
+fly deploy --config fly.toml --remote-only
+```
+
+Volume сохраняет `open-flow.sqlite` вместе с его файлами WAL и SHM. Миграции SQLite выполняются по
+порядку при запуске Server; дополнительных шагов не требуется.
+
+## Резервное копирование
+
+Fly автоматически создаёт снимки volume, но Server гарантирует только резервные копии в
+остановленном состоянии. Для согласованной резервной копии остановите machine перед созданием
+снимка:
+
+```bash
+fly machine stop <machine-id> --app my-open-flow
+fly volumes snapshots create <volume-id> --app my-open-flow
+fly machine start <machine-id> --app my-open-flow
+```
+
+Идентификаторы можно найти с помощью `fly machine list` и `fly volumes list`.
+
+## Масштабирование и простаивающие machine
+
+- Сохраняйте число machine равным одной. Для большей ёмкости измените `size` и `memory` в секции
+  `[[vm]]` в `fly.toml` и повторно разверните приложение.
+- По умолчанию `memory = "1gb"`. Isolated VM каждого Run по умолчанию ограничена 128 МБ,
+  `OPEN_FLOW_MAX_CONCURRENT_RUNS` по умолчанию равен 4, а процессу Node нужна собственная память.
+  Увеличивайте память вместе с лимитом параллелизма.
+- Если вы используете только ручные Run и Webhook и готовы мириться с холодными стартами, задайте
+  `auto_stop_machines = "suspend"` и `min_machines_running = 0`. Cron и Poll Trigger не срабатывают,
+  пока machine приостановлена, а первый запрос Webhook ждёт пробуждения machine.

--- a/docs/server/fly-io/README.zh-CN.md
+++ b/docs/server/fly-io/README.zh-CN.md
@@ -1,0 +1,164 @@
+# Fly.io 部署
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+Open Flow Server 可以作为 Node Docker runtime 部署到 Fly.io。本部署使用仓库的 `apps/server/Dockerfile`、根目录的 `fly.toml`，以及挂载到
+`/data/open-flow` 的 Fly volume。Fly 负责 TLS 终止、远程 Docker 构建、健康检查、滚动部署和可选的自定义域名。
+
+部署边界与[容器交付参考](../container-delivery.md)相同：单个 Server machine、单个 SQLite writer。machine 数量不能超过 1。
+
+## 1. 前提
+
+- Fly.io 账号。
+- 已安装 `flyctl` 并通过 `fly auth login` 登录。
+- 本地 Docker，或使用 Fly remote builder。`apps/server/Dockerfile` 使用 BuildKit 语法，remote builder 支持该语法。
+
+## 2. 创建应用
+
+先创建应用，不立即部署：
+
+```bash
+fly apps create my-open-flow
+```
+
+Fly app 名称全局唯一。使用其他名称时，部署前更新 `fly.toml` 的 `app` 字段：
+
+```toml
+app = "my-open-flow"
+```
+
+## 3. 创建数据卷
+
+镜像把 SQLite 保存在 `/data/open-flow`。创建与 `fly.toml` 中 `source` 同名的 volume：
+
+```bash
+fly volumes create open_flow_data \
+  --region iad \
+  --size 1 \
+  --app my-open-flow
+```
+
+Run 历史和 RunEvent 会持续占用空间。预期 Run 量较大时增大 `--size`，或之后用 `fly volumes extend` 扩容。
+
+## 4. 设置 secret
+
+operator token 至少包含 32 UTF-8 bytes，通过 Fly secret 注入，不要写进 `fly.toml`：
+
+```bash
+OPEN_FLOW_TOKEN="$(openssl rand -hex 32)"
+
+fly secrets set \
+  OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN" \
+  --app my-open-flow
+```
+
+把 `OPEN_FLOW_TOKEN` 保存到密码管理器。它同时用于 Workbench 登录和 Control API 的 Bearer token。
+
+`fly.toml` 已把 `OPEN_FLOW_SESSION_COOKIE_SECURE` 设为 `true`：`force_https` 会把明文请求重定向到 HTTPS，浏览器只通过 TLS 访问 Server。
+
+需要 Connector 时再设置以下 secret：
+
+```bash
+fly secrets set \
+  OPEN_FLOW_CONNECTOR_ORIGIN="https://connector.example.com" \
+  OPEN_FLOW_CONNECTOR_TOKEN="replace-with-a-scoped-runtime-token" \
+  OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="https://connector.example.com" \
+  --app my-open-flow
+```
+
+OpenConnector 部署在同一个 Fly 组织时，runtime origin 可以使用 Fly 私有网络地址，例如 `http://my-open-connector.internal:3000`；
+console origin 仍然必须是用户浏览器可访问的 HTTPS 公网地址。
+
+需要 Provider Integration 时再设置 callback origin 和 key：
+
+```bash
+fly secrets set \
+  OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN="https://my-open-flow.fly.dev" \
+  OPEN_FLOW_INTEGRATION_CALLBACK_KEY="$(openssl rand -hex 32)" \
+  --app my-open-flow
+```
+
+`fly secrets set` 会重新部署 machine。完整环境变量和各 origin 的约束见[容器交付参考](../container-delivery.md#4-配置)。
+
+## 5. 部署
+
+从仓库根目录部署：
+
+```bash
+fly deploy --config fly.toml --remote-only --ha=false
+```
+
+`--ha=false` 阻止 Fly 为新应用创建第二台 machine。Server 只允许一个 SQLite writer，而每台 machine 各自挂载独立 volume，两台 machine 会持有两份互不
+相干的状态。之后的每次部署都保持 machine 数量为 1，不要用 `fly scale count` 超过 1。
+
+`fly.toml` 使用：
+
+- `apps/server/Dockerfile` 构建镜像，构建上下文是仓库根目录；
+- `internal_port = 3000` 对应镜像默认端口；
+- `GET /readyz` 作为 HTTP 健康检查。Server 未启动、后台处理停止或配置的 Connector 不可用时返回 503，Fly 停止向该 machine 转发流量并让部署失败。
+  只需要进程存活检查时可改为 `/healthz`；
+- `kill_signal = "SIGTERM"` 和 `kill_timeout = "45s"`。Server 收到信号后最多等待 30 秒完成 Run drain 和 SQLite 关闭，宽限期必须大于 30 秒；
+- `auto_stop_machines = "off"` 和 `min_machines_running = 1`。Cron 和 Poll Trigger 只在 machine 运行时触发。
+
+## 6. 验证
+
+```bash
+curl https://my-open-flow.fly.dev/healthz
+curl https://my-open-flow.fly.dev/readyz
+```
+
+预期分别返回 `{"status":"ok"}` 和 `{"status":"ready"}`。打开 `https://my-open-flow.fly.dev`，用 `OPEN_FLOW_TOKEN` 登录 Workbench。
+
+诊断部署或启动问题时查看日志：
+
+```bash
+fly logs --app my-open-flow
+```
+
+## 7. 自定义域名
+
+```bash
+fly certs add flow.example.com --app my-open-flow
+```
+
+按 Fly 输出创建 DNS 记录后检查证书状态：
+
+```bash
+fly certs check flow.example.com --app my-open-flow
+```
+
+配置了 Integration callback 时，把 `OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN` 更新为新域名：
+
+```bash
+fly secrets set \
+  OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN="https://flow.example.com" \
+  --app my-open-flow
+```
+
+## 8. 更新
+
+```bash
+git pull
+fly deploy --config fly.toml --remote-only
+```
+
+volume 保留 `open-flow.sqlite` 及其 WAL/SHM 文件。SQLite migration 在 Server 启动时按顺序执行，不需要额外步骤。
+
+## 9. 备份
+
+Fly 会自动创建 volume snapshot，但 Server 只承诺 quiesced backup。需要一致备份时先停止 machine，再创建 snapshot：
+
+```bash
+fly machine stop <machine-id> --app my-open-flow
+fly volumes snapshots create <volume-id> --app my-open-flow
+fly machine start <machine-id> --app my-open-flow
+```
+
+machine id 和 volume id 分别来自 `fly machine list` 和 `fly volumes list`。
+
+## 10. 扩缩容与休眠
+
+- 保持 machine 数量为 1。需要更多资源时调整 `fly.toml` 中 `[[vm]]` 的 `size` 和 `memory`，然后重新部署。
+- 默认 `memory = "1gb"`。每个 Run 的 Isolated VM 默认上限 128 MB，`OPEN_FLOW_MAX_CONCURRENT_RUNS` 默认 4，再加上 Node 进程本身。提高并发时同步提高内存。
+- 只使用手动 Run 和 Webhook、且可以接受冷启动时，可改为 `auto_stop_machines = "suspend"` 和 `min_machines_running = 0`。machine 休眠期间 Cron 和
+  Poll Trigger 不会触发，首个 Webhook 请求要等待 machine 唤醒。

--- a/docs/server/fly-io/README.zh-CN.md
+++ b/docs/server/fly-io/README.zh-CN.md
@@ -151,8 +151,11 @@ Fly 会自动创建 volume snapshot，但 Server 只承诺 quiesced backup。需
 ```bash
 fly machine stop <machine-id> --app my-open-flow
 fly volumes snapshots create <volume-id> --app my-open-flow
+fly volumes snapshots list <volume-id> --app my-open-flow
 fly machine start <machine-id> --app my-open-flow
 ```
+
+snapshot 异步创建。保持 machine 停止，直到 `fly volumes snapshots list` 显示新 snapshot 的状态为 `created`，再启动 machine。
 
 machine id 和 volume id 分别来自 `fly machine list` 和 `fly volumes list`。
 

--- a/docs/server/fly-io/README.zh-TW.md
+++ b/docs/server/fly-io/README.zh-TW.md
@@ -1,0 +1,172 @@
+# Fly.io 部署
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+Open Flow Server 可以作為 Node Docker runtime 部署到 Fly.io。本部署使用儲存庫的 `apps/server/Dockerfile`、儲存庫根目錄的
+Fly app 設定檔 `fly.toml`，以及掛載到 `/data/open-flow` 的 Fly volume。Fly 負責 TLS 終止、遠端 Docker 建置、健康檢查、
+滾動部署和選用的自訂網域。
+
+部署邊界與[容器交付參考](../container-delivery.md)相同：單一 Server machine、單一 SQLite writer。machine 數量不可超過 1。
+
+## 前提條件
+
+- Fly.io 帳號。
+- 已安裝 `flyctl`，並透過 `fly auth login` 完成登入。
+- 本機可用的 Docker，或使用 Fly remote builder。`apps/server/Dockerfile` 使用 BuildKit 語法，remote builder 支援該語法。
+
+## 建立 App
+
+先建立 Fly app，暫不部署：
+
+```bash
+fly apps create my-open-flow
+```
+
+Fly app 名稱全域唯一。如果選用其他名稱，部署前請更新 `fly.toml` 中的 `app` 欄位：
+
+```toml
+app = "my-open-flow"
+```
+
+## 建立持久化儲存
+
+映像檔把 SQLite 保存在 `/data/open-flow`。建立與 `fly.toml` 中 source 同名的 Fly volume：
+
+```bash
+fly volumes create open_flow_data \
+  --region iad \
+  --size 1 \
+  --app my-open-flow
+```
+
+Run 歷史和 RunEvent 會隨時間持續增長。預期 Run 數量較多時請加大 `--size`，或之後用 `fly volumes extend` 擴充 volume。
+
+## 設定 secret
+
+operator token 至少要包含 32 個 UTF-8 bytes。請把它儲存為 Fly secret，不要提交到 `fly.toml` 中：
+
+```bash
+OPEN_FLOW_TOKEN="$(openssl rand -hex 32)"
+
+fly secrets set \
+  OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN" \
+  --app my-open-flow
+```
+
+請把 `OPEN_FLOW_TOKEN` 保存在密碼管理器中。同一個值既用於登入 Workbench，也作為 Control API 的 Bearer token。
+
+`fly.toml` 已把 `OPEN_FLOW_SESSION_COOKIE_SECURE` 設為 `true`：`force_https` 會重新導向明文 HTTP 請求，因此瀏覽器只會透過
+TLS 存取 Server。
+
+需要 Connector 時再設定 Connector secret：
+
+```bash
+fly secrets set \
+  OPEN_FLOW_CONNECTOR_ORIGIN="https://connector.example.com" \
+  OPEN_FLOW_CONNECTOR_TOKEN="replace-with-a-scoped-runtime-token" \
+  OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="https://connector.example.com" \
+  --app my-open-flow
+```
+
+OpenConnector 執行在同一個 Fly organization 時，runtime origin 可以使用 Fly 私有網路，例如
+`http://my-open-connector.internal:3000`。console origin 仍然必須是使用者瀏覽器可以開啟的公開 HTTPS origin。
+
+需要 Provider Integration 時再設定 callback origin 和 key：
+
+```bash
+fly secrets set \
+  OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN="https://my-open-flow.fly.dev" \
+  OPEN_FLOW_INTEGRATION_CALLBACK_KEY="$(openssl rand -hex 32)" \
+  --app my-open-flow
+```
+
+`fly secrets set` 會重新部署 machine。完整的環境變數清單和各 origin 的限制請參閱
+[容器交付參考](../container-delivery.md#4-配置)。
+
+## 部署
+
+從儲存庫根目錄部署：
+
+```bash
+fly deploy --config fly.toml --remote-only --ha=false
+```
+
+`--ha=false` 可阻止 Fly 為新 app 建立第二台 machine。Server 只允許一個 SQLite writer，而每台 machine 各自掛載獨立的 volume，
+因此兩台 machine 會持有兩份互不相關的狀態。之後每次部署都要保持 machine 數量為 1，也不要用 `fly scale count` 提高數量。
+
+Fly 設定使用：
+
+- `apps/server/Dockerfile` 建置映像檔，建置上下文為儲存庫根目錄。
+- `internal_port = 3000`，即映像檔的預設連接埠。
+- `GET /readyz` 作為 HTTP 健康檢查。Server 啟動中、背景處理已停止或設定的 Connector 無法連線時，它會回傳 503；Fly 隨即停止把流量
+  轉發到該 machine，並讓部署失敗。只需要存活檢查時，可把路徑改為 `/healthz`。
+- `kill_signal = "SIGTERM"` 和 `kill_timeout = "45s"`。Server 最多等待 30 秒完成 Run drain 並關閉 SQLite，因此寬限期必須超過
+  30 秒。
+- `auto_stop_machines = "off"` 和 `min_machines_running = 1`。Cron 和 Poll Trigger 只在 machine 執行期間觸發。
+
+## 驗證執行環境
+
+```bash
+curl https://my-open-flow.fly.dev/healthz
+curl https://my-open-flow.fly.dev/readyz
+```
+
+預期回應分別為 `{"status":"ok"}` 和 `{"status":"ready"}`。開啟 `https://my-open-flow.fly.dev`，用 `OPEN_FLOW_TOKEN` 登入
+Workbench。
+
+診斷部署或啟動問題時查看日誌：
+
+```bash
+fly logs --app my-open-flow
+```
+
+## 自訂網域
+
+向 Fly 註冊網域：
+
+```bash
+fly certs add flow.example.com --app my-open-flow
+```
+
+Fly 會列出需要建立的 DNS 記錄。DNS 就緒後，檢查憑證狀態：
+
+```bash
+fly certs check flow.example.com --app my-open-flow
+```
+
+若已設定 Integration callback，請把 `OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN` 指向新網域：
+
+```bash
+fly secrets set \
+  OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN="https://flow.example.com" \
+  --app my-open-flow
+```
+
+## 更新
+
+```bash
+git pull
+fly deploy --config fly.toml --remote-only
+```
+
+volume 會保留 `open-flow.sqlite` 及其 WAL 和 SHM 檔案。SQLite migration 會在 Server 啟動時依序執行，不需要額外步驟。
+
+## 備份
+
+Fly 會自動建立 volume snapshot，但 Server 只承諾 quiesced backup。需要一致的備份時，請先停止 machine，再建立 snapshot：
+
+```bash
+fly machine stop <machine-id> --app my-open-flow
+fly volumes snapshots create <volume-id> --app my-open-flow
+fly machine start <machine-id> --app my-open-flow
+```
+
+id 可透過 `fly machine list` 和 `fly volumes list` 取得。
+
+## 擴縮容與閒置 machine
+
+- 保持 machine 數量為 1。需要更多容量時，修改 `fly.toml` 中 `[[vm]]` 下的 `size` 和 `memory`，然後重新部署。
+- 預設為 `memory = "1gb"`。每個 Run 的 Isolated VM 預設上限為 128 MB，`OPEN_FLOW_MAX_CONCURRENT_RUNS` 預設為 4，Node 程序本身也
+  需要記憶體。提高並行上限時請一併提高記憶體。
+- 如果只使用手動 Run 和 Webhook，而且可以接受冷啟動，可設定 `auto_stop_machines = "suspend"` 和 `min_machines_running = 0`。
+  machine 暫停期間 Cron 和 Poll Trigger 不會觸發，首個 Webhook 請求要等待 machine 喚醒。

--- a/docs/server/fly-io/README.zh-TW.md
+++ b/docs/server/fly-io/README.zh-TW.md
@@ -158,8 +158,11 @@ Fly 會自動建立 volume snapshot，但 Server 只承諾 quiesced backup。需
 ```bash
 fly machine stop <machine-id> --app my-open-flow
 fly volumes snapshots create <volume-id> --app my-open-flow
+fly volumes snapshots list <volume-id> --app my-open-flow
 fly machine start <machine-id> --app my-open-flow
 ```
+
+snapshot 會非同步建立。請保持 machine 停止，直到 `fly volumes snapshots list` 顯示新 snapshot 的狀態為 `created`，再啟動 machine。
 
 id 可透過 `fly machine list` 和 `fly volumes list` 取得。
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,42 @@
+# Change this to the globally unique Fly app name you create with `fly apps create`.
+app = "my-open-flow"
+primary_region = "iad"
+
+# The Server drains Runs, SSE connections, and SQLite for up to 30 seconds after SIGTERM.
+kill_signal = "SIGTERM"
+kill_timeout = "45s"
+
+[build]
+dockerfile = "apps/server/Dockerfile"
+
+[env]
+NODE_ENV = "production"
+OPEN_FLOW_HOST = "0.0.0.0"
+OPEN_FLOW_PORT = "3000"
+OPEN_FLOW_DATA_DIR = "/data/open-flow"
+OPEN_FLOW_SESSION_COOKIE_SECURE = "true"
+OPEN_FLOW_LOG_LEVEL = "info"
+
+[mounts]
+source = "open_flow_data"
+destination = "/data/open-flow"
+
+[http_service]
+internal_port = 3000
+force_https = true
+# Cron and Poll Triggers only fire while the machine is running, so keep one machine up.
+auto_stop_machines = "off"
+auto_start_machines = true
+min_machines_running = 1
+
+[[http_service.checks]]
+interval = "30s"
+timeout = "5s"
+grace_period = "15s"
+method = "GET"
+path = "/readyz"
+protocol = "http"
+
+[[vm]]
+size = "shared-cpu-1x"
+memory = "1gb"


### PR DESCRIPTION
Open Flow can now be deployed to Fly.io the same way OpenConnector is. A root _fly.toml_ builds _apps/server/Dockerfile_, mounts a Fly volume at _/data/open-flow_, uses `GET /readyz` as the HTTP check, keeps one machine running so Cron and Poll Triggers keep firing, and sets a 45 second `kill_timeout` to cover the Server's 30 second drain. The guide in _docs/server/fly-io/_ ships in all seven README languages, and every README lists Fly.io as a third way to run Open Flow next to OOMOL Hosted and Docker.

Fly mounts volumes as `root:root`, which the previous non-root `node` image could not write to, so the image now runs as root and the Docker smoke test drops its `Config.User` assertion. Because each machine mounts its own volume and the Server allows a single SQLite writer, the docs deploy with `--ha=false` and keep the machine count at one.

Verified with `bun run test:docker`, a local run against a root-owned volume, and a throwaway Fly app: remote build, readiness check, HTTPS redirect, Control API writes, `fly machine restart` with persisted state, then destroyed.
