### PR TITLE
docs: add OpenConnector and oo CLI setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ graph and remains editable by both people and Agents.
 [Install the `oo` CLI](https://github.com/oomol-lab/oo-cli) to author Open Flow from Codex, Claude
 Code, or another terminal Agent.
 
+To use your own Open Flow, set `OO_OPEN_FLOW_URL` and `OO_OPEN_FLOW_TOKEN` in the shell that runs the
+Agent; see [Use Open Flow with OpenConnector and oo CLI](docs/server/self-hosted-stack/README.md).
+
 ## Choose How to Run Open Flow
 
 Use the same Open Flow product and Workbench through any supported path.
@@ -135,7 +138,7 @@ Code Tasks place custom JavaScript directly in the graph, with typed inputs and 
 
 ```mermaid
 flowchart LR
-  Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
+  Workbench["Workbench"] -->|"Control API"| Server["Open Flow"]
   CLI["oo flow CLI"] -->|"Control API"| Server
   Server -. "optional" .-> Connector["Connector runtime"]
   Connector --> Providers["Third-party Providers"]
@@ -211,6 +214,10 @@ Open Flow and need no registration. See the
 [configuration reference](docs/server/container-delivery.md#4-配置) for Integration callback
 settings and the constraints on each origin.
 
+To start OpenConnector and Open Flow together, create a runtime token, authorize an account, and
+build a first Flow with `oo flow`, see
+[Use Open Flow with OpenConnector and oo CLI](docs/server/self-hosted-stack/README.md).
+
 ## One Product, Portable Deployments
 
 The Workbench and CLI speak a versioned Control API rather than depending on a particular database
@@ -272,6 +279,7 @@ Start with the [documentation index](docs/README.md). The most useful references
 - [Workbench and Designer frontend notes](docs/authoring/frontend-ui.md)
 - [Server deployment](docs/server/container-delivery.md)
 - [Fly.io deployment](docs/server/fly-io/README.md)
+- [Use Open Flow with OpenConnector and oo CLI](docs/server/self-hosted-stack/README.md)
 - [Contributing](CONTRIBUTING.md)
 - [Code of Conduct](CODE_OF_CONDUCT.md)
 - [Security](SECURITY.md)

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -57,6 +57,10 @@ L'Agent crée un véritable Draft dans le déploiement Open Flow sélectionné, 
 
 [Installez la CLI `oo`](https://github.com/oomol-lab/oo-cli) pour créer des Open Flow depuis Codex, Claude Code ou un autre Agent de terminal.
 
+Pour utiliser votre propre Open Flow, définissez `OO_OPEN_FLOW_URL` et `OO_OPEN_FLOW_TOKEN` dans le
+shell qui exécute l'Agent ; consultez
+[Utiliser Open Flow avec OpenConnector et oo CLI](server/self-hosted-stack/README.fr.md).
+
 ## Choisir comment exécuter Open Flow
 
 Les trois options prises en charge utilisent le même produit Open Flow et le même Workbench.
@@ -129,7 +133,7 @@ sorties typées.
 
 ```mermaid
 flowchart LR
-  Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
+  Workbench["Workbench"] -->|"Control API"| Server["Open Flow"]
   CLI["oo flow CLI"] -->|"Control API"| Server
   Server -. "optionnel" .-> Connector["Runtime Connector"]
   Connector --> Providers["Providers tiers"]
@@ -206,6 +210,10 @@ définitions de Triggers de Provider sont livrées avec Open Flow et ne nécessi
 enregistrement. Consultez la [référence de configuration](server/container-delivery.md#4-配置) pour
 les paramètres de callback d'Integration et les contraintes applicables à chaque origine.
 
+Pour démarrer OpenConnector et Open Flow ensemble, créer un runtime token, autoriser un compte et
+construire un premier Flow avec `oo flow`, consultez
+[Utiliser Open Flow avec OpenConnector et oo CLI](server/self-hosted-stack/README.fr.md).
+
 ## Un seul produit, des déploiements portables
 
 Le Workbench et la CLI parlent une Control API versionnée plutôt que de dépendre d'une base de données
@@ -269,6 +277,7 @@ Commencez par l'[index de la documentation](README.md). Les références les plu
 - [Notes sur le frontend du Workbench et du Designer](authoring/frontend-ui.md)
 - [Déploiement du Server](server/container-delivery.md)
 - [Déploiement sur Fly.io](server/fly-io/README.fr.md)
+- [Utiliser Open Flow avec OpenConnector et oo CLI](server/self-hosted-stack/README.fr.md)
 - [Contribuer](../CONTRIBUTING.md)
 - [Code de conduite](../CODE_OF_CONDUCT.md)
 - [Sécurité](../SECURITY.md)

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -52,6 +52,9 @@ Agent が作成するのは、使い捨てのローカル設定ではなく、�
 
 [Codex、Claude Code、または他のターミナル Agent から Open Flow を作成するために `oo` CLI をインストールします。](https://github.com/oomol-lab/oo-cli)
 
+自分で動かしている Open Flow を使う場合は、Agent を実行するシェルで `OO_OPEN_FLOW_URL` と `OO_OPEN_FLOW_TOKEN` を設定してください。
+詳細は [OpenConnector と oo CLI で Open Flow を使う](server/self-hosted-stack/README.ja.md) を参照してください。
+
 ## Open Flow の実行方法を選ぶ
 
 どの対応パスでも、同じ Open Flow プロダクトと Workbench を利用できます。
@@ -115,7 +118,7 @@ Code Task では、カスタム JavaScript をグラフ内に直接配置し、�
 
 ```mermaid
 flowchart LR
-  Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
+  Workbench["Workbench"] -->|"Control API"| Server["Open Flow"]
   CLI["oo flow CLI"] -->|"Control API"| Server
   Server -. "任意" .-> Connector["Connector ランタイム"]
   Connector --> Providers["サードパーティ Provider"]
@@ -179,6 +182,9 @@ runtime origin は Server が Connector に到達するためのアドレスで�
 アドレスです。Provider Trigger の定義は Open Flow に同梱されており、登録は不要です。Integration callback の設定と各 origin の制約については
 [設定リファレンス](server/container-delivery.md#4-配置) を参照してください。
 
+OpenConnector と Open Flow を一緒に起動し、runtime token を作成し、アカウントを認可して、`oo flow` で最初の Flow を作る手順は
+[OpenConnector と oo CLI で Open Flow を使う](server/self-hosted-stack/README.ja.md) を参照してください。
+
 ## 一つのプロダクト、ポータブルなデプロイメント
 
 Workbench と CLI は、特定のデータベースやクラウドランタイムに依存するのではなく、バージョン管理された Control API で通信します。デプロイメントが実行と
@@ -231,6 +237,7 @@ bun run build
 - [Workbench と Designer のフロントエンドに関する注意](authoring/frontend-ui.md)
 - [Server のデプロイ](server/container-delivery.md)
 - [Fly.io へのデプロイ](server/fly-io/README.ja.md)
+- [OpenConnector と oo CLI で Open Flow を使う](server/self-hosted-stack/README.ja.md)
 - [コントリビューション](../CONTRIBUTING.md)
 - [行動規範](../CODE_OF_CONDUCT.md)
 - [セキュリティ](../SECURITY.md)

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -52,6 +52,9 @@ Agent는 일회용 로컬 설정이 아니라 선택한 Open Flow 배포 안에 
 
 [Codex, Claude Code 또는 다른 터미널 Agent에서 Open Flow를 작성하려면 `oo` CLI를 설치하세요.](https://github.com/oomol-lab/oo-cli)
 
+직접 실행 중인 Open Flow를 사용한다면 Agent를 실행하는 셸에 `OO_OPEN_FLOW_URL`과 `OO_OPEN_FLOW_TOKEN`을 설정하세요.
+[OpenConnector와 oo CLI로 Open Flow 사용하기](server/self-hosted-stack/README.ko.md)를 참고하세요.
+
 ## Open Flow 실행 방식 선택
 
 지원되는 세 방식 모두 동일한 Open Flow 제품과 Workbench를 사용합니다.
@@ -119,7 +122,7 @@ Code Task는 사용자 정의 JavaScript를 그래프에 직접 배치하고 타
 
 ```mermaid
 flowchart LR
-  Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
+  Workbench["Workbench"] -->|"Control API"| Server["Open Flow"]
   CLI["oo flow CLI"] -->|"Control API"| Server
   Server -. "선택 사항" .-> Connector["Connector 런타임"]
   Connector --> Providers["서드파티 Provider"]
@@ -187,6 +190,9 @@ runtime origin은 Server가 Connector에 접근하는 주소이고, console orig
 Connector Console을 여는 주소입니다. Provider Trigger 정의는 Open Flow에 내장되어 있으므로 별도 등록이 필요 없습니다.
 Integration 콜백 설정과 각 origin의 제약은 [구성 참조](server/container-delivery.md#4-配置)를 참고하세요.
 
+OpenConnector와 Open Flow를 함께 시작하고, runtime token을 만들고, 계정을 연결한 뒤, `oo flow`로 첫 Flow를
+만드는 방법은 [OpenConnector와 oo CLI로 Open Flow 사용하기](server/self-hosted-stack/README.ko.md)를 참고하세요.
+
 ## 하나의 제품, 이식 가능한 배포
 
 Workbench와 CLI는 특정 데이터베이스나 클라우드 런타임에 의존하지 않고 버전 관리되는 Control API로 통신합니다.
@@ -245,6 +251,7 @@ bun run build
 - [Workbench 및 Designer 프런트엔드 참고 사항](authoring/frontend-ui.md)
 - [Server 배포](server/container-delivery.md)
 - [Fly.io 배포](server/fly-io/README.ko.md)
+- [OpenConnector와 oo CLI로 Open Flow 사용하기](server/self-hosted-stack/README.ko.md)
 - [기여 안내](../CONTRIBUTING.md)
 - [행동 강령](../CODE_OF_CONDUCT.md)
 - [보안 정책](../SECURITY.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,3 +15,4 @@ Open Flow 提供公共产品合同、Workbench runtime、CLI runtime 与完整 S
 
 - [Server 容器交付参考](server/container-delivery.md)
 - [Fly.io 部署](server/fly-io/README.zh-CN.md) ([English](server/fly-io/README.md))
+- [用 OpenConnector 和 oo CLI 运行 Open Flow](server/self-hosted-stack/README.zh-CN.md) ([English](server/self-hosted-stack/README.md))

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -56,6 +56,10 @@ Agent создаёт настоящий Draft в выбранном deployment O
 
 [Установите `oo` CLI](https://github.com/oomol-lab/oo-cli), чтобы создавать Open Flow из Codex, Claude Code или другого терминального Agent.
 
+Чтобы пользоваться своим Open Flow, задайте `OO_OPEN_FLOW_URL` и `OO_OPEN_FLOW_TOKEN` в shell, где
+запускается Agent; см.
+[Использование Open Flow с OpenConnector и oo CLI](server/self-hosted-stack/README.ru.md).
+
 ## Выберите способ запуска Open Flow
 
 Все поддерживаемые варианты используют один и тот же продукт Open Flow и Workbench.
@@ -128,7 +132,7 @@ Code Task размещает пользовательский JavaScript пря�
 
 ```mermaid
 flowchart LR
-  Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
+  Workbench["Workbench"] -->|"Control API"| Server["Open Flow"]
   CLI["oo flow CLI"] -->|"Control API"| Server
   Server -. "опционально" .-> Connector["Среда выполнения Connector"]
   Connector --> Providers["Сторонние Provider"]
@@ -202,6 +206,10 @@ Runtime origin определяет, где Server обращается к Conne
 поставляются вместе с Open Flow и не требуют регистрации. Настройки Integration callback и
 ограничения для каждого origin см. в [справочнике по конфигурации](server/container-delivery.md#4-配置).
 
+Как вместе запустить OpenConnector и Open Flow, создать runtime token, подключить аккаунт и
+собрать первый Flow через `oo flow`, см. в
+[Использование Open Flow с OpenConnector и oo CLI](server/self-hosted-stack/README.ru.md).
+
 ## Один продукт, переносимые deployment
 
 Workbench и CLI используют версионированный Control API и не зависят от конкретной базы данных или
@@ -262,6 +270,7 @@ bun run build
 - [Заметки по frontend Workbench и Designer](authoring/frontend-ui.md)
 - [Развёртывание Server](server/container-delivery.md)
 - [Развёртывание на Fly.io](server/fly-io/README.ru.md)
+- [Использование Open Flow с OpenConnector и oo CLI](server/self-hosted-stack/README.ru.md)
 - [Участие в разработке](../CONTRIBUTING.md)
 - [Кодекс поведения](../CODE_OF_CONDUCT.md)
 - [Безопасность](../SECURITY.md)

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -51,6 +51,9 @@ Agent 创建的是所选 Open Flow 部署中的真实 Draft，而不是用完即
 
 [安装 `oo` CLI](https://github.com/oomol-lab/oo-cli)，即可通过 Codex、Claude Code 或其他终端 Agent 创作 Open Flow。
 
+使用自己部署的 Open Flow 时，在运行 Agent 的 shell 中设置 `OO_OPEN_FLOW_URL` 和 `OO_OPEN_FLOW_TOKEN`，见
+[用 OpenConnector 和 oo CLI 运行 Open Flow](server/self-hosted-stack/README.zh-CN.md)。
+
 ## 选择 Open Flow 的运行方式
 
 三种支持的方式使用同一套 Open Flow 产品和 Workbench。
@@ -112,7 +115,7 @@ Code Task 将自定义 JavaScript 直接放在流程图中，并保留类型化�
 
 ```mermaid
 flowchart LR
-  Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
+  Workbench["Workbench"] -->|"Control API"| Server["Open Flow"]
   CLI["oo flow CLI"] -->|"Control API"| Server
   Server -. "可选" .-> Connector["Connector 运行时"]
   Connector --> Providers["第三方 Provider"]
@@ -176,6 +179,9 @@ runtime origin 是 Server 访问 Connector 的地址，console origin 是用户�
 定义随 Open Flow 内置，不需要额外注册。Integration callback 的配置和各 origin 的约束参见
 [配置说明](server/container-delivery.md#4-配置)。
 
+要同时启动 OpenConnector 和 Open Flow、创建 runtime token、授权账号并用 `oo flow` 创建第一个 Flow，见
+[用 OpenConnector 和 oo CLI 运行 Open Flow](server/self-hosted-stack/README.zh-CN.md)。
+
 ## 一套产品，多种部署
 
 Workbench 和 CLI 通过有版本的 Control API 工作，不依赖特定数据库或云运行时。部署端负责执行和持久化；客户端不会创建第二套本地
@@ -229,6 +235,7 @@ SQLite volume 恢复。不要在仓库根目录直接运行 `bun test`，它会�
 - [Workbench 与 Designer 前端注意事项](authoring/frontend-ui.md)
 - [Server 部署](server/container-delivery.md)
 - [Fly.io 部署](server/fly-io/README.zh-CN.md)
+- [用 OpenConnector 和 oo CLI 运行 Open Flow](server/self-hosted-stack/README.zh-CN.md)
 - [参与贡献](../CONTRIBUTING.md)
 - [行为准则](../CODE_OF_CONDUCT.md)
 - [安全政策](../SECURITY.md)

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -51,6 +51,9 @@ Agent 建立的是所選 Open Flow 部署中的真實 Draft，而不是用完即
 
 [安裝 `oo` CLI](https://github.com/oomol-lab/oo-cli)，即可透過 Codex、Claude Code 或其他終端 Agent 創作 Open Flow。
 
+使用自己部署的 Open Flow 時，請在執行 Agent 的 shell 中設定 `OO_OPEN_FLOW_URL` 和 `OO_OPEN_FLOW_TOKEN`，見
+[用 OpenConnector 和 oo CLI 執行 Open Flow](server/self-hosted-stack/README.zh-TW.md)。
+
 ## 選擇 Open Flow 的執行方式
 
 三種支援的方式使用同一套 Open Flow 產品和 Workbench。
@@ -112,7 +115,7 @@ Code Task 將自訂 JavaScript 直接放在流程圖中，並保留類型化的�
 
 ```mermaid
 flowchart LR
-  Workbench["Workbench"] -->|"Control API"| Server["Open Flow Server"]
+  Workbench["Workbench"] -->|"Control API"| Server["Open Flow"]
   CLI["oo flow CLI"] -->|"Control API"| Server
   Server -. "選用" .-> Connector["Connector 執行環境"]
   Connector --> Providers["第三方 Provider"]
@@ -175,6 +178,9 @@ runtime origin 是 Server 存取 Connector 的位址，console origin 是使用�
 定義隨 Open Flow 內建，不需要額外註冊。Integration callback 的設定和各 origin 的限制請參閱
 [設定說明](server/container-delivery.md#4-配置)。
 
+要同時啟動 OpenConnector 和 Open Flow、建立 runtime token、授權帳號並用 `oo flow` 建立第一個 Flow，見
+[用 OpenConnector 和 oo CLI 執行 Open Flow](server/self-hosted-stack/README.zh-TW.md)。
+
 ## 一套產品，多種部署
 
 Workbench 和 CLI 透過有版本的 Control API 運作，不依賴特定資料庫或雲端執行環境。部署端負責執行和持久化；用戶端不會建立第二套本機
@@ -227,6 +233,7 @@ SQLite volume 復原。不要在儲存庫根目錄直接執行 `bun test`，它�
 - [Workbench 與 Designer 前端注意事項](authoring/frontend-ui.md)
 - [Server 部署](server/container-delivery.md)
 - [Fly.io 部署](server/fly-io/README.zh-TW.md)
+- [用 OpenConnector 和 oo CLI 執行 Open Flow](server/self-hosted-stack/README.zh-TW.md)
 - [參與貢獻](../CONTRIBUTING.md)
 - [行為準則](../CODE_OF_CONDUCT.md)
 - [安全政策](../SECURITY.md)

--- a/docs/server/self-hosted-stack/README.fr.md
+++ b/docs/server/self-hosted-stack/README.fr.md
@@ -1,0 +1,301 @@
+# Utiliser Open Flow avec OpenConnector et oo CLI
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+Open Flow peut fonctionner seul. Deux fonctions ont besoin d'autres projets OOMOL :
+
+- Les Actions et les Provider Triggers qui appellent GitHub, Gmail, Slack et des services
+  semblables ont besoin d'un Connector. Un
+  [OpenConnector](https://github.com/oomol-lab/open-connector) auto-hébergé stocke les identifiants
+  des Providers, exécute les Actions et sert la Connector Console où les utilisateurs autorisent
+  des comptes.
+- Pour créer des Flows depuis un Agent de terminal tel que Codex ou Claude Code, il faut
+  `oo flow`. La [oo CLI](https://github.com/oomol-lab/oo-cli) fournit `oo flow` et l'envoie à la
+  Control API d'un Open Flow.
+
+Ce guide démarre les trois sur une seule machine avec Docker, les relie et construit un premier
+Flow depuis le terminal. Les variables d'environnement sont les mêmes que dans la
+[référence de livraison en conteneur](../container-delivery.md#4-配置). Ce guide n'ajoute que
+l'ordre des étapes et les valeurs qui doivent correspondre entre les projets.
+
+```mermaid
+flowchart LR
+  Agent["Agent de terminal"] --> CLI["oo flow"]
+  CLI -->|"OO_OPEN_FLOW_TOKEN"| Flow["Open Flow :3000"]
+  Browser["Navigateur"] -->|"Connexion au Workbench"| Flow
+  Flow -->|"OPEN_FLOW_CONNECTOR_TOKEN"| Connector["OpenConnector :3001"]
+  Browser -->|"Connector Console"| Connector
+  Connector --> Providers["GitHub, Gmail, Slack, ..."]
+```
+
+Ces quatre valeurs doivent correspondre :
+
+| Usage                                   | Où la définir                                               | Valeur                                                                    |
+| --------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `oo flow` vers la Control API           | `OO_OPEN_FLOW_URL` et `OO_OPEN_FLOW_TOKEN` dans le shell    | Origine de cet Open Flow et la même valeur que son `OPEN_FLOW_TOKEN`      |
+| Open Flow vers le runtime Connector     | `OPEN_FLOW_CONNECTOR_ORIGIN` et `OPEN_FLOW_CONNECTOR_TOKEN` | Origine runtime joignable par Open Flow et un runtime token OpenConnector |
+| Navigateur vers la Connector Console    | `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN`                        | Origine publique de la Web Console OpenConnector                          |
+| Navigateur et API admin vers la Console | `OOMOL_CONNECT_ADMIN_TOKEN` sur OpenConnector               | Token admin que les utilisateurs saisissent dans la Console               |
+
+## Prérequis
+
+- [Docker](https://docs.docker.com/get-docker/) et OpenSSL.
+- La CLI `oo`. Sur macOS ou Linux :
+
+  ```bash
+  curl -fsSL https://cli.oomol.com/install.sh | bash
+  ```
+
+  Voir le [README de oo CLI](https://github.com/oomol-lab/oo-cli#install) pour Windows et les
+  autres modes d'installation. Votre propre Open Flow n'a besoin ni de `oo login` ni d'un compte
+  OOMOL.
+
+- Pour les Providers OAuth tels que Gmail ou Slack, les identifiants de client OAuth des
+  applications que vous enregistrez chez ces Providers. GitHub fonctionne avec un personal access
+  token et est le premier Provider le plus rapide. Les déploiements Connector hébergés par OOMOL
+  incluent des applications OAuth gérées ; un OpenConnector auto-hébergé n'en a pas.
+
+Les exemples publient OpenConnector sur le port hôte `3001` et Open Flow sur le port hôte `3000`,
+et placent les deux conteneurs sur un même réseau Docker pour qu'Open Flow joigne le Connector par
+nom de conteneur.
+
+## 1. Démarrer OpenConnector
+
+```bash
+docker network create oomol
+
+export OOMOL_CONNECT_ADMIN_TOKEN="$(openssl rand -hex 32)"
+export OOMOL_CONNECT_ENCRYPTION_KEY="$(openssl rand -hex 32)"
+
+docker run -d \
+  --name open-connector \
+  --network oomol \
+  --publish 3001:3000 \
+  --volume open-connector-data:/app/data \
+  --env OOMOL_CONNECT_ORIGIN="http://localhost:3001" \
+  --env OOMOL_CONNECT_ADMIN_TOKEN="$OOMOL_CONNECT_ADMIN_TOKEN" \
+  --env OOMOL_CONNECT_ENCRYPTION_KEY="$OOMOL_CONNECT_ENCRYPTION_KEY" \
+  ghcr.io/oomol-lab/open-connector:latest
+
+curl http://localhost:3001/health
+```
+
+- `OOMOL_CONNECT_ORIGIN` est l'origine que les navigateurs utilisent pour joindre OpenConnector.
+  Les URL de redirection OAuth en sont dérivées, elle doit donc correspondre au port publié.
+- `OOMOL_CONNECT_ADMIN_TOKEN` protège l'API admin, `/docs` et la Web Console. Sans lui, quiconque
+  peut joindre le port `3001` peut lire et modifier les identifiants.
+- `OOMOL_CONNECT_ENCRYPTION_KEY` chiffre les identifiants stockés sur le disque.
+
+Ouvrez `http://localhost:3001`, saisissez le token admin et vérifiez que la Web Console se charge.
+La
+[référence de configuration OpenConnector](https://github.com/oomol-lab/open-connector/blob/main/docs/configuration.md)
+couvre PostgreSQL, le stockage de transit et les autres variables.
+
+## 2. Créer un runtime token pour Open Flow
+
+Open Flow appelle l'API runtime d'OpenConnector sous `/v1` : le catalogue de Providers et
+d'Actions, la liste des Connections, l'exécution d'Actions, et `POST /v1/proxy/:service` pour les
+Triggers Poll et Integration. Donnez-lui un runtime token de longue durée, pas le token admin. Créez-le
+sur la page Access de la Web Console, ou via l'API admin :
+
+```bash
+curl -s -X POST http://localhost:3001/api/runtime-tokens \
+  -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"name":"open-flow","allowedActions":[],"blockedActions":[],"allowedProxies":["*"]}'
+```
+
+La réponse contient le token une seule fois, dans `token`. Enregistrez-le comme
+`OPEN_FLOW_CONNECTOR_TOKEN` :
+
+```bash
+export OPEN_FLOW_CONNECTOR_TOKEN="<token issu de la réponse>"
+```
+
+Règles de token qui comptent pour Open Flow :
+
+- `allowedProxies` est vide par défaut. Un token de longue durée sans droit proxy ne peut pas appeler
+  `/v1/proxy/:service`, donc les Triggers Poll et Integration échouent. Autorisez `*`, ou listez
+  les Providers dont vous prévoyez d'utiliser les Provider Triggers, par exemple
+  `["gmail","github"]`.
+- `allowedActions` et `blockedActions` limitent les Actions qu'Open Flow peut exécuter. Des
+  listes vides autorisent toutes les Actions permises par la politique de déploiement.
+- Laissez `allowedConnections` non défini, sauf si vous voulez limiter Open Flow à des Connections
+  précises. Un Connector Node lié à une Connection hors de cette liste échoue avec
+  `connector.connection-required`.
+
+Dès qu'un token de longue durée existe, OpenConnector exige un runtime token sur chaque requête `/v1` et
+`/mcp`. Les autres appelants du même OpenConnector, comme `oo connector` ou les hôtes MCP, ont
+alors besoin de leurs propres tokens.
+
+## 3. Démarrer Open Flow
+
+Construisez l'image depuis la racine du dépôt et démarrez-la sur le même réseau :
+
+```bash
+git clone https://github.com/oomol-lab/open-flow.git
+cd open-flow
+
+export OPEN_FLOW_TOKEN="$(openssl rand -hex 32)"
+docker build --file apps/server/Dockerfile --tag open-flow-server:dev .
+
+docker run -d \
+  --name open-flow \
+  --network oomol \
+  --publish 3000:3000 \
+  --volume open-flow-data:/data/open-flow \
+  --env OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN" \
+  --env OPEN_FLOW_CONNECTOR_ORIGIN="http://open-connector:3000" \
+  --env OPEN_FLOW_CONNECTOR_TOKEN="$OPEN_FLOW_CONNECTOR_TOKEN" \
+  --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
+  open-flow-server:dev
+
+curl http://localhost:3000/readyz
+```
+
+- `OPEN_FLOW_CONNECTOR_ORIGIN` est l'adresse utilisée par le processus Open Flow. Dans le réseau
+  `oomol`, c'est le nom du conteneur et le port du conteneur, pas le port publié sur l'hôte.
+- `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` est l'adresse qu'ouvrent les navigateurs des utilisateurs.
+  Le Workbench pointe vers `<console origin>/providers/<service>` quand un Connector Node ou un
+  Provider Trigger a besoin d'un compte. Seuls les hôtes loopback peuvent utiliser HTTP en clair ;
+  tout le reste doit être une origine HTTPS sans chemin.
+- `/readyz` renvoie `{"status":"ready"}` seulement lorsque Open Flow tourne et que le Connector
+  configuré répond à son health check. Un 503 avec un Connector configuré signifie en général que
+  l'origine runtime est fausse ou que le conteneur n'est pas sur le même réseau.
+
+Ouvrez `http://localhost:3000` et connectez-vous avec `OPEN_FLOW_TOKEN`. Le catalogue du Workbench
+liste alors les Providers et Actions d'OpenConnector.
+
+## 4. Autoriser un compte
+
+Les Connections vivent dans OpenConnector, pas dans Open Flow. Open Flow ne stocke que des ID de
+Connection et ne voit jamais les identifiants des Providers.
+
+Pour GitHub, enregistrez un personal access token via la page GitHub de la Console à
+`http://localhost:3001/providers/github`, ou via l'API admin :
+
+```bash
+curl -s -X PUT http://localhost:3001/api/connections/github \
+  -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"authType":"api_key","values":{"apiKey":"github_pat_..."}}'
+```
+
+Pour les Providers OAuth, configurez d'abord le client OAuth dans la Console, puis autorisez le
+compte depuis la page du Provider. Voir le
+[guide des identifiants OpenConnector](https://github.com/oomol-lab/open-connector/blob/main/docs/credentials.md)
+pour les clients OAuth, les Connections nommées et le renouvellement des tokens.
+
+Vérifiez qu'Open Flow voit la Connection :
+
+```bash
+export OO_OPEN_FLOW_URL="http://localhost:3000"
+export OO_OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN"
+
+oo flow connector connections github
+```
+
+## 5. Connecter oo CLI à Open Flow
+
+`oo flow` choisit un Open Flow d'après l'environnement :
+
+- Avec `OO_OPEN_FLOW_URL` et `OO_OPEN_FLOW_TOKEN` tous deux définis, `oo flow` se connecte
+  directement à cet Open Flow. Il ne lit ni compte OOMOL, ni Team, ni `OO_ENDPOINT`.
+- `OO_OPEN_FLOW_TOKEN` doit égaler l'`OPEN_FLOW_TOKEN` de cet Open Flow. La CLI l'envoie uniquement
+  comme Bearer token vers `/v1/` de l'origine choisie.
+- Définir une seule des deux variables est une erreur. Désactivez les deux pour revenir à OOMOL
+  Hosted.
+
+```bash
+export OO_OPEN_FLOW_URL="http://localhost:3000"
+export OO_OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN"
+
+oo flow --help
+oo flow list
+```
+
+Pour qu'un Agent IA construise des Flows, démarrez Codex, Claude Code ou un autre Agent de
+terminal dans un shell où les deux variables sont exportées. Le skill `oo` fourni avec la CLI
+apprend à l'Agent quand et comment appeler `oo flow`. Vous n'avez pas besoin de l'URL d'Open Flow
+ni du token dans le prompt.
+
+La liste complète des commandes et les variables d'environnement sont dans la
+[référence des commandes oo CLI](https://github.com/oomol-lab/oo-cli/blob/main/docs/commands.md#open-flow).
+
+## 6. Construire un Flow depuis le terminal
+
+Les Flows peuvent être désignés par ID ou par nom exact. Les commandes ci-dessous créent un Draft,
+ajoutent un Connector Node lié à la Connection GitHub, le vérifient, l'exécutent et le publient :
+
+```bash
+oo flow create "GitHub digest"
+oo flow connector search "current user"
+oo flow connector add "GitHub digest" github.get_current_user --name me
+oo flow check "GitHub digest"
+oo flow run "GitHub digest" --wait
+oo flow publish "GitHub digest"
+oo flow open "GitHub digest"
+```
+
+- `connector add` lie la Connection par défaut de l'Action lorsque `--connection` est omis. Passez
+  `--connection <alias>` pour choisir une Connection nommée.
+- `check` valide la Revision. Que les identifiants fonctionnent, et que le Provider exécute
+  vraiment l'Action, n'est testé que par `run`.
+- `run --wait` exécute le Draft via OpenConnector et affiche le résultat.
+  `oo flow runs events <run>` montre l'historique complet des événements.
+- `open` affiche l'URL Workbench du Flow et l'ouvre dans le navigateur. Le token opérateur n'est
+  pas placé dans l'URL. Le navigateur se connecte avec sa propre session.
+
+Ajoutez `--json` à n'importe quelle commande pour une sortie machine versionnée. `oo flow node add`,
+`oo flow connect`, `oo flow trigger add` et `oo flow apply --file` couvrent les Code Tasks, Edges,
+Triggers, et l'écriture d'un Flow depuis un fichier. Voir `oo flow --help`.
+
+## 7. Optionnel : réutiliser le même OpenConnector depuis oo connector
+
+Le même OpenConnector peut aussi servir les commandes `oo connector` hors d'Open Flow. Il faut un
+runtime token distinct. Réservez ce token à Open Flow :
+
+```bash
+oo connector login http://localhost:3001 --token <un-autre-runtime-token>
+oo connector search "send an email"
+```
+
+`oo connector login` n'affecte que les commandes connector et est stocké à part des réglages
+`oo flow`. Voir le
+[guide du connector auto-hébergé](https://github.com/oomol-lab/oo-cli/blob/main/docs/self-hosted-connector.md).
+
+## Notes pour la production
+
+- Placez la terminaison TLS devant les deux services. `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` et
+  `OOMOL_CONNECT_ORIGIN` doivent être l'origine HTTPS publique de la Console, et les deux doivent
+  être la même origine, car les redirections OAuth et les liens Workbench l'utilisent. L'origine
+  runtime peut rester sur un réseau privé en HTTP. Lorsqu'elle traverse un réseau non fiable,
+  protégez le bearer token avec TLS.
+- Définissez `OPEN_FLOW_SESSION_COOKIE_SECURE=true` derrière TLS.
+- Les Integration Triggers (callbacks de Provider) ont aussi besoin de
+  `OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN` et `OPEN_FLOW_INTEGRATION_CALLBACK_KEY`. Sans eux, Publish
+  échoue.
+- Injectez chaque token via des secrets ou un fichier env lisible seulement par le déployeur.
+  Lorsque vous renouvelez le runtime token OpenConnector depuis la page Access, mettez à jour
+  `OPEN_FLOW_CONNECTOR_TOKEN` en même temps.
+- Chaque service possède ses propres données : `/data/open-flow` pour Open Flow et `/app/data`
+  pour OpenConnector. Sauvegardez-les séparément. Voir la
+  [référence de livraison en conteneur](../container-delivery.md#6-持久化与恢复).
+- Sur Fly.io, exécutez OpenConnector et Open Flow comme deux apps dans une organisation et
+  utilisez le réseau privé Fly pour l'origine runtime, par exemple
+  `http://my-open-connector.internal:3000`. Voir le
+  [guide de déploiement Fly.io](../fly-io/README.fr.md) et le
+  [guide Fly.io d'OpenConnector](https://github.com/oomol-lab/open-connector/blob/main/docs/fly-io.md).
+
+## Dépannage
+
+| Symptôme                                                                    | Cause probable                                                                                                                     |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `connector.unavailable` dans le Workbench ou la CLI                         | `OPEN_FLOW_CONNECTOR_ORIGIN` est injoignable depuis le conteneur Open Flow, ou OpenConnector a rejeté `OPEN_FLOW_CONNECTOR_TOKEN`. |
+| `/readyz` renvoie 503 alors que `/healthz` renvoie 200                      | Le health check du Connector a échoué. Vérifiez `docker logs open-flow` et que les deux conteneurs partagent le réseau.            |
+| `connector.connection-required` à l'exécution                               | La Connection est absente, inactive, ou exclue par `allowedConnections` du token. Réautorisez dans la Console.                     |
+| Poll ou Integration Trigger échoue alors que les Actions manuelles marchent | Le runtime token n'a pas de droit `allowedProxies` pour ce Provider, ou `OOMOL_CONNECT_BLOCKED_PROXIES` le bloque.                 |
+| `oo flow` demande une connexion OOMOL                                       | `OO_OPEN_FLOW_URL` ou `OO_OPEN_FLOW_TOKEN` manque. Les deux doivent être définis dans le même shell.                               |
+| `oo flow` renvoie 401                                                       | `OO_OPEN_FLOW_TOKEN` diffère de l'`OPEN_FLOW_TOKEN` de cet Open Flow.                                                              |
+| Le lien Workbench vers la Console ouvre un mauvais hôte                     | `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` pointe vers l'adresse du conteneur au lieu de l'origine joignable par les navigateurs.        |
+| L'autorisation OAuth revient vers la mauvaise URL                           | `OOMOL_CONNECT_ORIGIN` ne correspond pas à l'origine utilisée par le navigateur pour ouvrir la Console.                            |

--- a/docs/server/self-hosted-stack/README.fr.md
+++ b/docs/server/self-hosted-stack/README.fr.md
@@ -28,7 +28,7 @@ flowchart LR
   Connector --> Providers["GitHub, Gmail, Slack, ..."]
 ```
 
-Ces quatre valeurs doivent correspondre :
+Définissez ces quatre valeurs :
 
 | Usage                                   | Où la définir                                               | Valeur                                                                    |
 | --------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------- |
@@ -105,6 +105,9 @@ curl -s -X POST http://localhost:3001/api/runtime-tokens \
   -d '{"name":"open-flow","allowedActions":[],"blockedActions":[],"allowedProxies":["*"]}'
 ```
 
+L'autorisation proxy `*` est pour ce parcours local. En production, listez seulement les Providers
+dont vous avez besoin.
+
 La réponse contient le token une seule fois, dans `token`. Enregistrez-le comme
 `OPEN_FLOW_CONNECTOR_TOKEN` :
 
@@ -150,7 +153,10 @@ docker run -d \
   --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
   open-flow-server:dev
 
-curl http://localhost:3000/readyz
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  curl -sf http://localhost:3000/readyz && break
+  sleep 1
+done
 ```
 
 - `OPEN_FLOW_CONNECTOR_ORIGIN` est l'adresse utilisée par le processus Open Flow. Dans le réseau
@@ -160,8 +166,9 @@ curl http://localhost:3000/readyz
   Provider Trigger a besoin d'un compte. Seuls les hôtes loopback peuvent utiliser HTTP en clair ;
   tout le reste doit être une origine HTTPS sans chemin.
 - `/readyz` renvoie `{"status":"ready"}` seulement lorsque Open Flow tourne et que le Connector
-  configuré répond à son health check. Un 503 avec un Connector configuré signifie en général que
-  l'origine runtime est fausse ou que le conteneur n'est pas sur le même réseau.
+  configuré répond à son health check. Un 503 pendant quelques secondes après `docker run -d` est
+  normal. S'il persiste, l'origine runtime est en général fausse ou le conteneur n'est pas sur le
+  même réseau.
 
 Ouvrez `http://localhost:3000` et connectez-vous avec `OPEN_FLOW_TOKEN`. Le catalogue du Workbench
 liste alors les Providers et Actions d'OpenConnector.
@@ -172,13 +179,18 @@ Les Connections vivent dans OpenConnector, pas dans Open Flow. Open Flow ne stoc
 Connection et ne voit jamais les identifiants des Providers.
 
 Pour GitHub, enregistrez un personal access token via la page GitHub de la Console à
-`http://localhost:3001/providers/github`, ou via l'API admin :
+`http://localhost:3001/providers/github`, ou via l'API admin. Après `read -s`, collez le token et
+appuyez sur Entrée. Il ne s'affiche pas :
 
 ```bash
+read -s GITHUB_PAT
 curl -s -X PUT http://localhost:3001/api/connections/github \
   -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
   -H 'content-type: application/json' \
-  -d '{"authType":"api_key","values":{"apiKey":"github_pat_..."}}'
+  --data-binary @- <<EOF
+{"authType":"api_key","values":{"apiKey":"${GITHUB_PAT}"}}
+EOF
+unset GITHUB_PAT
 ```
 
 Pour les Providers OAuth, configurez d'abord le client OAuth dans la Console, puis autorisez le
@@ -253,7 +265,7 @@ Triggers, et l'écriture d'un Flow depuis un fichier. Voir `oo flow --help`.
 ## 7. Optionnel : réutiliser le même OpenConnector depuis oo connector
 
 Le même OpenConnector peut aussi servir les commandes `oo connector` hors d'Open Flow. Il faut un
-runtime token distinct. Réservez ce token à Open Flow :
+runtime token distinct. Ne réutilisez pas le token Open Flow :
 
 ```bash
 oo connector login http://localhost:3001 --token <un-autre-runtime-token>

--- a/docs/server/self-hosted-stack/README.fr.md
+++ b/docs/server/self-hosted-stack/README.fr.md
@@ -153,10 +153,15 @@ docker run -d \
   --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
   open-flow-server:dev
 
+ready=0
 for i in 1 2 3 4 5 6 7 8 9 10; do
-  curl -sf http://localhost:3000/readyz && break
+  if curl -sf --max-time 2 http://localhost:3000/readyz; then
+    ready=1
+    break
+  fi
   sleep 1
 done
+[ "$ready" -eq 1 ]
 ```
 
 - `OPEN_FLOW_CONNECTOR_ORIGIN` est l'adresse utilisée par le processus Open Flow. Dans le réseau

--- a/docs/server/self-hosted-stack/README.ja.md
+++ b/docs/server/self-hosted-stack/README.ja.md
@@ -141,10 +141,15 @@ docker run -d \
   --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
   open-flow-server:dev
 
+ready=0
 for i in 1 2 3 4 5 6 7 8 9 10; do
-  curl -sf http://localhost:3000/readyz && break
+  if curl -sf --max-time 2 http://localhost:3000/readyz; then
+    ready=1
+    break
+  fi
   sleep 1
 done
+[ "$ready" -eq 1 ]
 ```
 
 - `OPEN_FLOW_CONNECTOR_ORIGIN` は Open Flow プロセスが使うアドレスです。`oomol` ネットワーク内では、公開されたホストの

--- a/docs/server/self-hosted-stack/README.ja.md
+++ b/docs/server/self-hosted-stack/README.ja.md
@@ -24,7 +24,7 @@ flowchart LR
   Connector --> Providers["GitHub, Gmail, Slack, ..."]
 ```
 
-次の 4 つの値を一致させてください。
+次の 4 つの値を設定してください。
 
 | 用途                                  | 設定場所                                                    | 値                                                                      |
 | ------------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------- |
@@ -98,6 +98,8 @@ curl -s -X POST http://localhost:3001/api/runtime-tokens \
   -d '{"name":"open-flow","allowedActions":[],"blockedActions":[],"allowedProxies":["*"]}'
 ```
 
+`*` の proxy 許可はこのローカル手順用です。本番では実際に使う Provider だけを列挙してください。
+
 レスポンスには token が `token` として 1 回だけ含まれます。これを `OPEN_FLOW_CONNECTOR_TOKEN` として保存します。
 
 ```bash
@@ -139,7 +141,10 @@ docker run -d \
   --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
   open-flow-server:dev
 
-curl http://localhost:3000/readyz
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  curl -sf http://localhost:3000/readyz && break
+  sleep 1
+done
 ```
 
 - `OPEN_FLOW_CONNECTOR_ORIGIN` は Open Flow プロセスが使うアドレスです。`oomol` ネットワーク内では、公開されたホストの
@@ -148,8 +153,8 @@ curl http://localhost:3000/readyz
   アカウントを必要とするとき、Workbench は `<console origin>/providers/<service>` にリンクします。平文の HTTP を使えるのは
   loopback ホストだけで、それ以外はパスを含まない HTTPS origin でなければなりません。
 - `/readyz` が `{"status":"ready"}` を返すのは、Open Flow が動作しており、設定された Connector がヘルスチェックに応答する
-  場合だけです。Connector を設定した状態で 503 が返る場合、通常は runtime origin が誤っているか、コンテナが同じ
-  ネットワークにありません。
+  場合だけです。`docker run -d` の直後に数秒 503 が返るのは普通です。それが続く場合、通常は runtime origin が誤っているか、
+  コンテナが同じネットワークにありません。
 
 `http://localhost:3000` を開き、`OPEN_FLOW_TOKEN` でサインインします。Workbench のカタログに OpenConnector の Provider と
 Action が表示されるようになります。
@@ -160,13 +165,17 @@ Connection は Open Flow ではなく OpenConnector にあります。Open Flow 
 Provider の認証情報を見ることはありません。
 
 GitHub の場合は、Console の GitHub ページ `http://localhost:3001/providers/github`、または admin API から personal access
-token を保存します。
+token を保存します。`read -s` のあと token を貼り付けて Enter を押してください。画面には表示されません。
 
 ```bash
+read -s GITHUB_PAT
 curl -s -X PUT http://localhost:3001/api/connections/github \
   -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
   -H 'content-type: application/json' \
-  -d '{"authType":"api_key","values":{"apiKey":"github_pat_..."}}'
+  --data-binary @- <<EOF
+{"authType":"api_key","values":{"apiKey":"${GITHUB_PAT}"}}
+EOF
+unset GITHUB_PAT
 ```
 
 OAuth Provider の場合は、まず Console で OAuth クライアントを設定し、その後 Provider ページからアカウントを認可します。
@@ -238,7 +247,7 @@ oo flow open "GitHub digest"
 ## 7. 任意: oo connector から同じ OpenConnector を使う
 
 同じ OpenConnector は、Open Flow の外でも `oo connector` コマンドに利用できます。別の runtime token が必要です。
-その token は Open Flow 専用にしてください。
+Open Flow の token は再利用しないでください。
 
 ```bash
 oo connector login http://localhost:3001 --token <別の runtime token>

--- a/docs/server/self-hosted-stack/README.ja.md
+++ b/docs/server/self-hosted-stack/README.ja.md
@@ -1,0 +1,280 @@
+# OpenConnector と oo CLI で Open Flow を使う
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+Open Flow は単体でも動作します。次の 2 つの機能には、ほかの OOMOL プロジェクトが必要です。
+
+- GitHub、Gmail、Slack などのサービスを呼び出す Action と Provider Trigger には Connector が必要です。セルフホストの
+  [OpenConnector](https://github.com/oomol-lab/open-connector) が Provider の認証情報を保存し、Action を実行し、
+  ユーザーがアカウントを認可する Connector Console を提供します。
+- Codex や Claude Code などのターミナル Agent から Flow を作るには `oo flow` を使います。`oo flow` は
+  [oo CLI](https://github.com/oomol-lab/oo-cli) が提供し、1 つの Open Flow の Control API に接続します。
+
+このガイドでは、Docker を使って 3 つすべてを 1 台のマシンで起動し、それらを接続して、ターミナルから最初の Flow を
+作ります。環境変数は[コンテナ配布リファレンス](../container-delivery.md#4-配置)と同じです。このガイドが追加するのは、
+操作の順序と、プロジェクト間で一致させなければならない値だけです。
+
+```mermaid
+flowchart LR
+  Agent["ターミナル Agent"] --> CLI["oo flow"]
+  CLI -->|"OO_OPEN_FLOW_TOKEN"| Flow["Open Flow :3000"]
+  Browser["ブラウザ"] -->|"Workbench サインイン"| Flow
+  Flow -->|"OPEN_FLOW_CONNECTOR_TOKEN"| Connector["OpenConnector :3001"]
+  Browser -->|"Connector Console"| Connector
+  Connector --> Providers["GitHub, Gmail, Slack, ..."]
+```
+
+次の 4 つの値を一致させてください。
+
+| 用途                                  | 設定場所                                                    | 値                                                                      |
+| ------------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `oo flow` から Control API へ         | シェルの `OO_OPEN_FLOW_URL` と `OO_OPEN_FLOW_TOKEN`         | Open Flow の origin と、その Open Flow の `OPEN_FLOW_TOKEN` と同じ値    |
+| Open Flow から Connector ランタイムへ | `OPEN_FLOW_CONNECTOR_ORIGIN` と `OPEN_FLOW_CONNECTOR_TOKEN` | Open Flow が到達できる runtime origin と OpenConnector の runtime token |
+| ブラウザから Connector Console へ     | `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN`                        | OpenConnector Web Console の公開 origin                                 |
+| ブラウザと admin API から Console へ  | OpenConnector の `OOMOL_CONNECT_ADMIN_TOKEN`                | ユーザーが Console で入力する admin token                               |
+
+## 前提条件
+
+- [Docker](https://docs.docker.com/get-docker/) と OpenSSL。
+- `oo` CLI。macOS または Linux では次のとおりです。
+
+  ```bash
+  curl -fsSL https://cli.oomol.com/install.sh | bash
+  ```
+
+  Windows やその他のインストール方法については [oo CLI README](https://github.com/oomol-lab/oo-cli#install) を
+  参照してください。自分で動かしている Open Flow には `oo login` も OOMOL アカウントも必要ありません。
+
+- Gmail や Slack などの OAuth Provider を使う場合は、それらの Provider に登録したアプリの OAuth クライアント認証情報。
+  GitHub は personal access token で動作し、最初の Provider として最も手軽です。OOMOL がホストする Connector
+  には管理された OAuth アプリが含まれますが、セルフホストの OpenConnector には含まれません。
+
+この例では、OpenConnector をホストのポート `3001` に、Open Flow をホストのポート `3000` に公開し、Open Flow がコンテナ名で
+Connector に到達できるよう、両方のコンテナを 1 つの Docker ネットワークに配置します。
+
+## 1. OpenConnector を起動する
+
+```bash
+docker network create oomol
+
+export OOMOL_CONNECT_ADMIN_TOKEN="$(openssl rand -hex 32)"
+export OOMOL_CONNECT_ENCRYPTION_KEY="$(openssl rand -hex 32)"
+
+docker run -d \
+  --name open-connector \
+  --network oomol \
+  --publish 3001:3000 \
+  --volume open-connector-data:/app/data \
+  --env OOMOL_CONNECT_ORIGIN="http://localhost:3001" \
+  --env OOMOL_CONNECT_ADMIN_TOKEN="$OOMOL_CONNECT_ADMIN_TOKEN" \
+  --env OOMOL_CONNECT_ENCRYPTION_KEY="$OOMOL_CONNECT_ENCRYPTION_KEY" \
+  ghcr.io/oomol-lab/open-connector:latest
+
+curl http://localhost:3001/health
+```
+
+- `OOMOL_CONNECT_ORIGIN` は、ブラウザが OpenConnector に到達するために使う origin です。OAuth のリダイレクト URL は
+  ここから作られるため、公開しているポートと一致していなければなりません。
+- `OOMOL_CONNECT_ADMIN_TOKEN` は admin API、`/docs`、および Web Console を保護します。これがないと、ポート `3001` に
+  到達できる誰もが認証情報を読み取り、変更できてしまいます。
+- `OOMOL_CONNECT_ENCRYPTION_KEY` はディスクに保存する認証情報を暗号化します。
+
+`http://localhost:3001` を開き、admin token を入力して、Web Console が読み込まれることを確認します。PostgreSQL、転送用
+ストレージ、その他の変数については
+[OpenConnector 設定リファレンス](https://github.com/oomol-lab/open-connector/blob/main/docs/configuration.md)
+を参照してください。
+
+## 2. Open Flow 用の runtime token を作成する
+
+Open Flow は `/v1` 配下の OpenConnector runtime API を呼び出します。具体的には、Provider と Action のカタログ、
+Connection の一覧、Action の実行、そして Poll Trigger と Integration Trigger のための `POST /v1/proxy/:service` です。
+admin token ではなく、長く使う runtime token を Open Flow に渡してください。Web Console の Access ページ、または admin API で
+作成します。
+
+```bash
+curl -s -X POST http://localhost:3001/api/runtime-tokens \
+  -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"name":"open-flow","allowedActions":[],"blockedActions":[],"allowedProxies":["*"]}'
+```
+
+レスポンスには token が `token` として 1 回だけ含まれます。これを `OPEN_FLOW_CONNECTOR_TOKEN` として保存します。
+
+```bash
+export OPEN_FLOW_CONNECTOR_TOKEN="<レスポンスに含まれる token>"
+```
+
+Open Flow に関係する token の規則は次のとおりです。
+
+- `allowedProxies` はデフォルトで空です。proxy の許可がない長期 token は `/v1/proxy/:service` を呼び出せません。
+  その場合、Poll Trigger と Integration Trigger は失敗します。`*` を許可するか、Provider Trigger を使う予定の Provider を
+  列挙してください。たとえば `["gmail","github"]` のようにします。
+- `allowedActions` と `blockedActions` は、Open Flow が実行できる Action を制限します。空のリストは、デプロイの
+  ポリシーが許可するすべての Action を許可します。
+- Open Flow を特定の Connection に限定したい場合を除き、`allowedConnections` は設定しないでください。許可範囲外の
+  Connection にバインドされた Connector Node は `connector.connection-required` で失敗します。
+
+長期 token を 1 つでも作ると、OpenConnector はすべての `/v1` と `/mcp` リクエストに runtime token を要求します。
+`oo connector` や MCP ホストなど、同じ OpenConnector を使う他の呼び出し元は、それ以降それぞれ独自の token が必要になります。
+
+## 3. Open Flow を起動する
+
+リポジトリのルートからイメージをビルドし、同じネットワーク上で起動します。
+
+```bash
+git clone https://github.com/oomol-lab/open-flow.git
+cd open-flow
+
+export OPEN_FLOW_TOKEN="$(openssl rand -hex 32)"
+docker build --file apps/server/Dockerfile --tag open-flow-server:dev .
+
+docker run -d \
+  --name open-flow \
+  --network oomol \
+  --publish 3000:3000 \
+  --volume open-flow-data:/data/open-flow \
+  --env OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN" \
+  --env OPEN_FLOW_CONNECTOR_ORIGIN="http://open-connector:3000" \
+  --env OPEN_FLOW_CONNECTOR_TOKEN="$OPEN_FLOW_CONNECTOR_TOKEN" \
+  --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
+  open-flow-server:dev
+
+curl http://localhost:3000/readyz
+```
+
+- `OPEN_FLOW_CONNECTOR_ORIGIN` は Open Flow プロセスが使うアドレスです。`oomol` ネットワーク内では、公開されたホストの
+  ポートではなく、コンテナ名とコンテナのポートになります。
+- `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` はユーザーのブラウザが開くアドレスです。Connector Node や Provider Trigger が
+  アカウントを必要とするとき、Workbench は `<console origin>/providers/<service>` にリンクします。平文の HTTP を使えるのは
+  loopback ホストだけで、それ以外はパスを含まない HTTPS origin でなければなりません。
+- `/readyz` が `{"status":"ready"}` を返すのは、Open Flow が動作しており、設定された Connector がヘルスチェックに応答する
+  場合だけです。Connector を設定した状態で 503 が返る場合、通常は runtime origin が誤っているか、コンテナが同じ
+  ネットワークにありません。
+
+`http://localhost:3000` を開き、`OPEN_FLOW_TOKEN` でサインインします。Workbench のカタログに OpenConnector の Provider と
+Action が表示されるようになります。
+
+## 4. アカウントを認可する
+
+Connection は Open Flow ではなく OpenConnector にあります。Open Flow が保存するのは Connection の ID だけで、
+Provider の認証情報を見ることはありません。
+
+GitHub の場合は、Console の GitHub ページ `http://localhost:3001/providers/github`、または admin API から personal access
+token を保存します。
+
+```bash
+curl -s -X PUT http://localhost:3001/api/connections/github \
+  -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"authType":"api_key","values":{"apiKey":"github_pat_..."}}'
+```
+
+OAuth Provider の場合は、まず Console で OAuth クライアントを設定し、その後 Provider ページからアカウントを認可します。
+OAuth クライアント、名前付き Connection、token の更新については
+[OpenConnector 認証情報ガイド](https://github.com/oomol-lab/open-connector/blob/main/docs/credentials.md)
+を参照してください。
+
+Open Flow から Connection が見えることを確認します。
+
+```bash
+export OO_OPEN_FLOW_URL="http://localhost:3000"
+export OO_OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN"
+
+oo flow connector connections github
+```
+
+## 5. oo CLI を Open Flow に向ける
+
+`oo flow` は環境変数から Open Flow を選びます。
+
+- `OO_OPEN_FLOW_URL` と `OO_OPEN_FLOW_TOKEN` の両方が設定されている場合、`oo flow` はその Open Flow に直接
+  接続します。OOMOL アカウント、Team、`OO_ENDPOINT` は読み取りません。
+- `OO_OPEN_FLOW_TOKEN` はその Open Flow の `OPEN_FLOW_TOKEN` と同じ値でなければなりません。CLI はこれを、選択した origin の
+  `/v1/` への Bearer token としてのみ送信します。
+- 2 つの変数のうち片方だけを設定するとエラーになります。両方を解除すると OOMOL Hosted に戻ります。
+
+```bash
+export OO_OPEN_FLOW_URL="http://localhost:3000"
+export OO_OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN"
+
+oo flow --help
+oo flow list
+```
+
+AI Agent に Flow を作らせるには、両方の変数がエクスポートされたシェルで Codex、Claude Code、または他のターミナル Agent を
+起動します。CLI に同梱されている `oo` skill が、いつどのように `oo flow` を呼び出すかを Agent に教えるため、プロンプトに
+Open Flow の URL や token を含める必要はありません。
+
+コマンドの全一覧と環境変数は
+[oo CLI コマンドリファレンス](https://github.com/oomol-lab/oo-cli/blob/main/docs/commands.md#open-flow) にあります。
+
+## 6. ターミナルから Flow を作る
+
+Flow は ID または正確な名前で参照できます。次のコマンドは Draft を作成し、GitHub の Connection にバインドされた Connector
+Node を追加し、確認し、実行し、公開します。
+
+```bash
+oo flow create "GitHub digest"
+oo flow connector search "current user"
+oo flow connector add "GitHub digest" github.get_current_user --name me
+oo flow check "GitHub digest"
+oo flow run "GitHub digest" --wait
+oo flow publish "GitHub digest"
+oo flow open "GitHub digest"
+```
+
+- `connector add` は、`--connection` を省略すると Action のデフォルトの Connection をバインドします。名前付きの Connection を
+  選ぶには `--connection <alias>` を渡します。
+- `check` は Revision が正しいかを確認します。認証情報が使えるか、Provider 側で実際に実行されるかは、`run` でのみ分かります。
+- `run --wait` は OpenConnector に対して Draft を実行し、結果を出力します。`oo flow runs events <run>` で完全なイベント履歴を
+  確認できます。
+- `open` は Flow の Workbench URL を出力し、ブラウザで開きます。operator token は URL に含まれず、ブラウザは自身のセッションで
+  サインインします。
+
+任意のコマンドに `--json` を追加すると、バージョン付きの機械可読出力が得られます。`oo flow node add`、`oo flow connect`、
+`oo flow trigger add`、`oo flow apply --file` は Code Task、Edge、Trigger、およびファイルからの Flow 作成に使います。
+`oo flow --help` を参照してください。
+
+## 7. 任意: oo connector から同じ OpenConnector を使う
+
+同じ OpenConnector は、Open Flow の外でも `oo connector` コマンドに利用できます。別の runtime token が必要です。
+その token は Open Flow 専用にしてください。
+
+```bash
+oo connector login http://localhost:3001 --token <別の runtime token>
+oo connector search "send an email"
+```
+
+`oo connector login` は connector コマンドにのみ影響し、`oo flow` の設定とは別に保存されます。
+[セルフホスト Connector ガイド](https://github.com/oomol-lab/oo-cli/blob/main/docs/self-hosted-connector.md) を参照してください。
+
+## 本番環境に関する注意
+
+- 両方のサービスの前段で TLS を終端します。`OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` と `OOMOL_CONNECT_ORIGIN` は Console の公開
+  HTTPS origin でなければならず、OAuth のリダイレクトと Workbench のリンクがこれを使うため、両方が同じ origin である必要が
+  あります。runtime origin はプライベートネットワーク内で HTTP のままでも構いません。信頼できないネットワークを越える場合は
+  bearer token を TLS で保護してください。
+- TLS の背後では `OPEN_FLOW_SESSION_COOKIE_SECURE=true` を設定します。
+- Integration Trigger (Provider の callback) には、さらに `OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN` と
+  `OPEN_FLOW_INTEGRATION_CALLBACK_KEY` が必要です。これらがないと Publish は失敗します。
+- すべての token は、secret またはデプロイ担当者だけが読める env ファイルを通じて渡してください。OpenConnector の runtime
+  token を Access ページで更新するときは、`OPEN_FLOW_CONNECTOR_TOKEN` も合わせて更新します。
+- 各サービスはそれぞれ独自のデータを持ちます。Open Flow は `/data/open-flow`、OpenConnector は `/app/data` です。
+  それぞれ別々にバックアップしてください。[コンテナ配布リファレンス](../container-delivery.md#6-持久化与恢复) を参照してください。
+- Fly.io では、OpenConnector と Open Flow を 1 つの organization 内の 2 つの app として実行し、runtime origin には Fly の
+  プライベートネットワーク、たとえば `http://my-open-connector.internal:3000` を使用します。
+  [Fly.io デプロイガイド](../fly-io/README.ja.md) と
+  [OpenConnector Fly.io ガイド](https://github.com/oomol-lab/open-connector/blob/main/docs/fly-io.md) を参照してください。
+
+## トラブルシューティング
+
+| 症状                                                                            | 考えられる原因                                                                                                                             |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Workbench または CLI で `connector.unavailable` が出る                          | Open Flow コンテナから `OPEN_FLOW_CONNECTOR_ORIGIN` に到達できないか、OpenConnector が `OPEN_FLOW_CONNECTOR_TOKEN` を拒否しました。        |
+| `/readyz` が 503 を返し、`/healthz` は 200 を返す                               | Connector のヘルスチェックが失敗しました。`docker logs open-flow` を確認し、両方のコンテナが同じネットワークにあることを確認してください。 |
+| 実行時に `connector.connection-required` が出る                                 | Connection が存在しないか、無効か、token の `allowedConnections` によって除外されています。Console で再認可してください。                  |
+| 手動の Action は動作するのに Poll Trigger または Integration Trigger が失敗する | runtime token にその Provider の `allowedProxies` 許可がないか、`OOMOL_CONNECT_BLOCKED_PROXIES` がブロックしています。                     |
+| `oo flow` が OOMOL へのログインを求める                                         | `OO_OPEN_FLOW_URL` または `OO_OPEN_FLOW_TOKEN` がありません。両方を同じシェルで設定する必要があります。                                    |
+| `oo flow` が 401 を返す                                                         | `OO_OPEN_FLOW_TOKEN` がその Open Flow の `OPEN_FLOW_TOKEN` と異なります。                                                                  |
+| Workbench から Console へのリンクが誤ったホストを開く                           | `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` が、ブラウザが到達できる origin ではなくコンテナのアドレスを指しています。                            |
+| OAuth 認可が誤った URL に戻る                                                   | `OOMOL_CONNECT_ORIGIN` が、ブラウザが Console を開くときに使った origin と一致していません。                                               |

--- a/docs/server/self-hosted-stack/README.ko.md
+++ b/docs/server/self-hosted-stack/README.ko.md
@@ -141,10 +141,15 @@ docker run -d \
   --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
   open-flow-server:dev
 
+ready=0
 for i in 1 2 3 4 5 6 7 8 9 10; do
-  curl -sf http://localhost:3000/readyz && break
+  if curl -sf --max-time 2 http://localhost:3000/readyz; then
+    ready=1
+    break
+  fi
   sleep 1
 done
+[ "$ready" -eq 1 ]
 ```
 
 - `OPEN_FLOW_CONNECTOR_ORIGIN`은 Open Flow 프로세스가 사용하는 주소입니다. `oomol` 네트워크 안에서는 호스트에 공개한

--- a/docs/server/self-hosted-stack/README.ko.md
+++ b/docs/server/self-hosted-stack/README.ko.md
@@ -24,7 +24,7 @@ flowchart LR
   Connector --> Providers["GitHub, Gmail, Slack, ..."]
 ```
 
-다음 네 값이 일치해야 합니다.
+다음 네 값을 설정하세요.
 
 | 용도                               | 설정 위치                                                  | 값                                                                      |
 | ---------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------- |
@@ -98,6 +98,8 @@ curl -s -X POST http://localhost:3001/api/runtime-tokens \
   -d '{"name":"open-flow","allowedActions":[],"blockedActions":[],"allowedProxies":["*"]}'
 ```
 
+`*` proxy 권한은 이 로컬 절차용입니다. 운영 환경에서는 실제로 쓰는 Provider만 나열하세요.
+
 응답의 `token` 필드는 이번에만 반환됩니다. 이 값을 `OPEN_FLOW_CONNECTOR_TOKEN`으로 저장하세요.
 
 ```bash
@@ -139,7 +141,10 @@ docker run -d \
   --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
   open-flow-server:dev
 
-curl http://localhost:3000/readyz
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  curl -sf http://localhost:3000/readyz && break
+  sleep 1
+done
 ```
 
 - `OPEN_FLOW_CONNECTOR_ORIGIN`은 Open Flow 프로세스가 사용하는 주소입니다. `oomol` 네트워크 안에서는 호스트에 공개한
@@ -148,7 +153,8 @@ curl http://localhost:3000/readyz
   계정을 필요로 할 때 Workbench는 `<console origin>/providers/<service>`로 연결합니다. 평문 HTTP는 loopback
   호스트만 사용할 수 있으며, 그 외에는 path가 없는 HTTPS origin이어야 합니다.
 - `/readyz`는 Open Flow가 실행 중이고 설정한 Connector가 헬스 체크에 응답할 때만 `{"status":"ready"}`를 반환합니다.
-  Connector를 설정했는데 503이 나오면 보통 runtime origin이 잘못되었거나 컨테이너가 같은 네트워크에 없는 경우입니다.
+  `docker run -d` 직후 몇 초 동안 503이 나오는 것은 정상입니다. 계속되면 보통 runtime origin이 잘못되었거나 컨테이너가
+  같은 네트워크에 없는 경우입니다.
 
 `http://localhost:3000`을 열고 `OPEN_FLOW_TOKEN`으로 로그인하세요. Workbench 목록에 OpenConnector의 Provider와
 Action이 나타납니다.
@@ -159,13 +165,17 @@ Connection은 Open Flow가 아니라 OpenConnector에 저장됩니다. Open Flow
 증명을 보지 않습니다.
 
 GitHub의 경우 Console의 GitHub 페이지 `http://localhost:3001/providers/github` 또는 admin API로 personal access
-token을 저장합니다.
+token을 저장합니다. `read -s` 다음에 token을 붙여넣고 Enter를 누르세요. 화면에 표시되지 않습니다.
 
 ```bash
+read -s GITHUB_PAT
 curl -s -X PUT http://localhost:3001/api/connections/github \
   -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
   -H 'content-type: application/json' \
-  -d '{"authType":"api_key","values":{"apiKey":"github_pat_..."}}'
+  --data-binary @- <<EOF
+{"authType":"api_key","values":{"apiKey":"${GITHUB_PAT}"}}
+EOF
+unset GITHUB_PAT
 ```
 
 OAuth Provider는 먼저 Console에서 OAuth 클라이언트를 설정한 뒤 Provider 페이지에서 계정을 연결하세요. OAuth
@@ -238,7 +248,7 @@ oo flow open "GitHub digest"
 ## 7. 선택: oo connector에서 같은 OpenConnector 사용하기
 
 같은 OpenConnector는 Open Flow 밖에서도 `oo connector` 명령에 쓸 수 있습니다. 별도의 runtime token이 필요합니다.
-그 token은 Open Flow 전용으로 두세요.
+Open Flow token을 재사용하지 마세요.
 
 ```bash
 oo connector login http://localhost:3001 --token <다른 runtime token>
@@ -278,5 +288,5 @@ oo connector search "send an email"
 | 수동 Action은 되는데 Poll 또는 Integration Trigger 실패 | runtime token에 해당 Provider의 `allowedProxies` 권한이 없거나 `OOMOL_CONNECT_BLOCKED_PROXIES`가 막고 있습니다.             |
 | `oo flow`가 OOMOL 로그인을 요구함                       | `OO_OPEN_FLOW_URL` 또는 `OO_OPEN_FLOW_TOKEN`이 없습니다. 둘 다 같은 셸에서 설정해야 합니다.                                 |
 | `oo flow`가 401을 반환함                                | `OO_OPEN_FLOW_TOKEN`이 그 Open Flow의 `OPEN_FLOW_TOKEN`과 다릅니다.                                                         |
-| Workbench의 Console 링크가 잘못된 호스트를 염           | `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN`이 브라우저가 접근할 수 있는 origin이 아니라 컨테이너 주소를 가리킵니다.                |
+| Workbench의 Console 링크가 잘못된 호스트를 엽니다       | `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN`이 브라우저가 접근할 수 있는 origin이 아니라 컨테이너 주소를 가리킵니다.                |
 | OAuth 인증이 잘못된 URL로 돌아옴                        | `OOMOL_CONNECT_ORIGIN`이 브라우저가 Console을 열 때 사용한 origin과 다릅니다.                                               |

--- a/docs/server/self-hosted-stack/README.ko.md
+++ b/docs/server/self-hosted-stack/README.ko.md
@@ -1,0 +1,282 @@
+# OpenConnector와 oo CLI로 Open Flow 사용하기
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+Open Flow는 단독으로 실행할 수 있습니다. 다음 두 기능에는 다른 OOMOL 프로젝트가 필요합니다.
+
+- GitHub, Gmail, Slack 같은 서비스를 호출하는 Action과 Provider Trigger에는 Connector가 필요합니다. 자체 호스팅한
+  [OpenConnector](https://github.com/oomol-lab/open-connector)가 Provider 자격 증명을 보관하고, Action을
+  실행하며, 사용자가 계정을 연결하는 Connector Console을 제공합니다.
+- Codex나 Claude Code 같은 터미널 Agent에서 Flow를 만들려면 `oo flow`를 사용합니다. `oo flow`는
+  [oo CLI](https://github.com/oomol-lab/oo-cli)가 제공하며 하나의 Open Flow의 Control API에 연결합니다.
+
+이 가이드는 Docker로 한 대의 컴퓨터에서 세 가지를 모두 시작하고, 서로 연결한 뒤, 터미널에서 첫 Flow를 만듭니다.
+환경 변수는 [컨테이너 배포 참조](../container-delivery.md#4-配置)와 동일합니다. 이 가이드는 작업 순서와
+프로젝트 간에 일치해야 하는 값만 추가로 설명합니다.
+
+```mermaid
+flowchart LR
+  Agent["터미널 Agent"] --> CLI["oo flow"]
+  CLI -->|"OO_OPEN_FLOW_TOKEN"| Flow["Open Flow :3000"]
+  Browser["브라우저"] -->|"Workbench 로그인"| Flow
+  Flow -->|"OPEN_FLOW_CONNECTOR_TOKEN"| Connector["OpenConnector :3001"]
+  Browser -->|"Connector Console"| Connector
+  Connector --> Providers["GitHub, Gmail, Slack, ..."]
+```
+
+다음 네 값이 일치해야 합니다.
+
+| 용도                               | 설정 위치                                                  | 값                                                                      |
+| ---------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `oo flow`에서 Control API로        | 셸의 `OO_OPEN_FLOW_URL`과 `OO_OPEN_FLOW_TOKEN`             | Open Flow origin과 그 Open Flow의 `OPEN_FLOW_TOKEN`과 같은 값           |
+| Open Flow에서 Connector 런타임으로 | `OPEN_FLOW_CONNECTOR_ORIGIN`과 `OPEN_FLOW_CONNECTOR_TOKEN` | Open Flow가 접근할 수 있는 runtime origin과 OpenConnector runtime token |
+| 브라우저에서 Connector Console로   | `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN`                       | OpenConnector Web Console의 공개 origin                                 |
+| 브라우저와 admin API에서 Console로 | OpenConnector의 `OOMOL_CONNECT_ADMIN_TOKEN`                | 사용자가 Console에 입력하는 admin token                                 |
+
+## 사전 요구 사항
+
+- [Docker](https://docs.docker.com/get-docker/)와 OpenSSL.
+- `oo` CLI. macOS 또는 Linux에서는 다음과 같이 설치합니다.
+
+  ```bash
+  curl -fsSL https://cli.oomol.com/install.sh | bash
+  ```
+
+  Windows와 그 밖의 설치 방법은 [oo CLI README](https://github.com/oomol-lab/oo-cli#install)를 참고하세요.
+  직접 실행 중인 Open Flow에는 `oo login`이나 OOMOL 계정이 필요 없습니다.
+
+- Gmail이나 Slack 같은 OAuth Provider를 사용하려면 해당 Provider에 등록한 앱의 OAuth 클라이언트 자격 증명이
+  필요합니다. GitHub는 personal access token으로 동작하므로 첫 Provider로 가장 빠르게 시작할 수 있습니다.
+  OOMOL이 호스팅하는 Connector에는 관리형 OAuth App이 포함되지만, 자체 호스팅 OpenConnector에는 포함되지
+  않습니다.
+
+예제에서는 OpenConnector를 호스트 포트 `3001`에, Open Flow를 호스트 포트 `3000`에 공개하고, Open Flow가 컨테이너
+이름으로 Connector에 접근할 수 있도록 두 컨테이너를 하나의 Docker 네트워크에 넣습니다.
+
+## 1. OpenConnector 시작하기
+
+```bash
+docker network create oomol
+
+export OOMOL_CONNECT_ADMIN_TOKEN="$(openssl rand -hex 32)"
+export OOMOL_CONNECT_ENCRYPTION_KEY="$(openssl rand -hex 32)"
+
+docker run -d \
+  --name open-connector \
+  --network oomol \
+  --publish 3001:3000 \
+  --volume open-connector-data:/app/data \
+  --env OOMOL_CONNECT_ORIGIN="http://localhost:3001" \
+  --env OOMOL_CONNECT_ADMIN_TOKEN="$OOMOL_CONNECT_ADMIN_TOKEN" \
+  --env OOMOL_CONNECT_ENCRYPTION_KEY="$OOMOL_CONNECT_ENCRYPTION_KEY" \
+  ghcr.io/oomol-lab/open-connector:latest
+
+curl http://localhost:3001/health
+```
+
+- `OOMOL_CONNECT_ORIGIN`은 브라우저가 OpenConnector에 접근할 때 쓰는 origin입니다. OAuth 리디렉션 URL이
+  여기에서 만들어지므로 공개한 포트와 같아야 합니다.
+- `OOMOL_CONNECT_ADMIN_TOKEN`은 admin API, `/docs`, Web Console을 보호합니다. 설정하지 않으면 포트 `3001`에
+  접근할 수 있는 누구나 자격 증명을 읽고 바꿀 수 있습니다.
+- `OOMOL_CONNECT_ENCRYPTION_KEY`는 디스크에 저장되는 자격 증명을 암호화합니다.
+
+`http://localhost:3001`을 열고 admin token을 입력한 뒤 Web Console이 로드되는지 확인하세요. PostgreSQL, 전송
+저장소, 나머지 변수는
+[OpenConnector 구성 참조](https://github.com/oomol-lab/open-connector/blob/main/docs/configuration.md)를
+참고하세요.
+
+## 2. Open Flow용 runtime token 만들기
+
+Open Flow는 `/v1` 아래의 OpenConnector runtime API를 호출합니다. Provider와 Action 목록, Connection
+목록, Action 실행, Poll 및 Integration Trigger용 `POST /v1/proxy/:service`입니다. admin token 대신 오래 쓰는
+runtime token을 주세요. Web Console의 Access 페이지나 admin API로 만들 수 있습니다.
+
+```bash
+curl -s -X POST http://localhost:3001/api/runtime-tokens \
+  -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"name":"open-flow","allowedActions":[],"blockedActions":[],"allowedProxies":["*"]}'
+```
+
+응답의 `token` 필드는 이번에만 반환됩니다. 이 값을 `OPEN_FLOW_CONNECTOR_TOKEN`으로 저장하세요.
+
+```bash
+export OPEN_FLOW_CONNECTOR_TOKEN="<응답에 포함된 token>"
+```
+
+Open Flow에 해당하는 token 규칙:
+
+- `allowedProxies`는 기본적으로 비어 있습니다. proxy 권한이 없는 장기 token은 `/v1/proxy/:service`를 호출할 수
+  없어 Poll과 Integration Trigger가 실패합니다. `*`을 허용하거나, Provider Trigger를 쓸 Provider를 나열하세요.
+  예: `["gmail","github"]`.
+- `allowedActions`와 `blockedActions`는 Open Flow가 실행할 수 있는 Action을 제한합니다. 빈 목록은 배포 정책이
+  허용하는 모든 Action을 허용합니다.
+- Open Flow를 특정 Connection으로 제한하려는 경우가 아니면 `allowedConnections`를 설정하지 마세요. 목록 밖
+  Connection에 묶인 Connector Node는 `connector.connection-required`로 실패합니다.
+
+장기 token을 하나라도 만들면 OpenConnector는 모든 `/v1`과 `/mcp` 요청에 runtime token을 요구합니다. 같은
+OpenConnector를 쓰는 `oo connector`나 MCP 호스트도 이후에는 각자 token이 필요합니다.
+
+## 3. Open Flow 시작하기
+
+저장소 루트에서 이미지를 빌드하고 같은 네트워크에서 시작합니다.
+
+```bash
+git clone https://github.com/oomol-lab/open-flow.git
+cd open-flow
+
+export OPEN_FLOW_TOKEN="$(openssl rand -hex 32)"
+docker build --file apps/server/Dockerfile --tag open-flow-server:dev .
+
+docker run -d \
+  --name open-flow \
+  --network oomol \
+  --publish 3000:3000 \
+  --volume open-flow-data:/data/open-flow \
+  --env OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN" \
+  --env OPEN_FLOW_CONNECTOR_ORIGIN="http://open-connector:3000" \
+  --env OPEN_FLOW_CONNECTOR_TOKEN="$OPEN_FLOW_CONNECTOR_TOKEN" \
+  --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
+  open-flow-server:dev
+
+curl http://localhost:3000/readyz
+```
+
+- `OPEN_FLOW_CONNECTOR_ORIGIN`은 Open Flow 프로세스가 사용하는 주소입니다. `oomol` 네트워크 안에서는 호스트에 공개한
+  포트가 아니라 컨테이너 이름과 컨테이너 포트입니다.
+- `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN`은 사용자 브라우저가 여는 주소입니다. Connector Node나 Provider Trigger가
+  계정을 필요로 할 때 Workbench는 `<console origin>/providers/<service>`로 연결합니다. 평문 HTTP는 loopback
+  호스트만 사용할 수 있으며, 그 외에는 path가 없는 HTTPS origin이어야 합니다.
+- `/readyz`는 Open Flow가 실행 중이고 설정한 Connector가 헬스 체크에 응답할 때만 `{"status":"ready"}`를 반환합니다.
+  Connector를 설정했는데 503이 나오면 보통 runtime origin이 잘못되었거나 컨테이너가 같은 네트워크에 없는 경우입니다.
+
+`http://localhost:3000`을 열고 `OPEN_FLOW_TOKEN`으로 로그인하세요. Workbench 목록에 OpenConnector의 Provider와
+Action이 나타납니다.
+
+## 4. 계정 연결하기
+
+Connection은 Open Flow가 아니라 OpenConnector에 저장됩니다. Open Flow는 Connection ID만 저장하며 Provider 자격
+증명을 보지 않습니다.
+
+GitHub의 경우 Console의 GitHub 페이지 `http://localhost:3001/providers/github` 또는 admin API로 personal access
+token을 저장합니다.
+
+```bash
+curl -s -X PUT http://localhost:3001/api/connections/github \
+  -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"authType":"api_key","values":{"apiKey":"github_pat_..."}}'
+```
+
+OAuth Provider는 먼저 Console에서 OAuth 클라이언트를 설정한 뒤 Provider 페이지에서 계정을 연결하세요. OAuth
+클라이언트, 이름이 있는 Connection, token 갱신은
+[OpenConnector 자격 증명 가이드](https://github.com/oomol-lab/open-connector/blob/main/docs/credentials.md)를
+참고하세요.
+
+Open Flow가 이 Connection을 볼 수 있는지 확인합니다.
+
+```bash
+export OO_OPEN_FLOW_URL="http://localhost:3000"
+export OO_OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN"
+
+oo flow connector connections github
+```
+
+## 5. oo CLI를 Open Flow에 연결하기
+
+`oo flow`는 환경 변수로 Open Flow를 고릅니다.
+
+- `OO_OPEN_FLOW_URL`과 `OO_OPEN_FLOW_TOKEN`을 모두 설정하면 `oo flow`는 그 Open Flow에 직접 연결합니다.
+  OOMOL 계정, Team, `OO_ENDPOINT`는 읽지 않습니다.
+- `OO_OPEN_FLOW_TOKEN`은 그 Open Flow의 `OPEN_FLOW_TOKEN`과 같아야 합니다. CLI는 선택한 origin의 `/v1/`에 Bearer
+  token으로만 보냅니다.
+- 둘 중 하나만 설정하면 오류입니다. 둘 다 해제하면 OOMOL Hosted로 돌아갑니다.
+
+```bash
+export OO_OPEN_FLOW_URL="http://localhost:3000"
+export OO_OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN"
+
+oo flow --help
+oo flow list
+```
+
+AI Agent가 Flow를 만들게 하려면 두 변수가 내보내진 셸에서 Codex, Claude Code 또는 다른 터미널 Agent를 시작하세요.
+CLI에 포함된 `oo` skill이 Agent에게 `oo flow`를 언제, 어떻게 호출할지 알려 주므로 prompt에 Open Flow URL이나 token을
+넣을 필요가 없습니다.
+
+전체 명령과 환경 변수는
+[oo CLI 명령 참조](https://github.com/oomol-lab/oo-cli/blob/main/docs/commands.md#open-flow)에 있습니다.
+
+## 6. 터미널에서 Flow 만들기
+
+Flow는 ID 또는 정확한 이름으로 지정할 수 있습니다. 아래 명령은 Draft를 만들고, GitHub Connection에 묶인 Connector
+Node를 추가한 뒤 검사, 실행, 게시합니다.
+
+```bash
+oo flow create "GitHub digest"
+oo flow connector search "current user"
+oo flow connector add "GitHub digest" github.get_current_user --name me
+oo flow check "GitHub digest"
+oo flow run "GitHub digest" --wait
+oo flow publish "GitHub digest"
+oo flow open "GitHub digest"
+```
+
+- `--connection`을 생략하면 `connector add`는 해당 Action의 기본 Connection을 묶습니다. 이름이 있는 Connection을
+  고르려면 `--connection <alias>`를 넘기세요.
+- `check`는 Revision이 올바른지 검사합니다. 자격 증명이 동작하는지, Provider에서 실제로 실행되는지는 `run`만
+  확인합니다.
+- `run --wait`는 OpenConnector를 통해 Draft를 실행하고 결과를 출력합니다. `oo flow runs events <run>`은 전체
+  이벤트 기록을 보여 줍니다.
+- `open`은 해당 Flow의 Workbench URL을 출력하고 브라우저에서 엽니다. operator token은 URL에 넣지 않으며, 브라우저는
+  자신의 session으로 로그인합니다.
+
+어떤 명령이든 `--json`을 붙이면 버전이 있는 기계 판독 출력을 얻습니다. `oo flow node add`, `oo flow connect`,
+`oo flow trigger add`, `oo flow apply --file`은 Code Task, Edge, Trigger, 파일에서 Flow 쓰기에 사용합니다.
+`oo flow --help`를 참고하세요.
+
+## 7. 선택: oo connector에서 같은 OpenConnector 사용하기
+
+같은 OpenConnector는 Open Flow 밖에서도 `oo connector` 명령에 쓸 수 있습니다. 별도의 runtime token이 필요합니다.
+그 token은 Open Flow 전용으로 두세요.
+
+```bash
+oo connector login http://localhost:3001 --token <다른 runtime token>
+oo connector search "send an email"
+```
+
+`oo connector login`은 connector 명령에만 영향을 주며 `oo flow` 설정과 따로 저장됩니다.
+[자체 호스팅 connector 가이드](https://github.com/oomol-lab/oo-cli/blob/main/docs/self-hosted-connector.md)를
+참고하세요.
+
+## 운영 환경 참고 사항
+
+- 두 서비스 앞에서 TLS를 종료하세요. `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN`과 `OOMOL_CONNECT_ORIGIN`은 Console의
+  공개 HTTPS origin이어야 하고, OAuth 리디렉션과 Workbench 링크가 이를 사용하므로 둘은 같은 origin이어야 합니다.
+  runtime origin은 사설 네트워크에서 HTTP로 둘 수 있습니다. 신뢰할 수 없는 네트워크를 지날 때는 bearer token을
+  TLS로 보호하세요.
+- TLS 뒤에는 `OPEN_FLOW_SESSION_COOKIE_SECURE=true`를 설정하세요.
+- Integration Trigger (Provider 콜백)에는 `OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN`과
+  `OPEN_FLOW_INTEGRATION_CALLBACK_KEY`도 필요합니다. 없으면 Publish가 실패합니다.
+- 모든 token은 secret 또는 배포자만 읽을 수 있는 env 파일로 넣으세요. Access 페이지에서 OpenConnector runtime
+  token을 바꿀 때 `OPEN_FLOW_CONNECTOR_TOKEN`도 함께 갱신하세요.
+- 각 서비스는 자신의 데이터를 가집니다. Open Flow는 `/data/open-flow`, OpenConnector는 `/app/data`입니다. 따로
+  백업하세요. [컨테이너 배포 참조](../container-delivery.md#6-持久化与恢复)를 참고하세요.
+- Fly.io에서는 OpenConnector와 Open Flow를 한 organization 안의 두 app으로 실행하고, runtime origin에는 Fly 사설
+  네트워크를 사용하세요. 예: `http://my-open-connector.internal:3000`.
+  [Fly.io 배포 가이드](../fly-io/README.ko.md)와
+  [OpenConnector Fly.io 가이드](https://github.com/oomol-lab/open-connector/blob/main/docs/fly-io.md)를
+  참고하세요.
+
+## 문제 해결
+
+| 증상                                                    | 가능한 원인                                                                                                                 |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Workbench 또는 CLI에서 `connector.unavailable`          | Open Flow 컨테이너가 `OPEN_FLOW_CONNECTOR_ORIGIN`에 닿지 않거나 OpenConnector가 `OPEN_FLOW_CONNECTOR_TOKEN`을 거절했습니다. |
+| `/readyz`가 503을 반환하고 `/healthz`는 200             | Connector 헬스 체크가 실패했습니다. `docker logs open-flow`를 확인하고 두 컨테이너가 같은 네트워크에 있는지 확인하세요.     |
+| 실행 시 `connector.connection-required`                 | Connection이 없거나, 비활성이거나, token의 `allowedConnections`에서 제외되었습니다. Console에서 다시 연결하세요.            |
+| 수동 Action은 되는데 Poll 또는 Integration Trigger 실패 | runtime token에 해당 Provider의 `allowedProxies` 권한이 없거나 `OOMOL_CONNECT_BLOCKED_PROXIES`가 막고 있습니다.             |
+| `oo flow`가 OOMOL 로그인을 요구함                       | `OO_OPEN_FLOW_URL` 또는 `OO_OPEN_FLOW_TOKEN`이 없습니다. 둘 다 같은 셸에서 설정해야 합니다.                                 |
+| `oo flow`가 401을 반환함                                | `OO_OPEN_FLOW_TOKEN`이 그 Open Flow의 `OPEN_FLOW_TOKEN`과 다릅니다.                                                         |
+| Workbench의 Console 링크가 잘못된 호스트를 염           | `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN`이 브라우저가 접근할 수 있는 origin이 아니라 컨테이너 주소를 가리킵니다.                |
+| OAuth 인증이 잘못된 URL로 돌아옴                        | `OOMOL_CONNECT_ORIGIN`이 브라우저가 Console을 열 때 사용한 origin과 다릅니다.                                               |

--- a/docs/server/self-hosted-stack/README.md
+++ b/docs/server/self-hosted-stack/README.md
@@ -144,10 +144,15 @@ docker run -d \
   --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
   open-flow-server:dev
 
+ready=0
 for i in 1 2 3 4 5 6 7 8 9 10; do
-  curl -sf http://localhost:3000/readyz && break
+  if curl -sf --max-time 2 http://localhost:3000/readyz; then
+    ready=1
+    break
+  fi
   sleep 1
 done
+[ "$ready" -eq 1 ]
 ```
 
 - `OPEN_FLOW_CONNECTOR_ORIGIN` is the address the Open Flow process uses. Inside the `oomol` network

--- a/docs/server/self-hosted-stack/README.md
+++ b/docs/server/self-hosted-stack/README.md
@@ -1,0 +1,288 @@
+# Use Open Flow with OpenConnector and oo CLI
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+Open Flow can run on its own. Two features need other OOMOL projects:
+
+- Actions and Provider Triggers that call GitHub, Gmail, Slack, and similar services need a
+  Connector. A self-hosted
+  [OpenConnector](https://github.com/oomol-lab/open-connector) stores provider credentials, runs
+  Actions, and serves the Connector Console where users authorize accounts.
+- Building Flows from a terminal Agent such as Codex or Claude Code goes through `oo flow`. The
+  [oo CLI](https://github.com/oomol-lab/oo-cli) provides `oo flow` and sends it to the Control API of
+  one Open Flow.
+
+This guide starts all three on one machine with Docker, connects them, and builds a first Flow from
+the terminal. The environment variables match the
+[container delivery reference](../container-delivery.md#4-配置). This guide only adds the order of
+steps and the values that must match across the projects.
+
+```mermaid
+flowchart LR
+  Agent["Terminal Agent"] --> CLI["oo flow"]
+  CLI -->|"OO_OPEN_FLOW_TOKEN"| Flow["Open Flow :3000"]
+  Browser["Browser"] -->|"Workbench sign-in"| Flow
+  Flow -->|"OPEN_FLOW_CONNECTOR_TOKEN"| Connector["OpenConnector :3001"]
+  Browser -->|"Connector Console"| Connector
+  Connector --> Providers["GitHub, Gmail, Slack, ..."]
+```
+
+These four values must match:
+
+| What                                 | Where                                                        | Value                                                                     |
+| ------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `oo flow` to the Control API         | `OO_OPEN_FLOW_URL` and `OO_OPEN_FLOW_TOKEN` in the shell     | Open Flow origin and the same value as that Open Flow's `OPEN_FLOW_TOKEN` |
+| Open Flow to the Connector runtime   | `OPEN_FLOW_CONNECTOR_ORIGIN` and `OPEN_FLOW_CONNECTOR_TOKEN` | Runtime origin Open Flow can reach and an OpenConnector runtime token     |
+| Browser to the Connector Console     | `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN`                         | Public origin of the OpenConnector Web Console                            |
+| Browser and admin API to the Console | `OOMOL_CONNECT_ADMIN_TOKEN` on OpenConnector                 | Admin token users enter in the Console                                    |
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) and OpenSSL.
+- The `oo` CLI. On macOS or Linux:
+
+  ```bash
+  curl -fsSL https://cli.oomol.com/install.sh | bash
+  ```
+
+  See the [oo CLI README](https://github.com/oomol-lab/oo-cli#install) for Windows and other
+  install paths. Your own Open Flow does not need `oo login` or an OOMOL account.
+
+- For OAuth providers such as Gmail or Slack, OAuth client credentials from apps you register with
+  those providers. GitHub works with a personal access token and is the quickest first provider.
+  OOMOL-hosted Connector deployments include managed OAuth apps; self-hosted OpenConnector does not.
+
+The examples publish OpenConnector on host port `3001` and Open Flow on host port `3000`, and put
+both containers on one Docker network so Open Flow can reach the Connector by container name.
+
+## 1. Start OpenConnector
+
+```bash
+docker network create oomol
+
+export OOMOL_CONNECT_ADMIN_TOKEN="$(openssl rand -hex 32)"
+export OOMOL_CONNECT_ENCRYPTION_KEY="$(openssl rand -hex 32)"
+
+docker run -d \
+  --name open-connector \
+  --network oomol \
+  --publish 3001:3000 \
+  --volume open-connector-data:/app/data \
+  --env OOMOL_CONNECT_ORIGIN="http://localhost:3001" \
+  --env OOMOL_CONNECT_ADMIN_TOKEN="$OOMOL_CONNECT_ADMIN_TOKEN" \
+  --env OOMOL_CONNECT_ENCRYPTION_KEY="$OOMOL_CONNECT_ENCRYPTION_KEY" \
+  ghcr.io/oomol-lab/open-connector:latest
+
+curl http://localhost:3001/health
+```
+
+- `OOMOL_CONNECT_ORIGIN` is the origin browsers use to reach OpenConnector. OAuth redirect URLs
+  are derived from it, so it must match the published port.
+- `OOMOL_CONNECT_ADMIN_TOKEN` protects the admin API, `/docs`, and the Web Console. Without it,
+  anyone who can reach port `3001` can read and change credentials.
+- `OOMOL_CONNECT_ENCRYPTION_KEY` encrypts stored credentials.
+
+Open `http://localhost:3001`, enter the admin token, and confirm the Web Console loads. The
+[OpenConnector configuration reference](https://github.com/oomol-lab/open-connector/blob/main/docs/configuration.md)
+covers PostgreSQL, transit storage, and the remaining variables.
+
+## 2. Create a runtime token for Open Flow
+
+Open Flow calls the OpenConnector runtime API under `/v1`: the provider and Action catalog,
+the Connection list, Action execution, and `POST /v1/proxy/:service` for Poll and Integration
+Triggers. Give it a long-lived runtime token rather than the admin token. Create one on the Access
+page of the Web Console, or through the admin API:
+
+```bash
+curl -s -X POST http://localhost:3001/api/runtime-tokens \
+  -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"name":"open-flow","allowedActions":[],"blockedActions":[],"allowedProxies":["*"]}'
+```
+
+The response contains the token once, as `token`. Store it as `OPEN_FLOW_CONNECTOR_TOKEN`:
+
+```bash
+export OPEN_FLOW_CONNECTOR_TOKEN="<token from the response>"
+```
+
+Token policy that matters for Open Flow:
+
+- `allowedProxies` is empty by default. A long-lived token without a proxy grant cannot call
+  `/v1/proxy/:service`, so Poll and Integration Triggers fail. Allow `*`, or list the providers
+  whose Provider Triggers you plan to use, for example `["gmail","github"]`.
+- `allowedActions` and `blockedActions` limit which Actions Open Flow can run. Empty lists allow
+  every Action that the deployment policy allows.
+- Leave `allowedConnections` unset unless you want to limit Open Flow to specific Connections. A
+  Connector Node bound to a Connection outside that list fails with `connector.connection-required`.
+
+Once any long-lived token exists, OpenConnector requires a runtime token on every `/v1` and `/mcp`
+request. Other callers of the same OpenConnector, such as `oo connector` or MCP hosts, then need
+their own tokens.
+
+## 3. Start Open Flow
+
+Build the image from the repository root and start it on the same network:
+
+```bash
+git clone https://github.com/oomol-lab/open-flow.git
+cd open-flow
+
+export OPEN_FLOW_TOKEN="$(openssl rand -hex 32)"
+docker build --file apps/server/Dockerfile --tag open-flow-server:dev .
+
+docker run -d \
+  --name open-flow \
+  --network oomol \
+  --publish 3000:3000 \
+  --volume open-flow-data:/data/open-flow \
+  --env OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN" \
+  --env OPEN_FLOW_CONNECTOR_ORIGIN="http://open-connector:3000" \
+  --env OPEN_FLOW_CONNECTOR_TOKEN="$OPEN_FLOW_CONNECTOR_TOKEN" \
+  --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
+  open-flow-server:dev
+
+curl http://localhost:3000/readyz
+```
+
+- `OPEN_FLOW_CONNECTOR_ORIGIN` is the address the Open Flow process uses. Inside the `oomol` network
+  that is the container name and the container port, not the published host port.
+- `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` is the address users' browsers open. The Workbench links to
+  `<console origin>/providers/<service>` when a Connector Node or Provider Trigger needs an account.
+  Only loopback hosts may use plain HTTP; anything else must be an HTTPS origin without a path.
+- `/readyz` returns `{"status":"ready"}` only when Open Flow is running and the configured
+  Connector answers its health check. A 503 with a configured Connector usually means the runtime
+  origin is wrong or the container is not on the same network.
+
+Open `http://localhost:3000` and sign in with `OPEN_FLOW_TOKEN`. The Workbench catalog now lists
+OpenConnector providers and Actions.
+
+## 4. Authorize an account
+
+Connections live in OpenConnector, not in Open Flow. Open Flow stores only Connection IDs and never
+sees provider credentials.
+
+For GitHub, store a personal access token through the Console's GitHub page at
+`http://localhost:3001/providers/github`, or through the admin API:
+
+```bash
+curl -s -X PUT http://localhost:3001/api/connections/github \
+  -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"authType":"api_key","values":{"apiKey":"github_pat_..."}}'
+```
+
+For OAuth providers, configure the OAuth client in the Console first, then authorize the account
+from the provider page. See the
+[OpenConnector credentials guide](https://github.com/oomol-lab/open-connector/blob/main/docs/credentials.md)
+for OAuth clients, named connections, and token refresh.
+
+Confirm Open Flow can see the Connection:
+
+```bash
+export OO_OPEN_FLOW_URL="http://localhost:3000"
+export OO_OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN"
+
+oo flow connector connections github
+```
+
+## 5. Point oo CLI at Open Flow
+
+`oo flow` selects an Open Flow from the environment:
+
+- With `OO_OPEN_FLOW_URL` and `OO_OPEN_FLOW_TOKEN` both set, `oo flow` connects directly to that
+  Open Flow. It does not read an OOMOL account, Team, or `OO_ENDPOINT`.
+- `OO_OPEN_FLOW_TOKEN` must equal that Open Flow's `OPEN_FLOW_TOKEN`. The CLI sends it only as a
+  Bearer token to `/v1/` on the selected origin.
+- Setting only one of the two variables is an error. Unset both to return to OOMOL Hosted.
+
+```bash
+export OO_OPEN_FLOW_URL="http://localhost:3000"
+export OO_OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN"
+
+oo flow --help
+oo flow list
+```
+
+To let an AI Agent build Flows, start Codex, Claude Code, or another terminal Agent in a shell
+where both variables are exported. The `oo` skill bundled with the CLI teaches the Agent when and
+how to call `oo flow`. You do not need the Open Flow URL or token in the prompt.
+
+The full command list and the environment variables are in the
+[oo CLI command reference](https://github.com/oomol-lab/oo-cli/blob/main/docs/commands.md#open-flow).
+
+## 6. Build a Flow from the terminal
+
+Flows can be referenced by ID or by exact name. The commands below create a Draft, add a Connector
+Node bound to the GitHub Connection, check it, run it, and publish it:
+
+```bash
+oo flow create "GitHub digest"
+oo flow connector search "current user"
+oo flow connector add "GitHub digest" github.get_current_user --name me
+oo flow check "GitHub digest"
+oo flow run "GitHub digest" --wait
+oo flow publish "GitHub digest"
+oo flow open "GitHub digest"
+```
+
+- `connector add` binds the Action's default Connection when `--connection` is omitted. Pass
+  `--connection <alias>` to select a named Connection.
+- `check` validates the Revision. Whether credentials work, and whether the provider actually
+  runs the Action, is only tested by `run`.
+- `run --wait` executes the Draft through OpenConnector and prints the result.
+  `oo flow runs events <run>` shows the full event history.
+- `open` prints the Workbench URL for the Flow and opens it in the browser. The operator token is
+  not placed in the URL. The browser signs in with its own session.
+
+Add `--json` to any command for versioned machine output. `oo flow node add`, `oo flow connect`,
+`oo flow trigger add`, and `oo flow apply --file` cover Code Tasks, Edges, Triggers, and writing a
+Flow from a file. See `oo flow --help`.
+
+## 7. Optional: Use the same OpenConnector from oo connector
+
+The same OpenConnector can also serve `oo connector` commands outside Open Flow. That needs a
+separate runtime token. Keep that token for Open Flow only:
+
+```bash
+oo connector login http://localhost:3001 --token <another-runtime-token>
+oo connector search "send an email"
+```
+
+`oo connector login` only affects the connector commands and is stored separately from `oo flow`
+settings. See the
+[self-hosted connector guide](https://github.com/oomol-lab/oo-cli/blob/main/docs/self-hosted-connector.md).
+
+## Production notes
+
+- Terminate TLS in front of both services. `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` and
+  `OOMOL_CONNECT_ORIGIN` must be the public HTTPS origin of the Console, and both must be the same
+  origin, because OAuth redirects and Workbench links use it. The runtime origin may stay on a
+  private network over HTTP. When it crosses an untrusted network, protect the bearer token with
+  TLS.
+- Set `OPEN_FLOW_SESSION_COOKIE_SECURE=true` behind TLS.
+- Integration Triggers (Provider callbacks) also need `OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN` and
+  `OPEN_FLOW_INTEGRATION_CALLBACK_KEY`. Without them, Publish fails.
+- Inject every token through secrets or an env file readable only by the deployer. When you rotate
+  the OpenConnector runtime token on the Access page, update `OPEN_FLOW_CONNECTOR_TOKEN` at the
+  same time.
+- Each service owns its own data: `/data/open-flow` for Open Flow and `/app/data` for
+  OpenConnector. Back them up separately. See the
+  [container delivery reference](../container-delivery.md#6-持久化与恢复).
+- On Fly.io, run OpenConnector and Open Flow as two apps in one organization and use the Fly private
+  network for the runtime origin, for example `http://my-open-connector.internal:3000`. See the
+  [Fly.io deployment guide](../fly-io/README.md) and the
+  [OpenConnector Fly.io guide](https://github.com/oomol-lab/open-connector/blob/main/docs/fly-io.md).
+
+## Troubleshooting
+
+| Symptom                                                     | Likely cause                                                                                                                     |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `connector.unavailable` in the Workbench or CLI             | `OPEN_FLOW_CONNECTOR_ORIGIN` is unreachable from the Open Flow container, or OpenConnector rejected `OPEN_FLOW_CONNECTOR_TOKEN`. |
+| `/readyz` returns 503 while `/healthz` returns 200          | The Connector health check failed. Check `docker logs open-flow` and that both containers share the network.                     |
+| `connector.connection-required` on run                      | The Connection is missing, inactive, or excluded by the token's `allowedConnections`. Re-authorize in the Console.               |
+| Poll or Integration Trigger fails while manual Actions work | The runtime token has no `allowedProxies` grant for that provider, or `OOMOL_CONNECT_BLOCKED_PROXIES` blocks it.                 |
+| `oo flow` asks for an OOMOL login                           | `OO_OPEN_FLOW_URL` or `OO_OPEN_FLOW_TOKEN` is missing. Both must be set in the same shell.                                       |
+| `oo flow` returns 401                                       | `OO_OPEN_FLOW_TOKEN` differs from that Open Flow's `OPEN_FLOW_TOKEN`.                                                            |
+| The Workbench link to the Console opens a wrong host        | `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` points at the container address instead of the origin browsers can reach.                   |
+| OAuth authorization returns to the wrong URL                | `OOMOL_CONNECT_ORIGIN` does not match the origin the browser used to open the Console.                                           |

--- a/docs/server/self-hosted-stack/README.md
+++ b/docs/server/self-hosted-stack/README.md
@@ -27,7 +27,7 @@ flowchart LR
   Connector --> Providers["GitHub, Gmail, Slack, ..."]
 ```
 
-These four values must match:
+Set these four values:
 
 | What                                 | Where                                                        | Value                                                                     |
 | ------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------------------- |
@@ -100,6 +100,8 @@ curl -s -X POST http://localhost:3001/api/runtime-tokens \
   -d '{"name":"open-flow","allowedActions":[],"blockedActions":[],"allowedProxies":["*"]}'
 ```
 
+The `*` proxy grant is for this local walkthrough. In production, list only the providers you use.
+
 The response contains the token once, as `token`. Store it as `OPEN_FLOW_CONNECTOR_TOKEN`:
 
 ```bash
@@ -142,7 +144,10 @@ docker run -d \
   --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
   open-flow-server:dev
 
-curl http://localhost:3000/readyz
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  curl -sf http://localhost:3000/readyz && break
+  sleep 1
+done
 ```
 
 - `OPEN_FLOW_CONNECTOR_ORIGIN` is the address the Open Flow process uses. Inside the `oomol` network
@@ -151,8 +156,8 @@ curl http://localhost:3000/readyz
   `<console origin>/providers/<service>` when a Connector Node or Provider Trigger needs an account.
   Only loopback hosts may use plain HTTP; anything else must be an HTTPS origin without a path.
 - `/readyz` returns `{"status":"ready"}` only when Open Flow is running and the configured
-  Connector answers its health check. A 503 with a configured Connector usually means the runtime
-  origin is wrong or the container is not on the same network.
+  Connector answers its health check. A 503 for a few seconds after `docker run -d` is normal. If
+  it lasts, the runtime origin is usually wrong or the container is not on the same network.
 
 Open `http://localhost:3000` and sign in with `OPEN_FLOW_TOKEN`. The Workbench catalog now lists
 OpenConnector providers and Actions.
@@ -163,13 +168,18 @@ Connections live in OpenConnector, not in Open Flow. Open Flow stores only Conne
 sees provider credentials.
 
 For GitHub, store a personal access token through the Console's GitHub page at
-`http://localhost:3001/providers/github`, or through the admin API:
+`http://localhost:3001/providers/github`, or through the admin API. After `read -s`, paste the
+token and press Enter. It will not print:
 
 ```bash
+read -s GITHUB_PAT
 curl -s -X PUT http://localhost:3001/api/connections/github \
   -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
   -H 'content-type: application/json' \
-  -d '{"authType":"api_key","values":{"apiKey":"github_pat_..."}}'
+  --data-binary @- <<EOF
+{"authType":"api_key","values":{"apiKey":"${GITHUB_PAT}"}}
+EOF
+unset GITHUB_PAT
 ```
 
 For OAuth providers, configure the OAuth client in the Console first, then authorize the account
@@ -242,7 +252,7 @@ Flow from a file. See `oo flow --help`.
 ## 7. Optional: Use the same OpenConnector from oo connector
 
 The same OpenConnector can also serve `oo connector` commands outside Open Flow. That needs a
-separate runtime token. Keep that token for Open Flow only:
+separate runtime token. Do not reuse the Open Flow token:
 
 ```bash
 oo connector login http://localhost:3001 --token <another-runtime-token>

--- a/docs/server/self-hosted-stack/README.ru.md
+++ b/docs/server/self-hosted-stack/README.ru.md
@@ -26,7 +26,7 @@ flowchart LR
   Connector --> Providers["GitHub, Gmail, Slack, ..."]
 ```
 
-Эти четыре значения должны совпадать:
+Задайте эти четыре значения:
 
 | Назначение                                | Где задаётся                                               | Что указать                                                            |
 | ----------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------- |
@@ -102,6 +102,9 @@ curl -s -X POST http://localhost:3001/api/runtime-tokens \
   -d '{"name":"open-flow","allowedActions":[],"blockedActions":[],"allowedProxies":["*"]}'
 ```
 
+Разрешение proxy `*` нужно для этого локального прохода. В рабочей среде перечислите только нужные
+провайдеры.
+
 В ответе поле `token` возвращается только один раз. Сохраните его как `OPEN_FLOW_CONNECTOR_TOKEN`:
 
 ```bash
@@ -144,7 +147,10 @@ docker run -d \
   --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
   open-flow-server:dev
 
-curl http://localhost:3000/readyz
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  curl -sf http://localhost:3000/readyz && break
+  sleep 1
+done
 ```
 
 - `OPEN_FLOW_CONNECTOR_ORIGIN` это адрес, которым пользуется процесс Open Flow. В сети `oomol` это имя
@@ -154,8 +160,8 @@ curl http://localhost:3000/readyz
   аккаунт. Обычный HTTP разрешён только для loopback-хостов. Во всех остальных случаях нужен HTTPS
   origin без path.
 - `/readyz` возвращает `{"status":"ready"}` только когда Open Flow работает и настроенный Connector
-  отвечает на проверку состояния. Код 503 при настроенном Connector обычно значит, что runtime origin
-  указан неверно или контейнеры не в одной сети.
+  отвечает на проверку состояния. Код 503 несколько секунд после `docker run -d` это нормально. Если
+  он не проходит, runtime origin обычно указан неверно или контейнеры не в одной сети.
 
 Откройте `http://localhost:3000` и войдите с `OPEN_FLOW_TOKEN`. В каталоге Workbench появятся
 провайдеры и Action из OpenConnector.
@@ -166,13 +172,18 @@ Connection хранятся в OpenConnector, а не в Open Flow. Open Flow с
 никогда не видит учётные данные провайдера.
 
 Для GitHub сохраните personal access token на странице GitHub в Console
-`http://localhost:3001/providers/github` или через admin API:
+`http://localhost:3001/providers/github` или через admin API. После `read -s` вставьте token и
+нажмите Enter. На экран он не выводится:
 
 ```bash
+read -s GITHUB_PAT
 curl -s -X PUT http://localhost:3001/api/connections/github \
   -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
   -H 'content-type: application/json' \
-  -d '{"authType":"api_key","values":{"apiKey":"github_pat_..."}}'
+  --data-binary @- <<EOF
+{"authType":"api_key","values":{"apiKey":"${GITHUB_PAT}"}}
+EOF
+unset GITHUB_PAT
 ```
 
 Для OAuth-провайдеров сначала настройте OAuth-клиент в Console, затем подключите аккаунт на странице
@@ -245,7 +256,7 @@ oo flow open "GitHub digest"
 ## 7. Необязательно: тот же OpenConnector из oo connector
 
 Тот же OpenConnector можно использовать и для команд `oo connector` вне Open Flow. Для этого нужен
-отдельный runtime token. Этот token оставляйте только для Open Flow:
+отдельный runtime token. Не используйте token Open Flow повторно:
 
 ```bash
 oo connector login http://localhost:3001 --token <другой-runtime-token>

--- a/docs/server/self-hosted-stack/README.ru.md
+++ b/docs/server/self-hosted-stack/README.ru.md
@@ -1,0 +1,290 @@
+# Использование Open Flow с OpenConnector и oo CLI
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+Open Flow может работать сам по себе. Для двух функций нужны другие проекты OOMOL:
+
+- Action и Provider Trigger, которые обращаются к GitHub, Gmail, Slack и похожим сервисам, требуют
+  Connector. Самостоятельно установленный
+  [OpenConnector](https://github.com/oomol-lab/open-connector) хранит учётные данные провайдеров,
+  выполняет Action и отдаёт Connector Console, где пользователи подключают аккаунты.
+- Чтобы собирать Flow из терминального Agent вроде Codex или Claude Code, нужен `oo flow`. Команду
+  даёт [oo CLI](https://github.com/oomol-lab/oo-cli) и отправляет её в Control API одного Open Flow.
+
+Это руководство запускает все три компонента на одной машине через Docker, соединяет их и создаёт
+первый Flow из терминала. Переменные окружения совпадают со
+[справочником по доставке контейнера](../container-delivery.md#4-配置). Здесь добавлены только порядок
+шагов и значения, которые должны совпадать между проектами.
+
+```mermaid
+flowchart LR
+  Agent["Терминальный Agent"] --> CLI["oo flow"]
+  CLI -->|"OO_OPEN_FLOW_TOKEN"| Flow["Open Flow :3000"]
+  Browser["Браузер"] -->|"Вход в Workbench"| Flow
+  Flow -->|"OPEN_FLOW_CONNECTOR_TOKEN"| Connector["OpenConnector :3001"]
+  Browser -->|"Connector Console"| Connector
+  Connector --> Providers["GitHub, Gmail, Slack, ..."]
+```
+
+Эти четыре значения должны совпадать:
+
+| Назначение                                | Где задаётся                                               | Что указать                                                            |
+| ----------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------- |
+| От `oo flow` к Control API                | `OO_OPEN_FLOW_URL` и `OO_OPEN_FLOW_TOKEN` в shell          | Origin этого Open Flow и то же значение, что и его `OPEN_FLOW_TOKEN`   |
+| От Open Flow к среде выполнения Connector | `OPEN_FLOW_CONNECTOR_ORIGIN` и `OPEN_FLOW_CONNECTOR_TOKEN` | Runtime origin, доступный для Open Flow, и runtime token OpenConnector |
+| От браузера к Connector Console           | `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN`                       | Публичный origin Web Console OpenConnector                             |
+| От браузера и admin API к Console         | `OOMOL_CONNECT_ADMIN_TOKEN` на OpenConnector               | Admin token, который пользователи вводят в Console                     |
+
+## Предварительные требования
+
+- [Docker](https://docs.docker.com/get-docker/) и OpenSSL.
+- CLI `oo`. На macOS или Linux:
+
+  ```bash
+  curl -fsSL https://cli.oomol.com/install.sh | bash
+  ```
+
+  Установка на Windows и другие способы описаны в
+  [README oo CLI](https://github.com/oomol-lab/oo-cli#install). Для своего Open Flow не нужны ни
+  `oo login`, ни аккаунт OOMOL.
+
+- Для OAuth-провайдеров вроде Gmail или Slack нужны данные OAuth-клиента из приложений, которые вы
+  регистрируете у этих провайдеров. GitHub работает с personal access token и подходит как самый
+  быстрый первый провайдер. У Connector, который хостит OOMOL, есть готовые OAuth-приложения. У
+  самостоятельно установленного OpenConnector их нет.
+
+В примерах OpenConnector публикуется на порт хоста `3001`, Open Flow на порт хоста `3000`, оба
+контейнера помещаются в одну сеть Docker, чтобы Open Flow мог достучаться до Connector по имени
+контейнера.
+
+## 1. Запуск OpenConnector
+
+```bash
+docker network create oomol
+
+export OOMOL_CONNECT_ADMIN_TOKEN="$(openssl rand -hex 32)"
+export OOMOL_CONNECT_ENCRYPTION_KEY="$(openssl rand -hex 32)"
+
+docker run -d \
+  --name open-connector \
+  --network oomol \
+  --publish 3001:3000 \
+  --volume open-connector-data:/app/data \
+  --env OOMOL_CONNECT_ORIGIN="http://localhost:3001" \
+  --env OOMOL_CONNECT_ADMIN_TOKEN="$OOMOL_CONNECT_ADMIN_TOKEN" \
+  --env OOMOL_CONNECT_ENCRYPTION_KEY="$OOMOL_CONNECT_ENCRYPTION_KEY" \
+  ghcr.io/oomol-lab/open-connector:latest
+
+curl http://localhost:3001/health
+```
+
+- `OOMOL_CONNECT_ORIGIN` это origin, по которому браузеры открывают OpenConnector. Адреса
+  перенаправления OAuth строятся из него, поэтому он должен совпадать с опубликованным портом.
+- `OOMOL_CONNECT_ADMIN_TOKEN` защищает admin API, `/docs` и Web Console. Без него любой, кто
+  достучится до порта `3001`, сможет читать и менять учётные данные.
+- `OOMOL_CONNECT_ENCRYPTION_KEY` шифрует учётные данные на диске.
+
+Откройте `http://localhost:3001`, введите admin token и убедитесь, что Web Console загружается.
+PostgreSQL, промежуточное хранилище и остальные переменные описаны в
+[справочнике по настройке OpenConnector](https://github.com/oomol-lab/open-connector/blob/main/docs/configuration.md).
+
+## 2. Создание runtime token для Open Flow
+
+Open Flow вызывает runtime API OpenConnector по пути `/v1`: каталог провайдеров и Action,
+список Connection, выполнение Action и `POST /v1/proxy/:service` для Poll и Integration Trigger.
+Дайте ему долгоживущий runtime token, а не admin token. Его можно создать на странице Access в Web
+Console или через admin API:
+
+```bash
+curl -s -X POST http://localhost:3001/api/runtime-tokens \
+  -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"name":"open-flow","allowedActions":[],"blockedActions":[],"allowedProxies":["*"]}'
+```
+
+В ответе поле `token` возвращается только один раз. Сохраните его как `OPEN_FLOW_CONNECTOR_TOKEN`:
+
+```bash
+export OPEN_FLOW_CONNECTOR_TOKEN="<token из ответа>"
+```
+
+Правила token, важные для Open Flow:
+
+- `allowedProxies` по умолчанию пуст. Долгоживущий token без права proxy не может вызывать
+  `/v1/proxy/:service`, поэтому Poll и Integration Trigger завершаются ошибкой. Разрешите `*` или перечислите
+  провайдеров, чьи Provider Trigger вы планируете использовать, например `["gmail","github"]`.
+- `allowedActions` и `blockedActions` ограничивают, какие Action может выполнять Open Flow. Пустые
+  списки разрешают все Action, которые допускает политика развёртывания.
+- Не задавайте `allowedConnections`, если не хотите ограничить Open Flow конкретными Connection.
+  Connector Node, привязанный к Connection вне списка, завершается с `connector.connection-required`.
+
+Как только появляется хотя бы один долгоживущий token, OpenConnector требует runtime token на каждый
+запрос `/v1` и `/mcp`. Другим клиентам того же OpenConnector, например `oo connector` или MCP-хостам,
+с этого момента тоже нужны свои token.
+
+## 3. Запуск Open Flow
+
+Соберите образ из корня репозитория и запустите его в той же сети:
+
+```bash
+git clone https://github.com/oomol-lab/open-flow.git
+cd open-flow
+
+export OPEN_FLOW_TOKEN="$(openssl rand -hex 32)"
+docker build --file apps/server/Dockerfile --tag open-flow-server:dev .
+
+docker run -d \
+  --name open-flow \
+  --network oomol \
+  --publish 3000:3000 \
+  --volume open-flow-data:/data/open-flow \
+  --env OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN" \
+  --env OPEN_FLOW_CONNECTOR_ORIGIN="http://open-connector:3000" \
+  --env OPEN_FLOW_CONNECTOR_TOKEN="$OPEN_FLOW_CONNECTOR_TOKEN" \
+  --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
+  open-flow-server:dev
+
+curl http://localhost:3000/readyz
+```
+
+- `OPEN_FLOW_CONNECTOR_ORIGIN` это адрес, которым пользуется процесс Open Flow. В сети `oomol` это имя
+  контейнера и порт контейнера, а не опубликованный порт хоста.
+- `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` это адрес, который открывают браузеры пользователей. Workbench
+  ведёт на `<console origin>/providers/<service>`, когда Connector Node или Provider Trigger нужен
+  аккаунт. Обычный HTTP разрешён только для loopback-хостов. Во всех остальных случаях нужен HTTPS
+  origin без path.
+- `/readyz` возвращает `{"status":"ready"}` только когда Open Flow работает и настроенный Connector
+  отвечает на проверку состояния. Код 503 при настроенном Connector обычно значит, что runtime origin
+  указан неверно или контейнеры не в одной сети.
+
+Откройте `http://localhost:3000` и войдите с `OPEN_FLOW_TOKEN`. В каталоге Workbench появятся
+провайдеры и Action из OpenConnector.
+
+## 4. Подключение аккаунта
+
+Connection хранятся в OpenConnector, а не в Open Flow. Open Flow сохраняет только ID Connection и
+никогда не видит учётные данные провайдера.
+
+Для GitHub сохраните personal access token на странице GitHub в Console
+`http://localhost:3001/providers/github` или через admin API:
+
+```bash
+curl -s -X PUT http://localhost:3001/api/connections/github \
+  -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"authType":"api_key","values":{"apiKey":"github_pat_..."}}'
+```
+
+Для OAuth-провайдеров сначала настройте OAuth-клиент в Console, затем подключите аккаунт на странице
+провайдера. Про OAuth-клиенты, именованные Connection и обновление token см.
+[руководство по учётным данным OpenConnector](https://github.com/oomol-lab/open-connector/blob/main/docs/credentials.md).
+
+Проверьте, что Open Flow видит этот Connection:
+
+```bash
+export OO_OPEN_FLOW_URL="http://localhost:3000"
+export OO_OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN"
+
+oo flow connector connections github
+```
+
+## 5. Настройка oo CLI на Open Flow
+
+`oo flow` выбирает Open Flow по переменным окружения:
+
+- Если заданы и `OO_OPEN_FLOW_URL`, и `OO_OPEN_FLOW_TOKEN`, `oo flow` подключается напрямую к этому
+  Open Flow. Аккаунт OOMOL, Team и `OO_ENDPOINT` не читаются.
+- `OO_OPEN_FLOW_TOKEN` должен совпадать с `OPEN_FLOW_TOKEN` этого Open Flow. CLI отправляет его только
+  как Bearer token на `/v1/` выбранного origin.
+- Если задана только одна из двух переменных, это ошибка. Снимите обе, чтобы вернуться к OOMOL
+  Hosted.
+
+```bash
+export OO_OPEN_FLOW_URL="http://localhost:3000"
+export OO_OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN"
+
+oo flow --help
+oo flow list
+```
+
+Чтобы AI Agent создавал Flow, запускайте Codex, Claude Code или другой терминальный Agent в shell, где
+экспортированы обе переменные. Встроенный в CLI skill `oo` учит Agent, когда и как вызывать
+`oo flow`. URL Open Flow и token в prompt писать не нужно.
+
+Полный список команд и переменные окружения есть в
+[справочнике команд oo CLI](https://github.com/oomol-lab/oo-cli/blob/main/docs/commands.md#open-flow).
+
+## 6. Создание Flow из терминала
+
+Flow можно указывать по ID или точному имени. Команды ниже создают Draft, добавляют Connector Node,
+привязанный к GitHub Connection, проверяют, запускают и публикуют его:
+
+```bash
+oo flow create "GitHub digest"
+oo flow connector search "current user"
+oo flow connector add "GitHub digest" github.get_current_user --name me
+oo flow check "GitHub digest"
+oo flow run "GitHub digest" --wait
+oo flow publish "GitHub digest"
+oo flow open "GitHub digest"
+```
+
+- Если `--connection` не указан, `connector add` привязывает Connection по умолчанию для этого
+  Action. Передайте `--connection <alias>`, чтобы выбрать именованный Connection.
+- `check` проверяет, корректен ли Revision. Работают ли учётные данные и выполняется ли Action у
+  провайдера, проверяет только `run`.
+- `run --wait` выполняет Draft через OpenConnector и печатает результат.
+  `oo flow runs events <run>` показывает полную историю событий.
+- `open` печатает URL Workbench для этого Flow и открывает его в браузере. Operator token в URL не
+  попадает. Браузер входит со своей сессией.
+
+Добавьте `--json` к любой команде, чтобы получить машиночитаемый вывод с версией. `oo flow node add`,
+`oo flow connect`, `oo flow trigger add` и `oo flow apply --file` нужны для Code Task, Edge, Trigger
+и записи Flow из файла. См. `oo flow --help`.
+
+## 7. Необязательно: тот же OpenConnector из oo connector
+
+Тот же OpenConnector можно использовать и для команд `oo connector` вне Open Flow. Для этого нужен
+отдельный runtime token. Этот token оставляйте только для Open Flow:
+
+```bash
+oo connector login http://localhost:3001 --token <другой-runtime-token>
+oo connector search "send an email"
+```
+
+`oo connector login` влияет только на команды connector и хранится отдельно от настроек `oo flow`.
+См. [руководство по своему connector](https://github.com/oomol-lab/oo-cli/blob/main/docs/self-hosted-connector.md).
+
+## Замечания для рабочей среды
+
+- Завершайте TLS перед обоими сервисами. `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` и
+  `OOMOL_CONNECT_ORIGIN` должны быть публичным HTTPS origin Console, и оба должны совпадать, потому
+  что их используют перенаправления OAuth и ссылки Workbench. Runtime origin может оставаться в
+  частной сети по HTTP. Если он идёт по недоверенной сети, защитите bearer token с помощью TLS.
+- За TLS задайте `OPEN_FLOW_SESSION_COOKIE_SECURE=true`.
+- Integration Trigger (обратные вызовы провайдера) также требуют
+  `OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN` и `OPEN_FLOW_INTEGRATION_CALLBACK_KEY`. Без них Publish
+  завершается ошибкой.
+- Все token передавайте через secrets или env-файл, который может читать только тот, кто
+  развёртывает. Когда меняете runtime token OpenConnector на странице Access, сразу обновите
+  `OPEN_FLOW_CONNECTOR_TOKEN`.
+- У каждого сервиса свои данные: `/data/open-flow` у Open Flow и `/app/data` у OpenConnector.
+  Резервные копии делайте отдельно. См.
+  [справочник по доставке контейнера](../container-delivery.md#6-持久化与恢复).
+- На Fly.io запускайте OpenConnector и Open Flow как два app в одной organization и используйте
+  частную сеть Fly для runtime origin, например `http://my-open-connector.internal:3000`. См.
+  [руководство по развёртыванию на Fly.io](../fly-io/README.ru.md) и
+  [руководство OpenConnector по Fly.io](https://github.com/oomol-lab/open-connector/blob/main/docs/fly-io.md).
+
+## Устранение неполадок
+
+| Симптом                                                                    | Вероятная причина                                                                                                          |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `connector.unavailable` в Workbench или CLI                                | Контейнер Open Flow не достучался до `OPEN_FLOW_CONNECTOR_ORIGIN`, или OpenConnector отклонил `OPEN_FLOW_CONNECTOR_TOKEN`. |
+| `/readyz` возвращает 503, а `/healthz` возвращает 200                      | Не прошла проверка состояния Connector. Смотрите `docker logs open-flow` и убедитесь, что оба контейнера в одной сети.     |
+| `connector.connection-required` при запуске                                | Connection отсутствует, неактивен или исключён `allowedConnections` у token. Подключите аккаунт заново в Console.          |
+| Poll или Integration Trigger завершаются ошибкой, а ручные Action работают | У runtime token нет права `allowedProxies` для этого провайдера, или его блокирует `OOMOL_CONNECT_BLOCKED_PROXIES`.        |
+| `oo flow` просит войти в OOMOL                                             | Нет `OO_OPEN_FLOW_URL` или `OO_OPEN_FLOW_TOKEN`. Обе переменные нужно задать в одном shell.                                |
+| `oo flow` возвращает 401                                                   | `OO_OPEN_FLOW_TOKEN` отличается от `OPEN_FLOW_TOKEN` этого Open Flow.                                                      |
+| Ссылка Workbench на Console открывает неверный хост                        | `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` указывает на адрес контейнера, а не на origin, доступный браузеру.                    |
+| OAuth возвращает на неверный URL                                           | `OOMOL_CONNECT_ORIGIN` не совпадает с origin, которым браузер открывал Console.                                            |

--- a/docs/server/self-hosted-stack/README.ru.md
+++ b/docs/server/self-hosted-stack/README.ru.md
@@ -147,10 +147,15 @@ docker run -d \
   --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
   open-flow-server:dev
 
+ready=0
 for i in 1 2 3 4 5 6 7 8 9 10; do
-  curl -sf http://localhost:3000/readyz && break
+  if curl -sf --max-time 2 http://localhost:3000/readyz; then
+    ready=1
+    break
+  fi
   sleep 1
 done
+[ "$ready" -eq 1 ]
 ```
 
 - `OPEN_FLOW_CONNECTOR_ORIGIN` это адрес, которым пользуется процесс Open Flow. В сети `oomol` это имя

--- a/docs/server/self-hosted-stack/README.zh-CN.md
+++ b/docs/server/self-hosted-stack/README.zh-CN.md
@@ -1,0 +1,253 @@
+# 用 OpenConnector 和 oo CLI 运行 Open Flow
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+Open Flow 可以单独运行。下面两类功能还需要另外两个项目：
+
+- 调用 GitHub、Gmail、Slack 等服务的 Action 和 Provider Trigger 需要 Connector。自行部署的
+  [OpenConnector](https://github.com/oomol-lab/open-connector) 保存账号凭据、执行 Action，并提供用户授权账号的
+  Connector Console。
+- 在 Codex、Claude Code 这类终端 Agent 里编写 Flow，要经过 `oo flow`。`oo flow` 由
+  [oo CLI](https://github.com/oomol-lab/oo-cli) 提供，并连到某一套 Open Flow 的 Control API。
+
+本文用 Docker 在同一台机器上启动这三者，把它们连起来，再从终端创建第一个 Flow。环境变量与
+[容器交付参考](../container-delivery.md#4-配置)相同。这里只补充操作顺序，以及各项目之间必须一致的值。
+
+```mermaid
+flowchart LR
+  Agent["终端 Agent"] --> CLI["oo flow"]
+  CLI -->|"OO_OPEN_FLOW_TOKEN"| Flow["Open Flow :3000"]
+  Browser["浏览器"] -->|"Workbench 登录"| Flow
+  Flow -->|"OPEN_FLOW_CONNECTOR_TOKEN"| Connector["OpenConnector :3001"]
+  Browser -->|"Connector Console"| Connector
+  Connector --> Providers["GitHub, Gmail, Slack, ..."]
+```
+
+这四组值必须一致：
+
+| 用途                          | 写在哪里                                                    | 填什么                                                                  |
+| ----------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `oo flow` 到 Control API      | shell 中的 `OO_OPEN_FLOW_URL` 和 `OO_OPEN_FLOW_TOKEN`       | Open Flow origin，以及与这套 Open Flow 的 `OPEN_FLOW_TOKEN` 相同的值    |
+| Open Flow 到 Connector 运行时 | `OPEN_FLOW_CONNECTOR_ORIGIN` 和 `OPEN_FLOW_CONNECTOR_TOKEN` | Open Flow 能访问的 runtime origin，以及一个 OpenConnector runtime token |
+| 浏览器到 Connector Console    | `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN`                        | OpenConnector Web Console 的公网 origin                                 |
+| 浏览器和管理 API 到 Console   | OpenConnector 侧的 `OOMOL_CONNECT_ADMIN_TOKEN`              | 用户在 Console 中输入的管理 token                                       |
+
+## 前置条件
+
+- [Docker](https://docs.docker.com/get-docker/) 和 OpenSSL。
+- `oo` CLI。macOS 或 Linux：
+
+  ```bash
+  curl -fsSL https://cli.oomol.com/install.sh | bash
+  ```
+
+  Windows 及其他安装方式见 [oo CLI README](https://github.com/oomol-lab/oo-cli#install)。使用自己部署的 Open Flow 不需要
+  `oo login`，也不需要 OOMOL 账号。
+
+- 对于 Gmail、Slack 等 OAuth Provider，需要你在这些 Provider 处注册应用得到的 OAuth client 凭据。GitHub 可以用 personal
+  access token，是最快能跑通的第一个 Provider。OOMOL 托管的 Connector 自带托管 OAuth 应用，自行部署的 OpenConnector 没有。
+
+示例把 OpenConnector 发布到宿主机端口 `3001`，Open Flow 发布到宿主机端口 `3000`，并把两个容器放进同一个 Docker 网络，
+这样 Open Flow 可以通过容器名访问 Connector。
+
+## 1. 启动 OpenConnector
+
+```bash
+docker network create oomol
+
+export OOMOL_CONNECT_ADMIN_TOKEN="$(openssl rand -hex 32)"
+export OOMOL_CONNECT_ENCRYPTION_KEY="$(openssl rand -hex 32)"
+
+docker run -d \
+  --name open-connector \
+  --network oomol \
+  --publish 3001:3000 \
+  --volume open-connector-data:/app/data \
+  --env OOMOL_CONNECT_ORIGIN="http://localhost:3001" \
+  --env OOMOL_CONNECT_ADMIN_TOKEN="$OOMOL_CONNECT_ADMIN_TOKEN" \
+  --env OOMOL_CONNECT_ENCRYPTION_KEY="$OOMOL_CONNECT_ENCRYPTION_KEY" \
+  ghcr.io/oomol-lab/open-connector:latest
+
+curl http://localhost:3001/health
+```
+
+- `OOMOL_CONNECT_ORIGIN` 是浏览器访问 OpenConnector 的 origin。OAuth 回调地址由它生成，所以必须与发布的端口一致。
+- `OOMOL_CONNECT_ADMIN_TOKEN` 保护管理 API、`/docs` 和 Web Console。不设置的话，任何能访问 `3001` 端口的人都能读取和修改凭据。
+- `OOMOL_CONNECT_ENCRYPTION_KEY` 用于加密保存在磁盘上的凭据。
+
+打开 `http://localhost:3001`，输入管理 token，确认 Web Console 能正常加载。PostgreSQL、中转存储和其余变量见
+[OpenConnector 配置参考](https://github.com/oomol-lab/open-connector/blob/main/docs/configuration.md)。
+
+## 2. 为 Open Flow 创建 runtime token
+
+Open Flow 调用 OpenConnector 位于 `/v1` 的运行时 API：Provider 与 Action 目录、Connection 列表、Action 执行，以及供
+Poll 和 Integration Trigger 使用的 `POST /v1/proxy/:service`。给它一个长期使用的 runtime token，不要用管理 token。可以在 Web
+Console 的 Access 页面创建，也可以通过管理 API 创建：
+
+```bash
+curl -s -X POST http://localhost:3001/api/runtime-tokens \
+  -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"name":"open-flow","allowedActions":[],"blockedActions":[],"allowedProxies":["*"]}'
+```
+
+响应中的 `token` 字段只会返回这一次。把它保存为 `OPEN_FLOW_CONNECTOR_TOKEN`：
+
+```bash
+export OPEN_FLOW_CONNECTOR_TOKEN="<响应中的 token>"
+```
+
+与 Open Flow 相关的 token 规则：
+
+- `allowedProxies` 默认为空。没有 proxy 权限的长期 token 无法调用 `/v1/proxy/:service`，Poll 和 Integration Trigger
+  会因此失败。允许 `*`，或列出你打算使用 Provider Trigger 的 Provider，例如 `["gmail","github"]`。
+- `allowedActions` 和 `blockedActions` 限制 Open Flow 可执行的 Action。空列表表示允许部署策略放行的全部 Action。
+- 除非要把 Open Flow 限定到特定 Connection，否则不要设置 `allowedConnections`。绑定到列表之外 Connection 的 Connector
+  Node 会以 `connector.connection-required` 失败。
+
+只要创建过长期 token，OpenConnector 就会要求每个 `/v1` 和 `/mcp` 请求都带 runtime token。同一套 OpenConnector 的其他调用方，例如
+`oo connector` 或 MCP host，从此也需要各自的 token。
+
+## 3. 启动 Open Flow
+
+在仓库根目录构建镜像，并在同一网络中启动：
+
+```bash
+git clone https://github.com/oomol-lab/open-flow.git
+cd open-flow
+
+export OPEN_FLOW_TOKEN="$(openssl rand -hex 32)"
+docker build --file apps/server/Dockerfile --tag open-flow-server:dev .
+
+docker run -d \
+  --name open-flow \
+  --network oomol \
+  --publish 3000:3000 \
+  --volume open-flow-data:/data/open-flow \
+  --env OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN" \
+  --env OPEN_FLOW_CONNECTOR_ORIGIN="http://open-connector:3000" \
+  --env OPEN_FLOW_CONNECTOR_TOKEN="$OPEN_FLOW_CONNECTOR_TOKEN" \
+  --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
+  open-flow-server:dev
+
+curl http://localhost:3000/readyz
+```
+
+- `OPEN_FLOW_CONNECTOR_ORIGIN` 是 Open Flow 进程使用的地址。在 `oomol` 网络内它是容器名加容器端口，而不是发布到宿主机的端口。
+- `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` 是用户浏览器打开的地址。当 Connector Node 或 Provider Trigger 需要账号时，Workbench
+  会链接到 `<console origin>/providers/<service>`。只有 loopback 主机可以使用明文 HTTP，其余情况必须是不带 path 的 HTTPS origin。
+- 只有当 Open Flow 在运行且配置的 Connector 通过健康检查时，`/readyz` 才返回 `{"status":"ready"}`。配置了 Connector 却返回 503，
+  通常是 runtime origin 写错，或容器不在同一网络。
+
+打开 `http://localhost:3000`，用 `OPEN_FLOW_TOKEN` 登录。Workbench 的目录中现在会列出 OpenConnector 的 Provider 和 Action。
+
+## 4. 授权账号
+
+Connection 保存在 OpenConnector 中，而不是 Open Flow 中。Open Flow 只保存 Connection 的 ID，永远接触不到 Provider 凭据。
+
+对于 GitHub，可以在 Console 的 GitHub 页面 `http://localhost:3001/providers/github` 保存 personal access token，也可以通过管理 API：
+
+```bash
+curl -s -X PUT http://localhost:3001/api/connections/github \
+  -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"authType":"api_key","values":{"apiKey":"github_pat_..."}}'
+```
+
+对于 OAuth Provider，先在 Console 中配置 OAuth client，再从 Provider 页面授权账号。OAuth client、命名 Connection 和 token
+刷新见 [OpenConnector 凭据指南](https://github.com/oomol-lab/open-connector/blob/main/docs/credentials.md)。
+
+确认 Open Flow 能看到这个 Connection：
+
+```bash
+export OO_OPEN_FLOW_URL="http://localhost:3000"
+export OO_OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN"
+
+oo flow connector connections github
+```
+
+## 5. 把 oo CLI 指向 Open Flow
+
+`oo flow` 根据环境变量选择 Open Flow：
+
+- 同时设置 `OO_OPEN_FLOW_URL` 和 `OO_OPEN_FLOW_TOKEN` 时，`oo flow` 直接连到这套 Open Flow，不读取 OOMOL 账号、Team 或
+  `OO_ENDPOINT`。
+- `OO_OPEN_FLOW_TOKEN` 必须等于这套 Open Flow 的 `OPEN_FLOW_TOKEN`。CLI 只把它作为 Bearer token 发送到所选 origin 的 `/v1/`。
+- 只设置其中一个变量会报错。两个都取消设置即可回到 OOMOL Hosted。
+
+```bash
+export OO_OPEN_FLOW_URL="http://localhost:3000"
+export OO_OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN"
+
+oo flow --help
+oo flow list
+```
+
+要让 AI Agent 创建 Flow，在已导出这两个变量的 shell 中启动 Codex、Claude Code 或其他终端 Agent。CLI 自带的 `oo` skill
+会教 Agent 何时以及如何调用 `oo flow`，不需要在 prompt 里写 Open Flow 的 URL 或 token。
+
+完整命令列表和环境变量见 [oo CLI 命令参考](https://github.com/oomol-lab/oo-cli/blob/main/docs/commands.md#open-flow)。
+
+## 6. 从终端创建 Flow
+
+Flow 可以用 ID 或精确名称引用。下面的命令创建一个 Draft，添加一个绑定到 GitHub Connection 的 Connector Node，检查、运行并发布：
+
+```bash
+oo flow create "GitHub digest"
+oo flow connector search "current user"
+oo flow connector add "GitHub digest" github.get_current_user --name me
+oo flow check "GitHub digest"
+oo flow run "GitHub digest" --wait
+oo flow publish "GitHub digest"
+oo flow open "GitHub digest"
+```
+
+- 省略 `--connection` 时，`connector add` 绑定该 Action 的默认 Connection。传 `--connection <alias>` 可选择命名 Connection。
+- `check` 检查 Revision 是否合法。账号是否可用、会不会在 Provider 上真正执行，只有 `run` 才会碰到。
+- `run --wait` 通过 OpenConnector 执行 Draft 并打印结果。`oo flow runs events <run>` 显示完整事件历史。
+- `open` 打印该 Flow 的 Workbench URL 并在浏览器中打开。operator token 不会放进 URL，浏览器用自己的 session 登录。
+
+给任意命令加上 `--json` 可得到带版本的机器可读输出。`oo flow node add`、`oo flow connect`、`oo flow trigger add` 和
+`oo flow apply --file` 分别用于 Code Task、Edge、Trigger，以及从文件写入 Flow，见 `oo flow --help`。
+
+## 7. 可选：在 oo connector 中复用同一套 OpenConnector
+
+同一个 OpenConnector 也可以在 Open Flow 之外给 `oo connector` 命令用。这需要另一个 runtime token。Open Flow 的 token
+应只给 Open Flow 用：
+
+```bash
+oo connector login http://localhost:3001 --token <另一个 runtime token>
+oo connector search "send an email"
+```
+
+`oo connector login` 只影响 connector 命令，其配置与 `oo flow` 的设置分开保存。见
+[自行部署 connector 指南](https://github.com/oomol-lab/oo-cli/blob/main/docs/self-hosted-connector.md)。
+
+## 生产环境注意事项
+
+- 在两个服务前面终止 TLS。`OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` 和 `OOMOL_CONNECT_ORIGIN` 必须是 Console 的公网 HTTPS
+  origin，且两者必须是同一个 origin，因为 OAuth 回调和 Workbench 链接都使用它。runtime origin 可以留在私网走 HTTP。
+  跨不受信任网络时必须用 TLS 保护 bearer token。
+- TLS 之后设置 `OPEN_FLOW_SESSION_COOKIE_SECURE=true`。
+- Integration Trigger (Provider 回调) 还需要 `OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN` 和
+  `OPEN_FLOW_INTEGRATION_CALLBACK_KEY`。缺少时 Publish 会失败。
+- 所有 token 都通过 secret 或只有部署者可读的 env file 注入。在 Access 页面更换 OpenConnector runtime token 时，要同步更新
+  `OPEN_FLOW_CONNECTOR_TOKEN`。
+- 每个服务拥有自己的数据：Open Flow 在 `/data/open-flow`，OpenConnector 在 `/app/data`。分别备份，见
+  [容器交付参考](../container-delivery.md#6-持久化与恢复)。
+- 在 Fly.io 上，把 OpenConnector 和 Open Flow 作为同一 organization 下的两个 app 运行，runtime origin 使用 Fly 私网，例如
+  `http://my-open-connector.internal:3000`。见 [Fly.io 部署指南](../fly-io/README.zh-CN.md) 和
+  [OpenConnector Fly.io 指南](https://github.com/oomol-lab/open-connector/blob/main/docs/fly-io.md)。
+
+## 故障排查
+
+| 现象                                                | 可能原因                                                                                                   |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Workbench 或 CLI 出现 `connector.unavailable`       | Open Flow 容器访问不到 `OPEN_FLOW_CONNECTOR_ORIGIN`，或 OpenConnector 拒绝了 `OPEN_FLOW_CONNECTOR_TOKEN`。 |
+| `/readyz` 返回 503 而 `/healthz` 返回 200           | Connector 健康检查失败。查看 `docker logs open-flow`，并确认两个容器在同一网络。                           |
+| 运行时出现 `connector.connection-required`          | Connection 缺失、未激活，或被 token 的 `allowedConnections` 排除。到 Console 重新授权。                    |
+| 手动 Action 正常但 Poll 或 Integration Trigger 失败 | runtime token 对该 Provider 没有 `allowedProxies` 权限，或被 `OOMOL_CONNECT_BLOCKED_PROXIES` 阻止。        |
+| `oo flow` 要求登录 OOMOL                            | 缺少 `OO_OPEN_FLOW_URL` 或 `OO_OPEN_FLOW_TOKEN`。两者必须在同一个 shell 中设置。                           |
+| `oo flow` 返回 401                                  | `OO_OPEN_FLOW_TOKEN` 与这套 Open Flow 的 `OPEN_FLOW_TOKEN` 不一致。                                        |
+| Workbench 指向 Console 的链接打开了错误的主机       | `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` 指向了容器地址，而不是浏览器可访问的 origin。                         |
+| OAuth 授权跳回了错误的 URL                          | `OOMOL_CONNECT_ORIGIN` 与浏览器打开 Console 时使用的 origin 不一致。                                       |

--- a/docs/server/self-hosted-stack/README.zh-CN.md
+++ b/docs/server/self-hosted-stack/README.zh-CN.md
@@ -23,7 +23,7 @@ flowchart LR
   Connector --> Providers["GitHub, Gmail, Slack, ..."]
 ```
 
-这四组值必须一致：
+需要设置这四组值：
 
 | 用途                          | 写在哪里                                                    | 填什么                                                                  |
 | ----------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------- |
@@ -91,6 +91,8 @@ curl -s -X POST http://localhost:3001/api/runtime-tokens \
   -d '{"name":"open-flow","allowedActions":[],"blockedActions":[],"allowedProxies":["*"]}'
 ```
 
+`*` 只用于这次本机走通。生产环境请只列出你实际要用的 Provider。
+
 响应中的 `token` 字段只会返回这一次。把它保存为 `OPEN_FLOW_CONNECTOR_TOKEN`：
 
 ```bash
@@ -130,14 +132,17 @@ docker run -d \
   --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
   open-flow-server:dev
 
-curl http://localhost:3000/readyz
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  curl -sf http://localhost:3000/readyz && break
+  sleep 1
+done
 ```
 
 - `OPEN_FLOW_CONNECTOR_ORIGIN` 是 Open Flow 进程使用的地址。在 `oomol` 网络内它是容器名加容器端口，而不是发布到宿主机的端口。
 - `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` 是用户浏览器打开的地址。当 Connector Node 或 Provider Trigger 需要账号时，Workbench
   会链接到 `<console origin>/providers/<service>`。只有 loopback 主机可以使用明文 HTTP，其余情况必须是不带 path 的 HTTPS origin。
-- 只有当 Open Flow 在运行且配置的 Connector 通过健康检查时，`/readyz` 才返回 `{"status":"ready"}`。配置了 Connector 却返回 503，
-  通常是 runtime origin 写错，或容器不在同一网络。
+- 只有当 Open Flow 在运行且配置的 Connector 通过健康检查时，`/readyz` 才返回 `{"status":"ready"}`。`docker run -d` 之后几秒内出现
+  503 是正常的。如果一直 503，通常是 runtime origin 写错，或容器不在同一网络。
 
 打开 `http://localhost:3000`，用 `OPEN_FLOW_TOKEN` 登录。Workbench 的目录中现在会列出 OpenConnector 的 Provider 和 Action。
 
@@ -145,13 +150,18 @@ curl http://localhost:3000/readyz
 
 Connection 保存在 OpenConnector 中，而不是 Open Flow 中。Open Flow 只保存 Connection 的 ID，永远接触不到 Provider 凭据。
 
-对于 GitHub，可以在 Console 的 GitHub 页面 `http://localhost:3001/providers/github` 保存 personal access token，也可以通过管理 API：
+对于 GitHub，可以在 Console 的 GitHub 页面 `http://localhost:3001/providers/github` 保存 personal access token，也可以通过管理 API。
+`read -s` 后粘贴 token 再按 Enter，屏幕上不会显示：
 
 ```bash
+read -s GITHUB_PAT
 curl -s -X PUT http://localhost:3001/api/connections/github \
   -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
   -H 'content-type: application/json' \
-  -d '{"authType":"api_key","values":{"apiKey":"github_pat_..."}}'
+  --data-binary @- <<EOF
+{"authType":"api_key","values":{"apiKey":"${GITHUB_PAT}"}}
+EOF
+unset GITHUB_PAT
 ```
 
 对于 OAuth Provider，先在 Console 中配置 OAuth client，再从 Provider 页面授权账号。OAuth client、命名 Connection 和 token
@@ -212,8 +222,7 @@ oo flow open "GitHub digest"
 
 ## 7. 可选：在 oo connector 中复用同一套 OpenConnector
 
-同一个 OpenConnector 也可以在 Open Flow 之外给 `oo connector` 命令用。这需要另一个 runtime token。Open Flow 的 token
-应只给 Open Flow 用：
+同一个 OpenConnector 也可以在 Open Flow 之外给 `oo connector` 命令用。这需要另一个 runtime token。不要复用 Open Flow 的 token：
 
 ```bash
 oo connector login http://localhost:3001 --token <另一个 runtime token>

--- a/docs/server/self-hosted-stack/README.zh-CN.md
+++ b/docs/server/self-hosted-stack/README.zh-CN.md
@@ -132,10 +132,15 @@ docker run -d \
   --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
   open-flow-server:dev
 
+ready=0
 for i in 1 2 3 4 5 6 7 8 9 10; do
-  curl -sf http://localhost:3000/readyz && break
+  if curl -sf --max-time 2 http://localhost:3000/readyz; then
+    ready=1
+    break
+  fi
   sleep 1
 done
+[ "$ready" -eq 1 ]
 ```
 
 - `OPEN_FLOW_CONNECTOR_ORIGIN` 是 Open Flow 进程使用的地址。在 `oomol` 网络内它是容器名加容器端口，而不是发布到宿主机的端口。

--- a/docs/server/self-hosted-stack/README.zh-TW.md
+++ b/docs/server/self-hosted-stack/README.zh-TW.md
@@ -1,0 +1,253 @@
+# 用 OpenConnector 和 oo CLI 執行 Open Flow
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+Open Flow 可以單獨執行。下面兩類功能還需要另外兩個專案：
+
+- 呼叫 GitHub、Gmail、Slack 等服務的 Action 和 Provider Trigger 需要 Connector。自行部署的
+  [OpenConnector](https://github.com/oomol-lab/open-connector) 保存帳號憑證、執行 Action，並提供使用者授權帳號的
+  Connector Console。
+- 在 Codex、Claude Code 這類終端 Agent 裡編寫 Flow，要經過 `oo flow`。`oo flow` 由
+  [oo CLI](https://github.com/oomol-lab/oo-cli) 提供，並連到某一套 Open Flow 的 Control API。
+
+本文用 Docker 在同一台機器上啟動這三者，把它們連起來，再從終端建立第一個 Flow。環境變數與
+[容器交付參考](../container-delivery.md#4-配置)相同。這裡只補充操作順序，以及各專案之間必須一致的值。
+
+```mermaid
+flowchart LR
+  Agent["終端 Agent"] --> CLI["oo flow"]
+  CLI -->|"OO_OPEN_FLOW_TOKEN"| Flow["Open Flow :3000"]
+  Browser["瀏覽器"] -->|"Workbench 登入"| Flow
+  Flow -->|"OPEN_FLOW_CONNECTOR_TOKEN"| Connector["OpenConnector :3001"]
+  Browser -->|"Connector Console"| Connector
+  Connector --> Providers["GitHub, Gmail, Slack, ..."]
+```
+
+這四組值必須一致：
+
+| 用途                            | 寫在哪裡                                                    | 填什麼                                                                  |
+| ------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `oo flow` 到 Control API        | shell 中的 `OO_OPEN_FLOW_URL` 和 `OO_OPEN_FLOW_TOKEN`       | Open Flow origin，以及與這套 Open Flow 的 `OPEN_FLOW_TOKEN` 相同的值    |
+| Open Flow 到 Connector 執行環境 | `OPEN_FLOW_CONNECTOR_ORIGIN` 和 `OPEN_FLOW_CONNECTOR_TOKEN` | Open Flow 能連到的 runtime origin，以及一個 OpenConnector runtime token |
+| 瀏覽器到 Connector Console      | `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN`                        | OpenConnector Web Console 的公開 origin                                 |
+| 瀏覽器和管理 API 到 Console     | OpenConnector 端的 `OOMOL_CONNECT_ADMIN_TOKEN`              | 使用者在 Console 中輸入的管理員 token                                   |
+
+## 前提條件
+
+- [Docker](https://docs.docker.com/get-docker/) 和 OpenSSL。
+- `oo` CLI。macOS 或 Linux：
+
+  ```bash
+  curl -fsSL https://cli.oomol.com/install.sh | bash
+  ```
+
+  Windows 及其他安裝方式請參閱 [oo CLI README](https://github.com/oomol-lab/oo-cli#install)。使用自己部署的 Open Flow 不需要
+  `oo login`，也不需要 OOMOL 帳號。
+
+- 對於 Gmail、Slack 等 OAuth Provider，需要你在這些 Provider 註冊應用程式後取得的 OAuth client 憑證。GitHub 可以使用 personal
+  access token，是最快能跑通的第一個 Provider。OOMOL 託管的 Connector 內建託管 OAuth 應用程式，自行部署的 OpenConnector 則沒有。
+
+範例把 OpenConnector 發布到主機連接埠 `3001`，Open Flow 發布到主機連接埠 `3000`，並把兩個容器放進同一個 Docker 網路，
+讓 Open Flow 可以透過容器名稱連到 Connector。
+
+## 1. 啟動 OpenConnector
+
+```bash
+docker network create oomol
+
+export OOMOL_CONNECT_ADMIN_TOKEN="$(openssl rand -hex 32)"
+export OOMOL_CONNECT_ENCRYPTION_KEY="$(openssl rand -hex 32)"
+
+docker run -d \
+  --name open-connector \
+  --network oomol \
+  --publish 3001:3000 \
+  --volume open-connector-data:/app/data \
+  --env OOMOL_CONNECT_ORIGIN="http://localhost:3001" \
+  --env OOMOL_CONNECT_ADMIN_TOKEN="$OOMOL_CONNECT_ADMIN_TOKEN" \
+  --env OOMOL_CONNECT_ENCRYPTION_KEY="$OOMOL_CONNECT_ENCRYPTION_KEY" \
+  ghcr.io/oomol-lab/open-connector:latest
+
+curl http://localhost:3001/health
+```
+
+- `OOMOL_CONNECT_ORIGIN` 是瀏覽器連到 OpenConnector 所用的 origin。OAuth 回呼網址由它產生，因此必須與發布的連接埠一致。
+- `OOMOL_CONNECT_ADMIN_TOKEN` 保護管理 API、`/docs` 和 Web Console。沒有設定時，任何能連到 `3001` 連接埠的人都能讀取和修改憑證。
+- `OOMOL_CONNECT_ENCRYPTION_KEY` 用於加密保存在磁碟上的憑證。
+
+開啟 `http://localhost:3001`，輸入管理員 token，確認 Web Console 能正常載入。PostgreSQL、轉送儲存和其餘變數請參閱
+[OpenConnector 設定參考](https://github.com/oomol-lab/open-connector/blob/main/docs/configuration.md)。
+
+## 2. 為 Open Flow 建立 runtime token
+
+Open Flow 會呼叫 OpenConnector 位於 `/v1` 的執行環境 API：Provider 與 Action 目錄、Connection 清單、Action 執行，以及供
+Poll 和 Integration Trigger 使用的 `POST /v1/proxy/:service`。請給它一個長期使用的 runtime token，不要用管理員 token。可以在 Web
+Console 的 Access 頁面建立，也可以透過管理 API 建立：
+
+```bash
+curl -s -X POST http://localhost:3001/api/runtime-tokens \
+  -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"name":"open-flow","allowedActions":[],"blockedActions":[],"allowedProxies":["*"]}'
+```
+
+回應中的 `token` 欄位只會回傳這一次。把它儲存為 `OPEN_FLOW_CONNECTOR_TOKEN`：
+
+```bash
+export OPEN_FLOW_CONNECTOR_TOKEN="<回應中的 token>"
+```
+
+與 Open Flow 相關的 token 規則：
+
+- `allowedProxies` 預設為空。沒有 proxy 權限的長期 token 無法呼叫 `/v1/proxy/:service`，Poll 和 Integration Trigger
+  會因此失敗。允許 `*`，或列出你打算使用 Provider Trigger 的 Provider，例如 `["gmail","github"]`。
+- `allowedActions` 和 `blockedActions` 限制 Open Flow 可執行的 Action。空清單表示允許部署原則放行的所有 Action。
+- 除非要把 Open Flow 限定在特定 Connection，否則不要設定 `allowedConnections`。綁定到清單之外 Connection 的 Connector
+  Node 會以 `connector.connection-required` 失敗。
+
+只要建立過長期 token，OpenConnector 就會要求每個 `/v1` 和 `/mcp` 請求都帶 runtime token。同一套 OpenConnector 的其他呼叫方，例如
+`oo connector` 或 MCP host，從此也需要各自的 token。
+
+## 3. 啟動 Open Flow
+
+在儲存庫根目錄建置映像檔，並在同一個網路中啟動：
+
+```bash
+git clone https://github.com/oomol-lab/open-flow.git
+cd open-flow
+
+export OPEN_FLOW_TOKEN="$(openssl rand -hex 32)"
+docker build --file apps/server/Dockerfile --tag open-flow-server:dev .
+
+docker run -d \
+  --name open-flow \
+  --network oomol \
+  --publish 3000:3000 \
+  --volume open-flow-data:/data/open-flow \
+  --env OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN" \
+  --env OPEN_FLOW_CONNECTOR_ORIGIN="http://open-connector:3000" \
+  --env OPEN_FLOW_CONNECTOR_TOKEN="$OPEN_FLOW_CONNECTOR_TOKEN" \
+  --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
+  open-flow-server:dev
+
+curl http://localhost:3000/readyz
+```
+
+- `OPEN_FLOW_CONNECTOR_ORIGIN` 是 Open Flow 程序使用的位址。在 `oomol` 網路內，它是容器名稱加容器連接埠，而不是發布到主機的連接埠。
+- `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` 是使用者瀏覽器開啟的位址。當 Connector Node 或 Provider Trigger 需要帳號時，Workbench
+  會連結到 `<console origin>/providers/<service>`。只有 loopback 主機可以使用明文 HTTP，其餘情況必須是不帶 path 的 HTTPS origin。
+- 只有當 Open Flow 正在執行且設定的 Connector 通過健康檢查時，`/readyz` 才會回傳 `{"status":"ready"}`。設定了 Connector 卻回傳 503，
+  通常是 runtime origin 寫錯，或容器不在同一個網路。
+
+開啟 `http://localhost:3000`，用 `OPEN_FLOW_TOKEN` 登入。Workbench 的目錄現在會列出 OpenConnector 的 Provider 和 Action。
+
+## 4. 授權帳號
+
+Connection 保存在 OpenConnector 中，而不是 Open Flow 中。Open Flow 只保存 Connection 的 ID，永遠接觸不到 Provider 憑證。
+
+對於 GitHub，可以在 Console 的 GitHub 頁面 `http://localhost:3001/providers/github` 儲存 personal access token，也可以透過管理 API：
+
+```bash
+curl -s -X PUT http://localhost:3001/api/connections/github \
+  -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"authType":"api_key","values":{"apiKey":"github_pat_..."}}'
+```
+
+對於 OAuth Provider，先在 Console 中設定 OAuth client，再從 Provider 頁面授權帳號。OAuth client、具名 Connection 和 token
+更新請參閱 [OpenConnector 憑證指南](https://github.com/oomol-lab/open-connector/blob/main/docs/credentials.md)。
+
+確認 Open Flow 能看到這個 Connection：
+
+```bash
+export OO_OPEN_FLOW_URL="http://localhost:3000"
+export OO_OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN"
+
+oo flow connector connections github
+```
+
+## 5. 把 oo CLI 指向 Open Flow
+
+`oo flow` 依據環境變數選擇 Open Flow：
+
+- 同時設定 `OO_OPEN_FLOW_URL` 和 `OO_OPEN_FLOW_TOKEN` 時，`oo flow` 會直接連到這套 Open Flow，不會讀取 OOMOL 帳號、Team 或
+  `OO_ENDPOINT`。
+- `OO_OPEN_FLOW_TOKEN` 必須等於這套 Open Flow 的 `OPEN_FLOW_TOKEN`。CLI 只會把它作為 Bearer token 傳送到所選 origin 的 `/v1/`。
+- 只設定其中一個變數會產生錯誤。兩個都取消設定即可回到 OOMOL Hosted。
+
+```bash
+export OO_OPEN_FLOW_URL="http://localhost:3000"
+export OO_OPEN_FLOW_TOKEN="$OPEN_FLOW_TOKEN"
+
+oo flow --help
+oo flow list
+```
+
+要讓 AI Agent 建立 Flow，請在已匯出這兩個變數的 shell 中啟動 Codex、Claude Code 或其他終端 Agent。CLI 隨附的 `oo` skill
+會教 Agent 何時以及如何呼叫 `oo flow`，不需要在 prompt 中寫入 Open Flow 的 URL 或 token。
+
+完整的命令清單和環境變數請參閱 [oo CLI 命令參考](https://github.com/oomol-lab/oo-cli/blob/main/docs/commands.md#open-flow)。
+
+## 6. 從終端建立 Flow
+
+Flow 可以用 ID 或精確名稱引用。下面的命令會建立一個 Draft，加入一個綁定到 GitHub Connection 的 Connector Node，然後檢查、執行並發布它：
+
+```bash
+oo flow create "GitHub digest"
+oo flow connector search "current user"
+oo flow connector add "GitHub digest" github.get_current_user --name me
+oo flow check "GitHub digest"
+oo flow run "GitHub digest" --wait
+oo flow publish "GitHub digest"
+oo flow open "GitHub digest"
+```
+
+- 省略 `--connection` 時，`connector add` 會綁定該 Action 的預設 Connection。傳入 `--connection <alias>` 可選擇具名 Connection。
+- `check` 檢查 Revision 是否合法。帳號是否可用、會不會在 Provider 上真正執行，只有 `run` 才會碰到。
+- `run --wait` 透過 OpenConnector 執行 Draft 並印出結果。`oo flow runs events <run>` 會顯示完整的事件記錄。
+- `open` 會印出該 Flow 的 Workbench URL 並在瀏覽器中開啟。operator token 不會放進 URL，瀏覽器以自己的 session 登入。
+
+為任意命令加上 `--json` 可取得有版本的機器可讀輸出。`oo flow node add`、`oo flow connect`、`oo flow trigger add` 和
+`oo flow apply --file` 分別用於 Code Task、Edge、Trigger，以及從檔案寫入 Flow，請參閱 `oo flow --help`。
+
+## 7. 選用：在 oo connector 中重複使用同一套 OpenConnector
+
+同一個 OpenConnector 也可以在 Open Flow 之外給 `oo connector` 命令用。這需要另一個 runtime token。Open Flow 的 token
+應只給 Open Flow 用：
+
+```bash
+oo connector login http://localhost:3001 --token <另一個 runtime token>
+oo connector search "send an email"
+```
+
+`oo connector login` 只影響 connector 命令，其設定與 `oo flow` 的設定分開保存。請參閱
+[自行部署 connector 指南](https://github.com/oomol-lab/oo-cli/blob/main/docs/self-hosted-connector.md)。
+
+## 正式環境注意事項
+
+- 在兩個服務前面終止 TLS。`OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` 和 `OOMOL_CONNECT_ORIGIN` 必須是 Console 的公開 HTTPS
+  origin，且兩者必須是同一個 origin，因為 OAuth 回呼和 Workbench 連結都會使用它。runtime origin 可以留在私有網路走 HTTP。
+  跨越不受信任的網路時，必須用 TLS 保護 bearer token。
+- 位於 TLS 後方時，請設定 `OPEN_FLOW_SESSION_COOKIE_SECURE=true`。
+- Integration Trigger (Provider callback) 還需要 `OPEN_FLOW_INTEGRATION_PUBLIC_ORIGIN` 和
+  `OPEN_FLOW_INTEGRATION_CALLBACK_KEY`。缺少時 Publish 會失敗。
+- 所有 token 都透過 secret 或只有部署者可讀的 env file 注入。在 Access 頁面更換 OpenConnector runtime token 時，要一併更新
+  `OPEN_FLOW_CONNECTOR_TOKEN`。
+- 每個服務擁有自己的資料：Open Flow 在 `/data/open-flow`，OpenConnector 在 `/app/data`。請分別備份，詳見
+  [容器交付參考](../container-delivery.md#6-持久化与恢复)。
+- 在 Fly.io 上，把 OpenConnector 和 Open Flow 作為同一個 organization 下的兩個 app 執行，runtime origin 使用 Fly 私有網路，例如
+  `http://my-open-connector.internal:3000`。請參閱 [Fly.io 部署指南](../fly-io/README.zh-TW.md) 和
+  [OpenConnector Fly.io 指南](https://github.com/oomol-lab/open-connector/blob/main/docs/fly-io.md)。
+
+## 疑難排解
+
+| 現象                                                | 可能原因                                                                                                 |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Workbench 或 CLI 出現 `connector.unavailable`       | Open Flow 容器連不到 `OPEN_FLOW_CONNECTOR_ORIGIN`，或 OpenConnector 拒絕了 `OPEN_FLOW_CONNECTOR_TOKEN`。 |
+| `/readyz` 回傳 503 而 `/healthz` 回傳 200           | Connector 健康檢查失敗。查看 `docker logs open-flow`，並確認兩個容器在同一個網路。                       |
+| 執行時出現 `connector.connection-required`          | Connection 不存在、未啟用，或被 token 的 `allowedConnections` 排除。請到 Console 重新授權。              |
+| 手動 Action 正常但 Poll 或 Integration Trigger 失敗 | runtime token 沒有該 Provider 的 `allowedProxies` 權限，或被 `OOMOL_CONNECT_BLOCKED_PROXIES` 封鎖。      |
+| `oo flow` 要求登入 OOMOL                            | 缺少 `OO_OPEN_FLOW_URL` 或 `OO_OPEN_FLOW_TOKEN`。兩者必須在同一個 shell 中設定。                         |
+| `oo flow` 回傳 401                                  | `OO_OPEN_FLOW_TOKEN` 與這套 Open Flow 的 `OPEN_FLOW_TOKEN` 不一致。                                      |
+| Workbench 指向 Console 的連結開啟了錯誤的主機       | `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` 指向了容器位址，而不是瀏覽器可連到的 origin。                       |
+| OAuth 授權跳回了錯誤的 URL                          | `OOMOL_CONNECT_ORIGIN` 與瀏覽器開啟 Console 時使用的 origin 不一致。                                     |

--- a/docs/server/self-hosted-stack/README.zh-TW.md
+++ b/docs/server/self-hosted-stack/README.zh-TW.md
@@ -132,10 +132,15 @@ docker run -d \
   --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
   open-flow-server:dev
 
+ready=0
 for i in 1 2 3 4 5 6 7 8 9 10; do
-  curl -sf http://localhost:3000/readyz && break
+  if curl -sf --max-time 2 http://localhost:3000/readyz; then
+    ready=1
+    break
+  fi
   sleep 1
 done
+[ "$ready" -eq 1 ]
 ```
 
 - `OPEN_FLOW_CONNECTOR_ORIGIN` 是 Open Flow 程序使用的位址。在 `oomol` 網路內，它是容器名稱加容器連接埠，而不是發布到主機的連接埠。

--- a/docs/server/self-hosted-stack/README.zh-TW.md
+++ b/docs/server/self-hosted-stack/README.zh-TW.md
@@ -23,7 +23,7 @@ flowchart LR
   Connector --> Providers["GitHub, Gmail, Slack, ..."]
 ```
 
-這四組值必須一致：
+需要設定這四組值：
 
 | 用途                            | 寫在哪裡                                                    | 填什麼                                                                  |
 | ------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------- |
@@ -91,6 +91,8 @@ curl -s -X POST http://localhost:3001/api/runtime-tokens \
   -d '{"name":"open-flow","allowedActions":[],"blockedActions":[],"allowedProxies":["*"]}'
 ```
 
+`*` 只用於這次本機走通。正式環境請只列出你實際要用的 Provider。
+
 回應中的 `token` 欄位只會回傳這一次。把它儲存為 `OPEN_FLOW_CONNECTOR_TOKEN`：
 
 ```bash
@@ -130,14 +132,17 @@ docker run -d \
   --env OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN="http://localhost:3001" \
   open-flow-server:dev
 
-curl http://localhost:3000/readyz
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  curl -sf http://localhost:3000/readyz && break
+  sleep 1
+done
 ```
 
 - `OPEN_FLOW_CONNECTOR_ORIGIN` 是 Open Flow 程序使用的位址。在 `oomol` 網路內，它是容器名稱加容器連接埠，而不是發布到主機的連接埠。
 - `OPEN_FLOW_CONNECTOR_CONSOLE_ORIGIN` 是使用者瀏覽器開啟的位址。當 Connector Node 或 Provider Trigger 需要帳號時，Workbench
   會連結到 `<console origin>/providers/<service>`。只有 loopback 主機可以使用明文 HTTP，其餘情況必須是不帶 path 的 HTTPS origin。
-- 只有當 Open Flow 正在執行且設定的 Connector 通過健康檢查時，`/readyz` 才會回傳 `{"status":"ready"}`。設定了 Connector 卻回傳 503，
-  通常是 runtime origin 寫錯，或容器不在同一個網路。
+- 只有當 Open Flow 正在執行且設定的 Connector 通過健康檢查時，`/readyz` 才會回傳 `{"status":"ready"}`。`docker run -d` 之後幾秒內出現
+  503 是正常的。如果一直 503，通常是 runtime origin 寫錯，或容器不在同一個網路。
 
 開啟 `http://localhost:3000`，用 `OPEN_FLOW_TOKEN` 登入。Workbench 的目錄現在會列出 OpenConnector 的 Provider 和 Action。
 
@@ -145,13 +150,18 @@ curl http://localhost:3000/readyz
 
 Connection 保存在 OpenConnector 中，而不是 Open Flow 中。Open Flow 只保存 Connection 的 ID，永遠接觸不到 Provider 憑證。
 
-對於 GitHub，可以在 Console 的 GitHub 頁面 `http://localhost:3001/providers/github` 儲存 personal access token，也可以透過管理 API：
+對於 GitHub，可以在 Console 的 GitHub 頁面 `http://localhost:3001/providers/github` 儲存 personal access token，也可以透過管理 API。
+`read -s` 後貼上 token 再按 Enter，螢幕上不會顯示：
 
 ```bash
+read -s GITHUB_PAT
 curl -s -X PUT http://localhost:3001/api/connections/github \
   -H "authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
   -H 'content-type: application/json' \
-  -d '{"authType":"api_key","values":{"apiKey":"github_pat_..."}}'
+  --data-binary @- <<EOF
+{"authType":"api_key","values":{"apiKey":"${GITHUB_PAT}"}}
+EOF
+unset GITHUB_PAT
 ```
 
 對於 OAuth Provider，先在 Console 中設定 OAuth client，再從 Provider 頁面授權帳號。OAuth client、具名 Connection 和 token
@@ -212,8 +222,7 @@ oo flow open "GitHub digest"
 
 ## 7. 選用：在 oo connector 中重複使用同一套 OpenConnector
 
-同一個 OpenConnector 也可以在 Open Flow 之外給 `oo connector` 命令用。這需要另一個 runtime token。Open Flow 的 token
-應只給 Open Flow 用：
+同一個 OpenConnector 也可以在 Open Flow 之外給 `oo connector` 命令用。這需要另一個 runtime token。不要重複使用 Open Flow 的 token：
 
 ```bash
 oo connector login http://localhost:3001 --token <另一個 runtime token>


### PR DESCRIPTION
The READMEs already covered Connector env vars and installing the oo CLI, but not how to run Open Flow next to OpenConnector, mint a runtime token, and point `oo flow` at that origin. This adds that walkthrough in seven languages under _docs/server/self-hosted-stack/_ and links it from the Agent and Connector sections.
