### PR TITLE
fix(designer): batch controlled selection updates

### DIFF
--- a/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.test.tsx
+++ b/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.test.tsx
@@ -616,8 +616,10 @@ describe('FlowDesignerView model synchronization', () => {
     const initial = props(model([source, task([])]), { selectedNodeIds: ['source'] })
     const view = FlowDesignerView(initial) as React.ReactElement<FlowDesignerProps>
     const stores = [...view.props.flowDesignerStore.$.nodes.values()]
-    const sourceStore = stores.find((node) => node.nodeId == 'source')!
-    const targetStore = stores.find((node) => node.nodeId == 'target')!
+    const sourceStore = stores.find((node) => node.nodeId == 'source')
+    const targetStore = stores.find((node) => node.nodeId == 'target')
+    if (sourceStore == null) throw new Error('Expected source node store.')
+    if (targetStore == null) throw new Error('Expected target node store.')
     const batchDepths: number[] = []
     const disposeSource = sourceStore.$.selected.reaction(() => batchDepths.push(reactDom.batchDepth), true)
     const disposeTarget = targetStore.$.selected.reaction(() => batchDepths.push(reactDom.batchDepth), true)

--- a/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.test.tsx
+++ b/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.test.tsx
@@ -26,7 +26,20 @@ const hooks = vi.hoisted(() => ({
   setups: [] as (() => void | (() => void))[],
 }))
 
+const reactDom = vi.hoisted(() => ({ batchDepth: 0 }))
+
 vi.mock('virtual:uno.css', () => ({}))
+
+vi.mock('react-dom', () => ({
+  unstable_batchedUpdates: <T,>(callback: () => T): T => {
+    reactDom.batchDepth++
+    try {
+      return callback()
+    } finally {
+      reactDom.batchDepth--
+    }
+  },
+}))
 
 vi.mock('react', async (importOriginal) => {
   const original = await importOriginal<typeof import('react')>()
@@ -596,6 +609,26 @@ describe('FlowDesignerView model synchronization', () => {
     view.props.onSelectionChange?.({ edges: [], nodes: nodes.toReversed().map((node) => ({ data: { store: node } }) as never) })
 
     expect(onSelectionChange).not.toHaveBeenCalled()
+    view.props.flowDesignerStore.dispose()
+  })
+
+  it('batches a controlled selection replacement', () => {
+    const initial = props(model([source, task([])]), { selectedNodeIds: ['source'] })
+    const view = FlowDesignerView(initial) as React.ReactElement<FlowDesignerProps>
+    const stores = [...view.props.flowDesignerStore.$.nodes.values()]
+    const sourceStore = stores.find((node) => node.nodeId == 'source')!
+    const targetStore = stores.find((node) => node.nodeId == 'target')!
+    const batchDepths: number[] = []
+    const disposeSource = sourceStore.$.selected.reaction(() => batchDepths.push(reactDom.batchDepth), true)
+    const disposeTarget = targetStore.$.selected.reaction(() => batchDepths.push(reactDom.batchDepth), true)
+
+    FlowDesignerView(props(model([source, task([])]), { selectedNodeIds: ['target'] }))
+
+    expect(batchDepths).toEqual([1, 1])
+    expect(sourceStore.$.selected.value).toBe(false)
+    expect(targetStore.$.selected.value).toBe(true)
+    disposeSource()
+    disposeTarget()
     view.props.flowDesignerStore.dispose()
   })
 

--- a/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.tsx
+++ b/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.tsx
@@ -29,6 +29,7 @@ import type { InlineTask } from '../../stores/node/taskNode.store.ts'
 
 import { dispose } from '@wopjs/disposable'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
+import { unstable_batchedUpdates } from 'react-dom'
 import { derive, val } from 'value-enhancer'
 import { reactiveMap } from 'value-enhancer/collections'
 import { toManifestHandleName, toManifestNodeId } from '../../base/rfHelpers.ts'
@@ -606,10 +607,13 @@ class FlowDesignerViewAdapter {
     const selectionChanged = selected.size != this.#selectedNodeIds.size || [...selected].some((nodeId) => !this.#selectedNodeIds.has(nodeId))
     this.#selectedNodeIds = selected
     if (selectionChanged) {
-      for (const [nodeId, entry] of this.#entries) {
-        const value = selected.has(nodeId)
-        if (entry.store.$.selected.value != value) entry.store.$$.selected.set(value)
-      }
+      // Keep React Flow from observing and echoing an intermediate selection while nodes are updated.
+      unstable_batchedUpdates(() => {
+        for (const [nodeId, entry] of this.#entries) {
+          const value = selected.has(nodeId)
+          if (entry.store.$.selected.value != value) entry.store.$$.selected.set(value)
+        }
+      })
     }
   }
 


### PR DESCRIPTION
## Summary

- Batch controlled selection updates to prevent React Flow from observing intermediate state.
- Add a regression test covering selection replacement.
- Set a default connector console origin in the development server.

## Testing

- Added and ran the FlowDesigner unit test for batched selection replacement.