### PR TITLE
fix(workbench): support public connector actions

### DIFF
--- a/apps/server/node/connector.ts
+++ b/apps/server/node/connector.ts
@@ -11,6 +11,7 @@ const maxActionCatalogBytes = 8 * 1024 * 1024
 const readinessTimeoutMs = 1_000
 
 interface RuntimeAction {
+  readonly authenticated: boolean
   readonly description: string
   readonly id: string
   readonly inputSchema: JsonValue
@@ -22,7 +23,7 @@ interface RuntimeAction {
 export interface ConnectorHost {
   execute(
     action: string,
-    connectionId: string,
+    connectionId: string | undefined,
     input: Readonly<Record<string, JsonValue>>,
     invocationId: string,
     signal: AbortSignal,
@@ -160,7 +161,7 @@ export class ConnectorClient implements ConnectorHost {
 
   async execute(
     action: string,
-    connectionId: string,
+    connectionId: string | undefined,
     input: Readonly<Record<string, JsonValue>>,
     invocationId: string,
     signal: AbortSignal,
@@ -168,7 +169,7 @@ export class ConnectorClient implements ConnectorHost {
   ): Promise<JsonValue> {
     const separator = action.indexOf('.')
     if (separator <= 0) throw connectionRequired()
-    const alias = await this.#resolveConnection(connectionId, action.slice(0, separator), signal, teamId)
+    const alias = connectionId == null ? undefined : await this.#resolveConnection(connectionId, action.slice(0, separator), signal, teamId)
 
     const actionResponse = await this.#request(
       'action.execute',
@@ -178,12 +179,12 @@ export class ConnectorClient implements ConnectorHost {
         headers: {
           'content-type': 'application/json',
           'idempotency-key': invocationId,
-          'x-oo-connector-alias': alias,
+          ...(alias == null ? {} : { 'x-oo-connector-alias': alias }),
         },
         method: 'POST',
       },
       signal,
-      { fields: { actionId: action, connectionId, invocationId }, teamId },
+      { fields: { actionId: action, ...(connectionId == null ? {} : { connectionId }), invocationId }, teamId },
     )
     const response = actionResponse.value
     if (!record(response)) throw unavailable()
@@ -421,7 +422,13 @@ function runtimeAction(value: unknown): RuntimeAction {
   const source = record(value) ? value : undefined
   if (source == null) throw unavailable()
   if (typeof source.description != 'string') throw unavailable()
+  const execution = record(source.execution) ? source.execution : undefined
+  let authenticated: boolean
+  if (typeof source.authenticated == 'boolean') authenticated = source.authenticated
+  else if (typeof execution?.noAuthRunnable == 'boolean') authenticated = !execution.noAuthRunnable
+  else throw unavailable()
   return {
+    authenticated,
     description: source.description,
     id: string(source.id),
     inputSchema: source.inputSchema as JsonValue,
@@ -477,7 +484,9 @@ function mapAction(action: RuntimeAction, providers: readonly ConnectorProvider[
   const provider = providers.find((candidate) => candidate.serviceId == action.service)
   if (provider == null) throw unavailable()
   const active = connections.filter((connection) => connection.serviceId == action.service && connection.status == 'active')
-  const defaultConnection = active.find((connection) => connection.isDefault) ?? (active.length == 1 ? active[0] : undefined)
+  const defaultConnection = action.authenticated
+    ? (active.find((connection) => connection.isDefault) ?? (active.length == 1 ? active[0] : undefined))
+    : undefined
   let ports: ReturnType<typeof connectorActionPorts>
   try {
     ports = connectorActionPorts(action.inputSchema, action.outputSchema)
@@ -486,6 +495,7 @@ function mapAction(action: RuntimeAction, providers: readonly ConnectorProvider[
   }
   return {
     actionId: action.id,
+    authenticated: action.authenticated,
     ...(defaultConnection == null ? {} : { defaultConnection }),
     description: action.description,
     ...(provider.icon == null ? {} : { icon: provider.icon }),

--- a/apps/server/node/service.ts
+++ b/apps/server/node/service.ts
@@ -1191,7 +1191,7 @@ export class ServerService {
         if (this.#connector == null) throw new ConnectorTaskError('connector.unavailable', 'The Connector request could not be completed.')
         return await this.#connector.execute(
           executor.action,
-          executor.connectionId!,
+          executor.connectionId,
           normalizeConnectorRuntimeInputs(
             task.inputs.filter((input) => 'handle' in input),
             invocation.input,

--- a/apps/server/test/connector.test.ts
+++ b/apps/server/test/connector.test.ts
@@ -128,7 +128,16 @@ describe('Server Connector host', () => {
   it('projects discovery and the explicit external Connection page from the injected host', async () => {
     const providers: readonly ConnectorProvider[] = [{ serviceId: 'example', serviceName: 'Example' }]
     const actions: readonly ConnectorAction[] = [
-      { actionId: 'example.echo', description: 'Echo.', inputs: {}, name: 'Echo', outputs: {}, serviceId: 'example', serviceName: 'Example' },
+      {
+        actionId: 'example.echo',
+        authenticated: true,
+        description: 'Echo.',
+        inputs: {},
+        name: 'Echo',
+        outputs: {},
+        serviceId: 'example',
+        serviceName: 'Example',
+      },
     ]
     const connections: readonly ConnectorConnection[] = [
       { connectionId: 'connection-work', displayName: 'Work', isDefault: true, serviceId: 'example', status: 'active' },
@@ -151,7 +160,7 @@ describe('Server Connector host', () => {
   })
 
   it('executes managed Connector Tasks through the injected host', async () => {
-    const execute = vi.fn(async (_action: string, _connectionId: string, input: Readonly<Record<string, JsonValue>>) => input)
+    const execute = vi.fn(async (_action: string, _connectionId: string | undefined, input: Readonly<Record<string, JsonValue>>) => input)
     const service = await open(createConnectorHost({ execute }))
     const runId = await run(service, connectorFlow())
 
@@ -160,6 +169,24 @@ describe('Server Connector host', () => {
       result: { kind: 'node-results', nodes: [{ jobs: [{ outputs: { message: 'hello' } }], nodeId: 'connector' }] },
       status: 'completed',
     })
+  })
+
+  it('executes public Connector Tasks without a Connection', async () => {
+    const execute = vi.fn(async (_action: string, _connectionId: string | undefined, input: Readonly<Record<string, JsonValue>>) => input)
+    const service = await open(createConnectorHost({ execute }))
+    const source = connectorFlow()
+    const task = source.document.tasks.connector!
+    const revision: RevisionContent = {
+      ...source,
+      document: {
+        ...source.document,
+        tasks: { ...source.document.tasks, connector: { ...task, executor: { action: 'example.echo', kind: 'connector' } } },
+      },
+    }
+    const runId = await run(service, revision)
+
+    expect(execute).toHaveBeenCalledWith('example.echo', undefined, { message: 'hello' }, expect.any(String), expect.any(AbortSignal), undefined)
+    expect(service.run(runId)?.status).toBe('completed')
   })
 
   it('uses the Flow Team fixed when a Run is admitted', async () => {

--- a/apps/server/test/connectorClient.test.ts
+++ b/apps/server/test/connectorClient.test.ts
@@ -293,6 +293,7 @@ describe('Server Connector client', () => {
     await expect(connector.listActions('example')).resolves.toEqual([
       expect.objectContaining({
         actionId: 'example.echo',
+        authenticated: true,
         defaultConnection: expect.objectContaining({ connectionId: 'connection-work' }),
         inputs: {
           message: { description: 'Message.', jsonSchema: { default: 'hello', description: 'Message.', type: 'string' }, nullable: true, value: 'hello' },
@@ -336,6 +337,7 @@ describe('Server Connector client', () => {
     }
     const action = {
       description: 'Echo one message.',
+      execution: { noAuthRunnable: false },
       id: 'example.echo',
       inputSchema: { properties: {}, type: 'object' },
       name: 'echo',
@@ -365,6 +367,7 @@ describe('Server Connector client', () => {
     await expect(connector.listActions('example')).resolves.toEqual([
       {
         actionId: 'example.echo',
+        authenticated: true,
         defaultConnection: {
           connectionId: 'connection-work',
           displayName: 'Work account',
@@ -387,6 +390,58 @@ describe('Server Connector client', () => {
         isDefault: true,
         serviceId: 'example',
         status: 'active',
+      },
+    ])
+  })
+
+  it('projects public Connector Actions without a Connection', async () => {
+    const origin = await startConnector((request, response) => {
+      if (request.url == '/v1/providers') {
+        return send(response, 200, success([{ displayName: 'Hacker News', service: 'hacker-news' }]))
+      }
+      if (request.url == '/v1/apps/services/hacker-news') {
+        return send(
+          response,
+          200,
+          success([
+            {
+              displayName: 'Reader',
+              id: 'hacker-news-reader',
+              isDefault: true,
+              service: 'hacker-news',
+              status: 'active',
+            },
+          ]),
+        )
+      }
+      return send(
+        response,
+        200,
+        success([
+          {
+            description: 'Get Ask HN stories.',
+            execution: { noAuthRunnable: true },
+            id: 'hacker-news.get-ask-stories',
+            inputSchema: { properties: {}, type: 'object' },
+            name: 'Get Ask Stories',
+            outputSchema: { properties: {}, type: 'object' },
+            service: 'hacker-news',
+          },
+        ]),
+      )
+    })
+    const connector = new ConnectorClient(origin, 'runtime-token')
+
+    await expect(connector.listActions('hacker-news')).resolves.toEqual([
+      {
+        actionId: 'hacker-news.get-ask-stories',
+        authenticated: false,
+        description: 'Get Ask HN stories.',
+        inputs: {},
+        name: 'Get Ask Stories',
+        outputs: {},
+        serviceId: 'hacker-news',
+        serviceName: 'Hacker News',
       },
     ])
   })
@@ -518,6 +573,20 @@ describe('Server Connector client', () => {
         path: '/v1/actions/example.echo',
       },
     ])
+  })
+
+  it('executes a public action without resolving a Connection', async () => {
+    const calls: { readonly alias?: string; readonly path: string }[] = []
+    const origin = await startConnector((request, response) => {
+      calls.push({ alias: request.headers['x-oo-connector-alias'] as string | undefined, path: request.url! })
+      send(response, 200, { data: { stories: [] }, success: true })
+    })
+    const connector = new ConnectorClient(origin, 'runtime-token')
+
+    await expect(connector.execute('hacker-news.get-ask-stories', undefined, {}, 'public-action', AbortSignal.timeout(30_000))).resolves.toEqual({
+      stories: [],
+    })
+    expect(calls).toEqual([{ alias: undefined, path: '/v1/actions/hacker-news.get-ask-stories' }])
   })
 
   it('preserves safe Connector input diagnostics in the Run event', async () => {

--- a/apps/server/test/controlApiConformance.test.ts
+++ b/apps/server/test/controlApiConformance.test.ts
@@ -32,6 +32,7 @@ const connectorConnection: ConnectorConnection = {
 
 const connectorAction: ConnectorAction = {
   actionId: 'mail.send',
+  authenticated: true,
   defaultConnection: connectorConnection,
   description: 'Send one message.',
   inputs: {

--- a/docs/control/contracts/control-api.md
+++ b/docs/control/contracts/control-api.md
@@ -279,6 +279,8 @@ interface TriggerBinding {
 occurrence 无法通过最终 admission guard。Poll test 不推进 checkpoint、不写 dedupe、不创建 Run。
 
 Connector credential 不进入响应、Revision 或 RunEvent。
+`ConnectorAction.authenticated` 是必需的 boolean；`false` 表示 Action 可以不绑定 Connection 直接执行，客户端不得显示账号连接要求，
+执行请求也不得为了该 Action 合成 Connection identity。`true` 表示执行需要有效 Connection。
 部署没有配置 Connector 时，catalog 和 Connection 请求返回 `connector.unconfigured`；已经配置但上游不可用或响应无效时返回
 `connector.unavailable`，客户端不能把两者合并为同一配置提示。
 

--- a/packages/open-flow/scripts/check-npm-package.ts
+++ b/packages/open-flow/scripts/check-npm-package.ts
@@ -366,7 +366,7 @@ async function verifyConsumer(versions: { readonly react: string; readonly react
         "import '@oomol-lab/open-flow/workbench.css'",
         "import '@oomol-lab/open-flow/theme.css'",
         'const connector: ConnectorProxy = { execute: async () => ({ data: {}, status: 200 }) }',
-        "const connectorAction: ConnectorAction = { actionId: 'mail.send', description: '', inputs: {}, name: 'send', outputs: {}, serviceId: 'mail', serviceName: 'Mail' }",
+        "const connectorAction: ConnectorAction = { actionId: 'mail.send', authenticated: true, description: '', inputs: {}, name: 'send', outputs: {}, serviceId: 'mail', serviceName: 'Mail' }",
         "const controlError: ControlErrorCode = 'flow.not-found'",
         "const uiLanguage: UiLanguage = resolveUiLanguage(['fr-CA'])",
         "const transition = transitionRun('queued', { kind: 'claim' })",

--- a/packages/open-flow/src/control/common/api.ts
+++ b/packages/open-flow/src/control/common/api.ts
@@ -103,6 +103,7 @@ export interface ConnectorConnection {
 
 export interface ConnectorAction {
   readonly actionId: string
+  readonly authenticated: boolean
   readonly defaultConnection?: ConnectorConnection
   readonly description: string
   readonly icon?: string
@@ -385,6 +386,7 @@ function connectorAction(value: unknown): ConnectorAction {
   const hasConnection = source.defaultConnection != null
   exact(source, [
     'actionId',
+    'authenticated',
     ...(hasConnection ? ['defaultConnection'] : []),
     'description',
     ...(icon == null ? [] : ['icon']),
@@ -397,6 +399,7 @@ function connectorAction(value: unknown): ConnectorAction {
   if (icon != null && typeof icon != 'string') return invalidResponse()
   const result: ConnectorAction = {
     actionId: string(source.actionId),
+    authenticated: typeof source.authenticated == 'boolean' ? source.authenticated : invalidResponse(),
     ...(hasConnection ? { defaultConnection: connection(source.defaultConnection) } : {}),
     description: typeof source.description == 'string' ? source.description : invalidResponse(),
     ...(icon == null ? {} : { icon }),

--- a/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/HelperLines/useHelpLines.ts
+++ b/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/HelperLines/useHelpLines.ts
@@ -1,6 +1,6 @@
 import type { Node, NodeChange, NodePositionChange, XYPosition } from '@xyflow/react'
 
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 export type HelperLinesData = [
   horizontal: number | undefined,
@@ -12,7 +12,7 @@ export const useHelperLines = (): HelperLinesData => {
   const [horizontal, setHorizontal] = useState<number | undefined>()
   const [vertical, setVertical] = useState<number | undefined>()
 
-  const onBeforeApplyNodesChanges = (changes: NodeChange[], nodes: Node[]) => {
+  const onBeforeApplyNodesChanges = useCallback((changes: NodeChange[], nodes: Node[]) => {
     // Clear any existing helper lines.
     setHorizontal(undefined)
     setVertical(undefined)
@@ -29,7 +29,7 @@ export const useHelperLines = (): HelperLinesData => {
       setHorizontal(helperLines.horizontal)
       setVertical(helperLines.vertical)
     }
-  }
+  }, [])
 
   return [horizontal, vertical, onBeforeApplyNodesChanges] as const
 }

--- a/packages/open-flow/src/flow/common/semantics.ts
+++ b/packages/open-flow/src/flow/common/semantics.ts
@@ -992,16 +992,6 @@ export async function validateFlow(revision: RevisionContent, engine: EngineCont
         values: { taskId },
       })
     }
-    if (task.executor.kind == 'connector' && task.executor.connectionId == null) {
-      checked.diagnostics.push({
-        code: 'task.connector-connection-required',
-        column: 0,
-        line: 1,
-        message: `Connector Task "${taskId}" requires a Connection.`,
-        path: `/document/tasks/${taskId}/executor/connectionId`,
-        values: { taskId },
-      })
-    }
   }
   const diagnostics = checked.diagnostics.toSorted(compareDiagnostics)
   return { closure, diagnostics, valid: diagnostics.length == 0 }

--- a/packages/open-flow/src/workbench/browser/runtime/designer/contextPanel.test.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/designer/contextPanel.test.tsx
@@ -10,6 +10,7 @@ import { BlockLibrary, ContextPanel } from './contextPanel.tsx'
 const connector: AddNodeOption = {
   connector: {
     actionId: 'create-issue',
+    authenticated: true,
     description: 'Create an issue.',
     inputs: {},
     name: 'Create issue',

--- a/packages/open-flow/src/workbench/browser/runtime/designer/nodeInspector.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/designer/nodeInspector.tsx
@@ -244,7 +244,8 @@ function TaskDefinition({
   const connector = 'executor' in task && task.executor.kind == 'connector' ? task.executor : undefined
   const activeConnections = activeConnectorConnections ?? []
   const connectionRequired =
-    connector != null && (connector.connectionId == null || (activeConnectorConnections != null && connectorConnection?.status != 'active'))
+    connectorAction?.authenticated == true &&
+    (connector?.connectionId == null || (activeConnectorConnections != null && connectorConnection?.status != 'active'))
   const codeEditor =
     module != null && 'moduleId' in task && moduleEditor?.moduleId == task.moduleId ? (
       <form
@@ -363,7 +364,7 @@ function TaskDefinition({
   )
   return (
     <>
-      {connector != null && (
+      {connector != null && connectorAction?.authenticated !== false && (
         <section className={`inspector-section connection-state ${connectionRequired ? 'required' : ''}`} data-inspector-section="account">
           <h3>
             <Icon name="connection" size={15} /> {t('inspector.account.title')}

--- a/packages/open-flow/src/workbench/browser/runtime/stores/connectorStore.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/connectorStore.test.ts
@@ -75,6 +75,7 @@ describe('ConnectorStore', () => {
           actions: [
             {
               actionId: 'mail.send',
+              authenticated: false,
               description: `Send for ${flowId}.`,
               inputs: {},
               name: 'Send',
@@ -96,9 +97,10 @@ describe('ConnectorStore', () => {
     try {
       await workspace.start(flows[0]!.flowId)
       const firstProviders = await connectors.browseAddNodeOptions(signal)
-      await connectors.provideAddNodeOptionChoices('connector-provider:mail', signal)
+      const firstActions = await connectors.provideAddNodeOptionChoices('connector-provider:mail', signal)
 
       expect(firstProviders?.[0]?.label).toBe('Mail flow-a')
+      expect(firstActions?.[0]?.description).toBe('Send for flow-a.')
       expect(connectors.$.actions.value['mail.send']?.description).toBe('Send for flow-a.')
 
       await workspace.selectFlow(flows[1]!.flowId)

--- a/packages/open-flow/src/workbench/browser/runtime/stores/connectorStore.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/connectorStore.ts
@@ -67,7 +67,7 @@ function option(action: ConnectorAction, t: TFunction): AddNodeOption {
   return {
     connector: action,
     description:
-      action.defaultConnection == null
+      action.authenticated && action.defaultConnection == null
         ? t('addNode.connectorNeedsConnection', { description: action.description, service: action.serviceName })
         : action.description,
     group: t('addNode.connectorActions'),
@@ -284,7 +284,7 @@ export class ConnectorStore {
       const action = await this.#loadAction(target.actionId, force)
       if (!this.#isCurrent(current, flowId)) return
       this.#set({ actions: { ...this.#state.value.actions, [action.actionId]: action } })
-      await this.#refreshConnections(flowId, target, action.serviceId, force, current)
+      if (action.authenticated) await this.#refreshConnections(flowId, target, action.serviceId, force, current)
     } catch (error) {
       if (this.#isCurrent(current, flowId)) {
         this.#set({ actionError: { actionId: target.actionId, message: errorNotice(error, this.#i18n.t).message } })

--- a/packages/open-flow/src/workbench/browser/runtime/workspace.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/workspace.test.ts
@@ -60,6 +60,54 @@ describe('Designer port projection', () => {
       expect.objectContaining({ handle: 'first', variableEnabled: false }),
     ])
   })
+
+  it('only requires a Connection for authenticated Connector Actions', () => {
+    const draft: NonNullable<Parameters<typeof designerGraph>[0]> = {
+      actorId: 'actor',
+      content: {
+        document: {
+          bindings: {},
+          graph: { nodes: { news: { concurrency: 1, inputs: {}, kind: 'task', taskId: 'news' } } },
+          subflows: {},
+          tasks: {
+            news: {
+              executor: { action: 'hacker-news.get-ask-stories', kind: 'connector' },
+              inputs: [],
+              name: 'Get Ask Stories',
+              outputs: [],
+            },
+          },
+        },
+        modelVersion: 1,
+        modules: {},
+      },
+      createdAt: '2026-08-31T00:00:00.000Z',
+      digest: 'digest',
+      flowId: 'flow',
+      modelVersion: 1,
+      parentRevisionId: null,
+      revisionId: 'revision',
+      version: 1,
+    }
+    const action = {
+      actionId: 'hacker-news.get-ask-stories',
+      authenticated: false,
+      description: 'Get Ask HN stories.',
+      inputs: {},
+      name: 'Get Ask Stories',
+      outputs: {},
+      serviceId: 'hacker-news',
+      serviceName: 'Hacker News',
+    }
+
+    const publicNode = designerGraph(draft, { kind: 'flow' }, {}, [], { [action.actionId]: action }).nodes[0]
+    const authenticatedNode = designerGraph(draft, { kind: 'flow' }, {}, [], {
+      [action.actionId]: { ...action, authenticated: true },
+    }).nodes[0]
+
+    expect(publicNode).toMatchObject({ diagnostics: 0, executorName: 'connector' })
+    expect(authenticatedNode).toMatchObject({ diagnostics: 1, executorName: 'connection required' })
+  })
 })
 
 describe('Designer presentation layouts', () => {

--- a/packages/open-flow/src/workbench/browser/runtime/workspace.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/workspace.ts
@@ -678,7 +678,8 @@ function semanticDesignerNode(nodeId: string, resolved: ResolvedNode, ports: Nod
   const connectionId = connector?.connectionId
   let selectedConnection = connectionId == null ? undefined : connections?.byId.get(connectionId)
   if (selectedConnection == null && defaultConnection != null && defaultConnection.connectionId == connectionId) selectedConnection = defaultConnection
-  const connectionRequired = connector != null && (connector.connectionId == null || (connections != null && selectedConnection?.status != 'active'))
+  const connectionRequired =
+    connectorAction?.authenticated == true && (connector?.connectionId == null || (connections != null && selectedConnection?.status != 'active'))
   const nodeRun = context.runNodes.get(nodeId)
   const common = {
     concurrency: node.concurrency,

--- a/packages/open-flow/test/flow-semantics.test.ts
+++ b/packages/open-flow/test/flow-semantics.test.ts
@@ -157,6 +157,28 @@ export default () => value`,
     expect(createRuntimeProgram(result.flow, 'outside-closure', 'sha256:implementation')).toBeUndefined()
   })
 
+  it('allows Connector Tasks without a Connection during deterministic validation', async () => {
+    const source: RevisionFixture = {
+      document: {
+        bindings: {},
+        graph: { nodes: { news: { concurrency: 1, inputs: {}, kind: 'task', taskId: 'news' } } },
+        subflows: {},
+        tasks: {
+          news: {
+            executor: { action: 'hacker-news.get-ask-stories', kind: 'connector' },
+            inputs: [],
+            name: 'Get Ask Stories',
+            outputs: [],
+          },
+        },
+      },
+      modelVersion: 1,
+      modules: {},
+    }
+
+    await expect(validateFlow(source, engine)).resolves.toMatchObject({ diagnostics: [], valid: true })
+  })
+
   it('reports unsupported Engine, invalid Flow, and invalid invocation inputs without platform errors', async () => {
     await expect(prepareFlow(revision('export default () => true'), 'unsupported')).resolves.toEqual({ kind: 'engine-unsupported' })
     await expect(prepareFlow(revision('export const value = true'), currentEngineContract)).resolves.toMatchObject({


### PR DESCRIPTION
## Summary

- expose whether Connector Actions require authentication in the Workbench contract
- let public Connector Actions run without a Connection and hide the Connection prompt
- stabilize the React Flow node-change callback to prevent a StoreUpdater feedback loop during asynchronous Connector refreshes

## Verification

- `cd packages/open-flow && bun run check`
- `cd packages/open-flow && bun run build`
- Open Flow: 104 test files and 632 tests passed
- Command: 4 test files and 56 tests passed