### PR TITLE
fix: refresh publish state without moving nodes

### DIFF
--- a/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.test.tsx
+++ b/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.test.tsx
@@ -583,6 +583,25 @@ describe('FlowDesignerView model synchronization', () => {
     store.dispose()
   })
 
+  it('keeps the current node position when editability changes', () => {
+    const value = model([task([])])
+    const initial = props(value)
+    const view = FlowDesignerView(initial) as React.ReactElement<FlowDesignerProps>
+    const node = [...view.props.flowDesignerStore.$.nodes.values()][0]!
+    node.$$.position.set({ x: 320, y: 180 })
+
+    FlowDesignerView({ ...initial, editable: false })
+    expect([...view.props.flowDesignerStore.$.nodes.values()][0]?.$.position.value).toEqual({ x: 320, y: 180 })
+
+    FlowDesignerView(initial)
+    expect([...view.props.flowDesignerStore.$.nodes.values()][0]?.$.position.value).toEqual({ x: 320, y: 180 })
+
+    const moved = { ...task([]), position: { x: 500, y: 400 } }
+    FlowDesignerView(props(model([moved]), { editable: false }))
+    expect([...view.props.flowDesignerStore.$.nodes.values()][0]?.$.position.value).toEqual(moved.position)
+    view.props.flowDesignerStore.dispose()
+  })
+
   it('persists edits made through the inline Condition controls', () => {
     const onChangeCondition = vi.fn()
     const view = FlowDesignerView(props(model([conditionNode()]), { onChangeCondition })) as React.ReactElement<FlowDesignerProps>

--- a/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.tsx
+++ b/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.tsx
@@ -697,9 +697,14 @@ class FlowDesignerViewAdapter {
       const { position, ...content } = node
       const contentKey = JSON.stringify([content, outputHandles])
       let entry = this.#entries.get(node.id)
+      let createdPosition = position
       let created = false
       if (entry?.kind != node.kind) entry = undefined
-      if (entry?.kind != 'comment' && entry?.editable != this.store.$.editable.value) entry = undefined
+      if (entry != null && entry.kind != 'comment' && entry.editable != this.store.$.editable.value) {
+        const previousPosition = this.#modelPositions.get(node.id)
+        if (previousPosition?.x == position.x && previousPosition.y == position.y) createdPosition = entry.store.$.position.value
+        entry = undefined
+      }
       if (node.kind == 'comment') {
         if (entry?.kind != 'comment') {
           entry = createCommentNodeEntry(node, contentKey, this.store.designerUIStore, this.store, this.#callbacks)
@@ -711,7 +716,7 @@ class FlowDesignerViewAdapter {
         }
         nextComments.set(node.id as NodeId, entry.store)
       } else if (entry == null) {
-        this.store.designerUIStore.setNodeUIData(node.id as NodeId, { rfNode: { position } })
+        this.store.designerUIStore.setNodeUIData(node.id as NodeId, { rfNode: { position: createdPosition } })
         entry = createNodeEntry(node, outputHandles, contentKey, this.store.designerUIStore, this.store, this.#callbacks)
         created = true
       } else {

--- a/packages/open-flow/src/workbench/browser/runtime/stores/workspaceStore.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/workspaceStore.test.ts
@@ -34,6 +34,85 @@ const draft = {
 } as const
 
 describe('WorkspaceStore', () => {
+  it('enables publishing after adding a node to a published Flow', async () => {
+    const publication = {
+      actorId: 'actor-1',
+      closureDigest: 'closure-1',
+      createdAt: timestamp,
+      engineContract: 'open-flow-engine/v1',
+      flowId: flow.flowId,
+      modelVersion: 1,
+      operation: 'publish',
+      publicationId: 'publication-1',
+      revisionDigest: draft.digest,
+      revisionId: draft.revisionId,
+      version: 1,
+    } as const
+    const request = vi.fn(async (path: string, init?: RequestInit) => {
+      if (path == '/v1/flows?limit=50&includeTotal=true') return Response.json({ flows: [flow], total: 1, version: 1 })
+      if (path == `/v1/flows/${flow.flowId}/draft`) return Response.json(draft)
+      if (path == `/v1/flows/${flow.flowId}/live`) {
+        return Response.json({
+          flowId: flow.flowId,
+          hasUnpublishedChanges: false,
+          publication,
+          revision: 1,
+          status: 'runnable',
+          version: 1,
+        })
+      }
+      if (path == `/v1/flows/${flow.flowId}/presentation`) {
+        if (init?.method == 'PUT') return Response.json({ revision: 2, updatedAt: timestamp, value: {}, version: 1 })
+        return Response.json({ revision: 1, updatedAt: timestamp, value: {}, version: 1 })
+      }
+      if (path == `/v1/flows/${flow.flowId}/draft/changes`) {
+        return Response.json({
+          revision: {
+            actorId: 'actor-1',
+            createdAt: timestamp,
+            digest: 'digest-2',
+            flowId: flow.flowId,
+            modelVersion: 1,
+            parentRevisionId: draft.revisionId,
+            revisionId: 'revision-2',
+            version: 1,
+          },
+          version: 1,
+        })
+      }
+      const check = /^\/v1\/flows\/flow-1\/revisions\/(revision-[12])\/check$/.exec(path)
+      if (check != null) {
+        return Response.json({
+          closureDigest: check[1] == 'revision-1' ? publication.closureDigest : 'closure-2',
+          diagnostics: [],
+          engineContract: publication.engineContract,
+          flowId: flow.flowId,
+          modelVersion: 1,
+          revisionDigest: check[1] == 'revision-1' ? draft.digest : 'digest-2',
+          revisionId: check[1],
+          valid: true,
+          version: 1,
+        })
+      }
+      throw new Error(`Unexpected request: ${path}`)
+    })
+    const store = new WorkspaceStore(new WorkbenchClient(request), vi.fn(), () => 'node-1')
+
+    try {
+      await store.start(flow.flowId)
+      expect(store.$.live.value?.hasUnpublishedChanges).toBe(false)
+      const option = store.$.addNodeOptions.value.find((candidate) => candidate.kind == 'value')
+      if (option == null) throw new Error('Expected Value node option.')
+
+      await store.addNode(option, { x: 100, y: 100 })
+
+      await vi.waitFor(() => expect(store.$.live.value?.hasUnpublishedChanges).toBe(true))
+      expect(request).toHaveBeenCalledWith(`/v1/flows/${flow.flowId}/draft/changes`, expect.objectContaining({ method: 'POST' }))
+    } finally {
+      store.dispose()
+    }
+  })
+
   it('loads a host-created Flow by ID before adding it to the catalog', async () => {
     const request = vi.fn(async (path: string) => {
       if (path == `/v1/flows/${flow.flowId}`) return Response.json(flow)

--- a/packages/open-flow/src/workbench/browser/runtime/stores/workspaceStore.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/workspaceStore.ts
@@ -779,7 +779,19 @@ export class WorkspaceStore {
     this.#set({ checkLoading: true, diagnosticFocus: undefined })
     try {
       const diagnostics = await this.#client.checkFlow(flowId, draft.revisionId)
-      if (!this.#disposed && flowId == this.#model.value.flowId && draft.revisionId == this.#model.value.draft?.revisionId) this.#set({ diagnostics })
+      if (!this.#disposed && flowId == this.#model.value.flowId && draft.revisionId == this.#model.value.draft?.revisionId) {
+        const live = this.#model.value.live
+        this.#set({
+          diagnostics,
+          live:
+            live == null
+              ? undefined
+              : {
+                  ...live,
+                  hasUnpublishedChanges: live.publication == null || live.publication.closureDigest != diagnostics.closureDigest,
+                },
+        })
+      }
     } catch (error) {
       if (!this.#disposed && flowId == this.#model.value.flowId && draft.revisionId == this.#model.value.draft?.revisionId) {
         this.#setNotice(errorNotice(error, this.#i18n.t))


### PR DESCRIPTION
## Summary

- refresh the Workbench unpublished-change state from the checked Draft closure digest after semantic edits
- preserve the current canvas node positions when publishing temporarily changes Designer editability
- add regressions for enabling publish after adding a node and retaining positions across editable/read-only transitions

## Verification

- bun run check
- bun run test
- bun run build