### PR TITLE
fix: address schema comparison review findings

### DIFF
--- a/packages/open-flow/src/flow/common/semantics.ts
+++ b/packages/open-flow/src/flow/common/semantics.ts
@@ -454,7 +454,8 @@ export function matchesSchema(value: JsonValue, schema: JsonValue): boolean {
 }
 
 function schemaAssignable(sourceSchema: JsonValue, targetSchema: JsonValue, sourceNullable = false, targetNullable = false): boolean {
-  if (sourceSchema === true || targetSchema === true || jsonEqual(sourceSchema, {}) || jsonEqual(targetSchema, {})) return true
+  if (targetSchema === true || jsonEqual(targetSchema, {})) return true
+  if (sourceSchema === true || jsonEqual(sourceSchema, {})) return false
   if (sourceSchema === false || targetSchema === false) return false
   const source = schemaObject(sourceSchema)
   const target = schemaObject(targetSchema)

--- a/packages/open-flow/src/manifest/common/schemaCompare.ts
+++ b/packages/open-flow/src/manifest/common/schemaCompare.ts
@@ -56,10 +56,12 @@ export function compareJSONSchema(fromSchema: CompareSchemaInfo, toSchema: Compa
 
 function resolveLocalRefs(schema: object): object {
   function target(reference: string): unknown {
-    if (reference == '#') return schema
-    if (!reference.startsWith('#/')) return
+    if (!reference.startsWith('#')) return
+    const pointer = decodeURIComponent(reference.slice(1))
+    if (pointer == '') return schema
+    if (!pointer.startsWith('/')) return
     let value: unknown = schema
-    for (const encoded of reference.slice(2).split('/')) {
+    for (const encoded of pointer.slice(1).split('/')) {
       if (value == null || typeof value != 'object' || Array.isArray(value)) return
       const token = encoded.replaceAll('~1', '/').replaceAll('~0', '~')
       if (!Object.hasOwn(value, token)) return
@@ -79,18 +81,47 @@ function resolveLocalRefs(schema: object): object {
       if (resolved === undefined) throw new TypeError(`Local JSON Schema reference "${reference}" does not exist.`)
       const nextReferences = new Set(references)
       nextReferences.add(reference)
-      const siblings = Object.fromEntries(
-        Object.entries(source)
-          .filter(([key]) => key != '$ref' && key != '$defs' && key != 'definitions')
-          .map(([key, item]) => [key, visit(item, nextReferences)]),
-      )
+      const siblings = Object.fromEntries(Object.entries(source).filter(([key]) => key != '$ref' && key != '$defs' && key != 'definitions'))
       const result = visit(resolved, nextReferences)
-      return Object.keys(siblings).length == 0 ? result : { allOf: [result, siblings] }
+      return Object.keys(siblings).length == 0 ? result : { allOf: [result, visit(siblings, references)] }
     }
     return Object.fromEntries(
       Object.entries(source)
         .filter(([key]) => key != '$defs' && key != 'definitions')
-        .map(([key, item]) => [key, visit(item, references)]),
+        .map(([key, item]) => {
+          switch (key) {
+            case 'additionalItems':
+            case 'additionalProperties':
+            case 'contains':
+            case 'else':
+            case 'if':
+            case 'not':
+            case 'propertyNames':
+            case 'then': {
+              return [key, visit(item, references)]
+            }
+            case 'items': {
+              return [key, Array.isArray(item) ? item.map((entry) => visit(entry, references)) : visit(item, references)]
+            }
+            case 'allOf':
+            case 'anyOf':
+            case 'oneOf': {
+              return [key, Array.isArray(item) ? item.map((entry) => visit(entry, references)) : item]
+            }
+            case 'patternProperties':
+            case 'properties': {
+              if (item == null || typeof item != 'object' || Array.isArray(item)) return [key, item]
+              return [key, Object.fromEntries(Object.entries(item).map(([name, entry]) => [name, visit(entry, references)]))]
+            }
+            case 'dependencies': {
+              if (item == null || typeof item != 'object' || Array.isArray(item)) return [key, item]
+              return [key, Object.fromEntries(Object.entries(item).map(([name, entry]) => [name, Array.isArray(entry) ? entry : visit(entry, references)]))]
+            }
+            default: {
+              return [key, item]
+            }
+          }
+        }),
     )
   }
 

--- a/packages/open-flow/test/designer/schema-compare.test.ts
+++ b/packages/open-flow/test/designer/schema-compare.test.ts
@@ -223,6 +223,54 @@ describe('In-process schema compare', () => {
     ).toEqual({ kind: 'compatible' })
   })
 
+  it('decodes URI fragments before evaluating JSON Pointers', () => {
+    expect(
+      compareJSONSchema(
+        {
+          packageId: undefined,
+          schema: {
+            $defs: { group: { text: { type: 'string' } } },
+            $ref: '#/$defs/group%2Ftext',
+          },
+        },
+        { packageId: undefined, schema: { type: 'string' } },
+      ),
+    ).toEqual({ kind: 'compatible' })
+  })
+
+  it('preserves literal objects containing $ref keys', () => {
+    const literal = { $ref: '#/$defs/text' }
+
+    expect(
+      compareJSONSchema(
+        { packageId: undefined, schema: { $defs: { text: { type: 'string' } }, const: literal } },
+        { packageId: undefined, schema: { const: literal } },
+      ),
+    ).toEqual({ kind: 'compatible' })
+    expect(
+      compareJSONSchema(
+        { packageId: undefined, schema: { $defs: { text: { type: 'string' } }, enum: [literal] } },
+        { packageId: undefined, schema: { enum: [literal] } },
+      ),
+    ).toEqual({ kind: 'compatible' })
+  })
+
+  it('allows a $ref sibling to repeat a reference', () => {
+    expect(
+      compareJSONSchema(
+        {
+          packageId: undefined,
+          schema: {
+            $defs: { text: { type: 'string' } },
+            $ref: '#/$defs/text',
+            allOf: [{ $ref: '#/$defs/text' }],
+          },
+        },
+        { packageId: undefined, schema: { type: 'string' } },
+      ),
+    ).toEqual({ kind: 'compatible' })
+  })
+
   it('fails closed for cyclic local references', () => {
     expect(
       compareJSONSchema(

--- a/packages/open-flow/test/flow-semantics.test.ts
+++ b/packages/open-flow/test/flow-semantics.test.ts
@@ -460,6 +460,52 @@ export default () => value`,
     await expect(validateFlow(valid, engine)).resolves.toMatchObject({ diagnostics: [], valid: true })
   })
 
+  it.each([
+    {
+      codes: ['graph.node-output-incompatible'],
+      name: 'rejects a true output for a constrained input',
+      sourceSchema: true as JsonValue,
+      targetSchema: { type: 'string' } as JsonValue,
+    },
+    {
+      codes: ['graph.node-output-incompatible'],
+      name: 'rejects an empty output schema for a constrained input',
+      sourceSchema: {} as JsonValue,
+      targetSchema: { type: 'string' } as JsonValue,
+    },
+    { codes: [], name: 'accepts two unconstrained schemas', sourceSchema: true as JsonValue, targetSchema: {} as JsonValue },
+  ])('$name', async ({ codes, sourceSchema, targetSchema }) => {
+    const source = revision('export default ({ input }) => ({ input })')
+    const task = source.document.graph.nodes.task
+    if (task?.kind != 'task' || task.task == null) throw new Error('Fixture inline Task is missing.')
+    const invalid: RevisionFixture = {
+      ...source,
+      document: {
+        ...source.document,
+        graph: {
+          nodes: {
+            source: {
+              concurrency: 1,
+              inputs: {},
+              kind: 'value',
+              name: 'Source',
+              values: [{ handle: 'value', jsonSchema: sourceSchema, nullable: false, value: 'text' }],
+            },
+            task: {
+              ...task,
+              inputs: { input: { kind: 'sources', sources: [{ kind: 'node', nodeId: 'source', output: 'value' }] } },
+              task: { ...task.task, inputs: [{ handle: 'input', jsonSchema: targetSchema, nullable: false }] },
+            },
+          },
+        },
+      },
+    }
+
+    const result = await validateFlow(invalid, engine)
+    expect(result.diagnostics.map(({ code }) => code)).toEqual(codes)
+    expect(result.valid).toBe(codes.length == 0)
+  })
+
   it('accepts a schema-nullable output for a nullable input', async () => {
     const source = revision('export default ({ input }) => ({ input })')
     const task = source.document.graph.nodes.task


### PR DESCRIPTION
## Summary

- reject unconstrained source schemas when the target schema is constrained
- resolve local JSON Schema references only in schema positions, preserving literal objects in const and enum
- decode URI fragments before JSON Pointer evaluation and keep sibling reference ancestry independent
- add regression coverage for all four review findings

## Verification

- bun run check
- bun run test
- bun run build
- bun run test:package