### PR TITLE
fix: add provider icon fallbacks

### DIFF
--- a/apps/server/browser/env.d.ts
+++ b/apps/server/browser/env.d.ts
@@ -1,5 +1,10 @@
 /// <reference types="vite/client" />
 
+declare module 'virtual:oomol-provider-icons' {
+  const iconUrls: Readonly<Record<string, string>>
+  export default iconUrls
+}
+
 declare module 'virtual:open-flow-twemoji' {
   const data: import('@iconify/types').IconifyJSONPackageExports
   export default data

--- a/apps/server/node/connector.ts
+++ b/apps/server/node/connector.ts
@@ -110,9 +110,11 @@ export class ConnectorClient implements ConnectorHost {
 
   async listProviders(signal?: AbortSignal, teamId?: string): Promise<readonly ConnectorProvider[]> {
     return (await this.#providers(signal, teamId)).map((provider) =>
-      provider.icon == null
-        ? { serviceId: provider.serviceId, serviceName: provider.serviceName }
-        : { icon: provider.icon, serviceId: provider.serviceId, serviceName: provider.serviceName },
+      Object.assign(
+        { serviceId: provider.serviceId, serviceName: provider.serviceName },
+        provider.homepageUrl == null ? {} : { homepageUrl: provider.homepageUrl },
+        provider.icon == null ? {} : { icon: provider.icon },
+      ),
     )
   }
 
@@ -501,9 +503,11 @@ function runtimeProvider(value: unknown) {
   const source = record(value) ? value : undefined
   if (source == null) throw unavailable()
   if (!Array.isArray(source.authTypes) || source.authTypes.some((authType) => typeof authType != 'string')) throw unavailable()
+  if (source.homepageUrl != null && typeof source.homepageUrl != 'string') throw unavailable()
   if (source.iconUrl != null && typeof source.iconUrl != 'string') throw unavailable()
   return {
     authenticated: !source.authTypes.includes('no_auth'),
+    ...(source.homepageUrl == null || source.homepageUrl.length == 0 ? {} : { homepageUrl: source.homepageUrl }),
     ...(source.iconUrl == null || source.iconUrl.length == 0 ? {} : { icon: source.iconUrl }),
     serviceId: string(source.service),
     serviceName: string(source.displayName),
@@ -588,6 +592,7 @@ function mapAction(
     authenticated: provider.authenticated,
     ...(defaultConnection == null ? {} : { defaultConnection }),
     description: action.description,
+    ...(provider.homepageUrl == null ? {} : { homepageUrl: provider.homepageUrl }),
     ...(provider.icon == null ? {} : { icon: provider.icon }),
     inputs: Object.fromEntries(
       ports.inputs.map((port) => {

--- a/apps/server/test/connectorClient.test.ts
+++ b/apps/server/test/connectorClient.test.ts
@@ -281,12 +281,20 @@ describe('Server Connector client', () => {
     })
     const connector = new ConnectorClient(origin, 'runtime-token')
 
-    await expect(connector.listProviders()).resolves.toEqual([{ icon: 'https://example.test/icon.svg', serviceId: 'example', serviceName: 'Example' }])
+    await expect(connector.listProviders()).resolves.toEqual([
+      {
+        homepageUrl: 'https://example.test',
+        icon: 'https://example.test/icon.svg',
+        serviceId: 'example',
+        serviceName: 'Example',
+      },
+    ])
     await expect(connector.listActions('example')).resolves.toEqual([
       expect.objectContaining({
         actionId: 'example.echo',
         authenticated: true,
         defaultConnection: expect.objectContaining({ connectionId: 'connection-work' }),
+        homepageUrl: 'https://example.test',
         inputs: {
           message: { description: 'Message.', jsonSchema: { default: 'hello', description: 'Message.', type: 'string' }, nullable: true, value: 'hello' },
         },

--- a/apps/server/test/process-recovery.test.ts
+++ b/apps/server/test/process-recovery.test.ts
@@ -206,6 +206,7 @@ it('serves the compiled Workbench and authenticates the Control API in the real 
   const asset = await fetch(`${app.origin}${assetPath}`)
   expect(asset.status).toBe(200)
   expect(asset.headers.get('cache-control')).toBe('public, max-age=31536000, immutable')
+  await asset.body?.cancel()
 
   await expect(json(await fetch(`${app.origin}/auth/session`))).resolves.toEqual({
     authenticated: false,

--- a/apps/server/vite.config.ts
+++ b/apps/server/vite.config.ts
@@ -1,6 +1,7 @@
 import { generateScopedName } from '@oomol-lab/open-flow/designer-css-modules'
 import { twemojiCollectionPlugin } from '@oomol-lab/open-flow/designer-twemoji-plugin'
 import designerUnoConfig from '@oomol-lab/open-flow/designer-vite-config'
+import { providerIconsPlugin } from '@oomol-lab/open-flow/provider-icons-plugin'
 import tailwindcss from '@tailwindcss/vite'
 import UnoCSS from '@unocss/vite'
 import react from '@vitejs/plugin-react'
@@ -12,7 +13,7 @@ const serverPathPattern = `^(?:${serverPaths.join('|')})(?:/|$)`
 export default defineConfig({
   build: { outDir: 'dist/public' },
   css: { modules: { generateScopedName } },
-  plugins: [twemojiCollectionPlugin(), tailwindcss(), UnoCSS(designerUnoConfig), react()],
+  plugins: [providerIconsPlugin(), twemojiCollectionPlugin(), tailwindcss(), UnoCSS(designerUnoConfig), react()],
   server: {
     proxy: { [serverPathPattern]: { target: process.env.OPEN_FLOW_DEV_API_ORIGIN ?? 'http://127.0.0.1:3001' } },
   },

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -1,6 +1,8 @@
+import { providerIconsPlugin } from '@oomol-lab/open-flow/provider-icons-plugin'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  plugins: [providerIconsPlugin({ iconUrls: {} })],
   test: {
     coverage: {
       include: [

--- a/packages/open-flow/package.json
+++ b/packages/open-flow/package.json
@@ -26,6 +26,7 @@
     "./control-api-conformance": "./src/control/common/conformance.ts",
     "./cron-trigger": "./src/trigger/common/cron.ts",
     "./designer-css-modules": "./src/build/node/cssModules.ts",
+    "./provider-icons-plugin": "./src/build/node/providerIcons.ts",
     "./designer-twemoji-plugin": "./src/build/node/twemojiCollection.ts",
     "./designer-vite-config": "./src/build/node/designerUnoConfig.ts",
     "./integration-trigger": "./src/trigger/common/integration.ts",

--- a/packages/open-flow/src/browser-assets.d.ts
+++ b/packages/open-flow/src/browser-assets.d.ts
@@ -13,6 +13,10 @@ declare module '*.svg' {
   export default source
 }
 declare module 'virtual:uno.css'
+declare module 'virtual:oomol-provider-icons' {
+  const iconUrls: Readonly<Record<string, string>>
+  export default iconUrls
+}
 declare module 'virtual:open-flow-twemoji' {
   import type { IconifyJSONPackageExports } from '@iconify/types'
 

--- a/packages/open-flow/src/build/node/providerIcons.test.ts
+++ b/packages/open-flow/src/build/node/providerIcons.test.ts
@@ -1,0 +1,73 @@
+import type { Plugin } from 'vite'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { providerIconsPlugin } from './providerIcons.ts'
+
+const resolvedModuleId = '\0virtual:oomol-provider-icons'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+async function load(plugin: Plugin): Promise<unknown> {
+  if (typeof plugin.load != 'function') throw new Error('Provider icons plugin does not have a load hook.')
+  return await Reflect.apply(plugin.load, {}, [resolvedModuleId])
+}
+
+describe('providerIconsPlugin', () => {
+  it.each(['Server Workbench', 'npm Workbench'])('settles the %s catalog fetch within the configured bound', async () => {
+    const controller = new AbortController()
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockImplementation(() => {
+      queueMicrotask(() => controller.abort())
+      return controller.signal
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+        const signal = init?.signal
+        if (signal == null) throw new Error('Catalog fetch did not include a timeout signal.')
+        return await new Promise<Response>((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+        })
+      }),
+    )
+
+    await expect(load(providerIconsPlugin())).resolves.toBe('export default {};')
+    expect(timeout).toHaveBeenCalledWith(5_000)
+  })
+
+  it('bundles valid catalog entries', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        Response.json({
+          items: [
+            { iconUrl: 'https://static.oomol.com/example.svg', service: 'example' },
+            { iconUrl: '', service: 'missing' },
+          ],
+        }),
+      ),
+    )
+
+    await expect(load(providerIconsPlugin())).resolves.toBe('export default {"example":"https://static.oomol.com/example.svg"};')
+  })
+
+  it('uses an empty catalog for invalid responses', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => Response.json({ items: null })),
+    )
+
+    await expect(load(providerIconsPlugin())).resolves.toBe('export default {};')
+  })
+
+  it('uses an empty catalog when the catalog is unavailable', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 503 })),
+    )
+
+    await expect(load(providerIconsPlugin())).resolves.toBe('export default {};')
+  })
+})

--- a/packages/open-flow/src/build/node/providerIcons.ts
+++ b/packages/open-flow/src/build/node/providerIcons.ts
@@ -1,6 +1,8 @@
 import type { Plugin } from 'vite'
 
 const catalogUrl = 'https://oomol.com/en/apps/catalog.json'
+const catalogTimeoutMs = 5_000
+const emptyModule = 'export default {};'
 const publicModuleId = 'virtual:oomol-provider-icons'
 const resolvedModuleId = `\0${publicModuleId}`
 
@@ -21,20 +23,24 @@ export function providerIconsPlugin(options: { readonly iconUrls?: Readonly<Reco
 }
 
 async function loadProviderIconsModule(): Promise<string> {
-  const response = await fetch(catalogUrl)
-  if (!response.ok) throw new Error(`Could not load OOMOL provider icons: ${response.status} ${response.statusText}`)
+  try {
+    const response = await fetch(catalogUrl, { signal: AbortSignal.timeout(catalogTimeoutMs) })
+    if (!response.ok) return emptyModule
 
-  const payload = (await response.json()) as { readonly items?: unknown }
-  if (!Array.isArray(payload.items)) throw new Error('Could not load OOMOL provider icons: catalog.items is not an array')
+    const payload = (await response.json()) as { readonly items?: unknown }
+    if (!Array.isArray(payload.items)) return emptyModule
 
-  const iconUrls: Record<string, string> = {}
-  for (const item of payload.items) {
-    const candidate = item as { readonly iconUrl?: unknown; readonly service?: unknown }
-    if (typeof candidate.service == 'string' && typeof candidate.iconUrl == 'string' && candidate.iconUrl.trim()) {
-      iconUrls[candidate.service] = candidate.iconUrl
+    const iconUrls: Record<string, string> = {}
+    for (const item of payload.items) {
+      const candidate = item as { readonly iconUrl?: unknown; readonly service?: unknown }
+      if (typeof candidate.service == 'string' && typeof candidate.iconUrl == 'string' && candidate.iconUrl.trim()) {
+        iconUrls[candidate.service] = candidate.iconUrl
+      }
     }
+    return serializeProviderIcons(iconUrls)
+  } catch {
+    return emptyModule
   }
-  return serializeProviderIcons(iconUrls)
 }
 
 function serializeProviderIcons(iconUrls: Readonly<Record<string, string>>): string {

--- a/packages/open-flow/src/build/node/providerIcons.ts
+++ b/packages/open-flow/src/build/node/providerIcons.ts
@@ -1,0 +1,42 @@
+import type { Plugin } from 'vite'
+
+const catalogUrl = 'https://oomol.com/en/apps/catalog.json'
+const publicModuleId = 'virtual:oomol-provider-icons'
+const resolvedModuleId = `\0${publicModuleId}`
+
+export function providerIconsPlugin(options: { readonly iconUrls?: Readonly<Record<string, string>> } = {}): Plugin {
+  let cachedModule: Promise<string> | undefined
+
+  return {
+    name: 'oomol-provider-icons',
+    resolveId(id): string | undefined {
+      return id == publicModuleId ? resolvedModuleId : undefined
+    },
+    load(id): Promise<string> | undefined {
+      if (id != resolvedModuleId) return
+      cachedModule ??= options.iconUrls == null ? loadProviderIconsModule() : Promise.resolve(serializeProviderIcons(options.iconUrls))
+      return cachedModule
+    },
+  }
+}
+
+async function loadProviderIconsModule(): Promise<string> {
+  const response = await fetch(catalogUrl)
+  if (!response.ok) throw new Error(`Could not load OOMOL provider icons: ${response.status} ${response.statusText}`)
+
+  const payload = (await response.json()) as { readonly items?: unknown }
+  if (!Array.isArray(payload.items)) throw new Error('Could not load OOMOL provider icons: catalog.items is not an array')
+
+  const iconUrls: Record<string, string> = {}
+  for (const item of payload.items) {
+    const candidate = item as { readonly iconUrl?: unknown; readonly service?: unknown }
+    if (typeof candidate.service == 'string' && typeof candidate.iconUrl == 'string' && candidate.iconUrl.trim()) {
+      iconUrls[candidate.service] = candidate.iconUrl
+    }
+  }
+  return serializeProviderIcons(iconUrls)
+}
+
+function serializeProviderIcons(iconUrls: Readonly<Record<string, string>>): string {
+  return `export default ${JSON.stringify(iconUrls)};`
+}

--- a/packages/open-flow/src/control/common/api.test.ts
+++ b/packages/open-flow/src/control/common/api.test.ts
@@ -63,14 +63,16 @@ describe('ControlClient Flow API', () => {
   it('scopes Connector resources to an encoded Flow identity', async () => {
     const request = vi.fn(async (path: string, _init?: RequestInit) => {
       if (path == '/v1/connector/providers?flowId=flow%2F1') {
-        return Response.json({ providers: [{ serviceId: 'mail', serviceName: 'Mail' }], version: 1 })
+        return Response.json({ providers: [{ homepageUrl: 'https://mail.example', serviceId: 'mail', serviceName: 'Mail' }], version: 1 })
       }
       if (path == '/v1/connector/connections/mail/page?flowId=flow%2F1') return Response.json({ url: 'https://connector.example/providers/mail', version: 1 })
       throw new Error(path)
     })
     const client = new ControlClient(request)
 
-    await expect(client.listConnectorProviders(undefined, flow.flowId)).resolves.toEqual([{ serviceId: 'mail', serviceName: 'Mail' }])
+    await expect(client.listConnectorProviders(undefined, flow.flowId)).resolves.toEqual([
+      { homepageUrl: 'https://mail.example', serviceId: 'mail', serviceName: 'Mail' },
+    ])
     await expect(client.createConnectorConnectionPage('mail', flow.flowId)).resolves.toBe('https://connector.example/providers/mail')
   })
 

--- a/packages/open-flow/src/control/common/api.ts
+++ b/packages/open-flow/src/control/common/api.ts
@@ -106,6 +106,7 @@ export interface ConnectorAction {
   readonly authenticated: boolean
   readonly defaultConnection?: ConnectorConnection
   readonly description: string
+  readonly homepageUrl?: string
   readonly icon?: string
   readonly inputs: Readonly<Record<string, InputPortDefinition>>
   readonly name: string
@@ -115,6 +116,7 @@ export interface ConnectorAction {
 }
 
 export interface ConnectorProvider {
+  readonly homepageUrl?: string
   readonly icon?: string
   readonly serviceId: string
   readonly serviceName: string
@@ -413,6 +415,7 @@ function ports<Value>(value: unknown, decode: (value: unknown) => Value): Readon
 
 function connectorAction(value: unknown): ConnectorAction {
   const source = record(value)
+  const homepageUrl = source.homepageUrl
   const icon = source.icon
   const hasConnection = source.defaultConnection != null
   exact(source, [
@@ -420,6 +423,7 @@ function connectorAction(value: unknown): ConnectorAction {
     'authenticated',
     ...(hasConnection ? ['defaultConnection'] : []),
     'description',
+    ...(homepageUrl == null ? [] : ['homepageUrl']),
     ...(icon == null ? [] : ['icon']),
     'inputs',
     'name',
@@ -427,12 +431,13 @@ function connectorAction(value: unknown): ConnectorAction {
     'serviceId',
     'serviceName',
   ])
-  if (icon != null && typeof icon != 'string') return invalidResponse()
+  if ((homepageUrl != null && typeof homepageUrl != 'string') || (icon != null && typeof icon != 'string')) return invalidResponse()
   const result: ConnectorAction = {
     actionId: string(source.actionId),
     authenticated: typeof source.authenticated == 'boolean' ? source.authenticated : invalidResponse(),
     ...(hasConnection ? { defaultConnection: connection(source.defaultConnection) } : {}),
     description: typeof source.description == 'string' ? source.description : invalidResponse(),
+    ...(homepageUrl == null ? {} : { homepageUrl }),
     ...(icon == null ? {} : { icon }),
     inputs: ports(source.inputs, inputPort),
     name: string(source.name),
@@ -448,10 +453,12 @@ function connectorAction(value: unknown): ConnectorAction {
 
 function connectorProvider(value: unknown): ConnectorProvider {
   const source = record(value)
+  const homepageUrl = source.homepageUrl
   const icon = source.icon
-  exact(source, ['serviceId', 'serviceName', ...(icon == null ? [] : ['icon'])])
-  if (icon != null && typeof icon != 'string') return invalidResponse()
+  exact(source, ['serviceId', 'serviceName', ...(homepageUrl == null ? [] : ['homepageUrl']), ...(icon == null ? [] : ['icon'])])
+  if ((homepageUrl != null && typeof homepageUrl != 'string') || (icon != null && typeof icon != 'string')) return invalidResponse()
   return {
+    ...(homepageUrl == null ? {} : { homepageUrl }),
     ...(icon == null ? {} : { icon }),
     serviceId: string(source.serviceId),
     serviceName: string(source.serviceName),

--- a/packages/open-flow/src/designer/browser/icons/DesignerIcon.tsx
+++ b/packages/open-flow/src/designer/browser/icons/DesignerIcon.tsx
@@ -14,19 +14,39 @@ export interface DesignerIconProps {
 }
 
 export const DesignerIcon = ({ src, className, fallback = null }: DesignerIconProps) => {
-  const result = useMemo(() => parseIconifyIcon(src), [src])
+  const image = useMemo(() => parseImageIcon(src), [src])
+  const source = image?.source ?? src
+  const result = useMemo(() => parseIconifyIcon(source), [source])
   const [error, setError] = useState<string>()
-  const onError = () => setError(src)
+  const onError = () => setError(source)
 
-  if (!src || src === error) {
+  if (!source) {
     return fallback as React.ReactElement
   }
+  if (source === error)
+    return image == null ? (fallback as React.ReactElement) : <DesignerIcon className={className} fallback={fallback} src={image.fallback} />
 
   return result ? (
     <IconifyIcon collection={result.collection} icon={result.icon} color={result.color} className={className} onError={onError} />
   ) : (
-    <img className={clsx(styles.img, className)} src={src} alt="" decoding="async" loading="lazy" referrerPolicy="no-referrer" onError={onError} />
+    <img className={clsx(styles.img, className)} src={source} alt="" decoding="async" loading="lazy" referrerPolicy="no-referrer" onError={onError} />
   )
+}
+
+const imageIconPrefix = 'data:application/vnd.open-flow.image-icon+json,'
+
+export function imageIcon(source: string, fallback: string): string {
+  return `${imageIconPrefix}${encodeURIComponent(JSON.stringify({ fallback, source }))}`
+}
+
+function parseImageIcon(src: string | undefined): { readonly fallback: string; readonly source: string } | undefined {
+  if (!src?.startsWith(imageIconPrefix)) return
+  try {
+    const value = JSON.parse(decodeURIComponent(src.slice(imageIconPrefix.length))) as { readonly fallback?: unknown; readonly source?: unknown }
+    if (typeof value.fallback == 'string' && typeof value.source == 'string') return { fallback: value.fallback, source: value.source }
+  } catch {
+    return
+  }
 }
 
 export function parseIconifyIcon(src: string | undefined): { collection: string; icon: string; color: string } | null {

--- a/packages/open-flow/src/distribution/node/browserPackage.ts
+++ b/packages/open-flow/src/distribution/node/browserPackage.ts
@@ -9,6 +9,7 @@ import { promisify } from 'node:util'
 import { build, esmExternalRequirePlugin } from 'vite'
 import { generateScopedName } from '../../build/node/cssModules.ts'
 import designerUnoConfig from '../../build/node/designerUnoConfig.ts'
+import { providerIconsPlugin } from '../../build/node/providerIcons.ts'
 import { twemojiCollectionPlugin } from '../../build/node/twemojiCollection.ts'
 
 const execFileAsync = promisify(execFile)
@@ -104,6 +105,7 @@ async function buildRuntime(
     logLevel: options.quiet ? 'silent' : 'info',
     plugins: [
       esmExternalRequirePlugin({ external: [/^effect(?:\/.*)?$/, /^react(?:\/.*)?$/, /^react-dom(?:\/.*)?$/] }),
+      providerIconsPlugin(),
       twemojiCollectionPlugin(),
       tailwindcss(),
       UnoCSS(designerUnoConfig),

--- a/packages/open-flow/src/workbench/browser/runtime/providerIcon.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/providerIcon.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { providerIconSource, providerInitials } from './providerIcon.ts'
+
+describe('providerIconSource', () => {
+  it('prefers the provider icon', () => {
+    expect(providerIconSource({ icon: ' https://example.com/icon.svg ', serviceId: 'example' }, { example: 'https://static.oomol.com/example.svg' })).toBe(
+      'https://example.com/icon.svg',
+    )
+  })
+
+  it('uses the bundled OOMOL catalog icon', () => {
+    expect(providerIconSource({ serviceId: 'example' }, { example: 'https://static.oomol.com/example.svg' })).toBe('https://static.oomol.com/example.svg')
+  })
+
+  it('uses the homepage favicon when no icon is mapped', () => {
+    expect(providerIconSource({ homepageUrl: 'https://example.com/docs', serviceId: 'example' }, {})).toBe(
+      'https://www.google.com/s2/favicons?sz=64&domain=example.com',
+    )
+  })
+
+  it('falls back to initials when no icon or valid homepage is available', () => {
+    expect(providerIconSource({ homepageUrl: 'not a URL', serviceId: 'example' }, {})).toBeUndefined()
+    expect(providerInitials('Google Drive')).toBe('GD')
+  })
+})

--- a/packages/open-flow/src/workbench/browser/runtime/providerIcon.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/providerIcon.ts
@@ -1,0 +1,51 @@
+import providerIconUrls from 'virtual:oomol-provider-icons'
+import { imageIcon } from '../../../designer/browser/icons/DesignerIcon.tsx'
+
+export function providerIcon(
+  provider: { readonly homepageUrl?: string; readonly icon?: string; readonly serviceId: string; readonly serviceName: string },
+  catalogIconUrls: Readonly<Record<string, string>> = providerIconUrls,
+): string {
+  const fallback = initialsIcon(providerInitials(provider.serviceName))
+  const source = providerIconSource(provider, catalogIconUrls)
+  return source == null ? fallback : imageIcon(source, fallback)
+}
+
+export function providerIconSource(
+  provider: { readonly homepageUrl?: string; readonly icon?: string; readonly serviceId: string },
+  catalogIconUrls: Readonly<Record<string, string>> = providerIconUrls,
+): string | undefined {
+  const icon = provider.icon?.trim()
+  if (icon) return icon
+
+  const catalogIcon = catalogIconUrls[provider.serviceId]?.trim()
+  if (catalogIcon) return catalogIcon
+
+  const hostname = homepageHostname(provider.homepageUrl)
+  return hostname == null ? undefined : `https://www.google.com/s2/favicons?sz=64&domain=${encodeURIComponent(hostname)}`
+}
+
+export function providerInitials(displayName: string): string {
+  return (
+    displayName
+      .split(/\s+/)
+      .map((part) => part[0])
+      .join('')
+      .slice(0, 2)
+      .toUpperCase() || '?'
+  )
+}
+
+function homepageHostname(homepageUrl: string | undefined): string | undefined {
+  if (!homepageUrl) return
+  try {
+    return new URL(homepageUrl).hostname || undefined
+  } catch {
+    return
+  }
+}
+
+function initialsIcon(initials: string): string {
+  const text = [...initials].map((letter) => `&#${letter.codePointAt(0)};`).join('')
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="12" fill="#e4e4e7"/><text x="32" y="33" fill="#3f3f46" font-family="Arial,sans-serif" font-size="25" font-weight="600" text-anchor="middle" dominant-baseline="central">${text}</text></svg>`
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`
+}

--- a/packages/open-flow/src/workbench/browser/runtime/stores/connectorStore.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/connectorStore.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { WorkbenchClient } from '../api.ts'
+import { providerIcon } from '../providerIcon.ts'
 import { ConnectorStore } from './connectorStore.ts'
 import { WorkspaceStore } from './workspaceStore.ts'
 
@@ -67,7 +68,7 @@ describe('ConnectorStore', () => {
       const flowId = new URL(path, 'https://open-flow.example').searchParams.get('flowId')
       if (path.startsWith('/v1/connector/providers?')) {
         connectorRequests.push(path)
-        return Response.json({ providers: [{ serviceId: 'mail', serviceName: `Mail ${flowId}` }], version: 1 })
+        return Response.json({ providers: [{ homepageUrl: 'https://mail.example', serviceId: 'mail', serviceName: `Mail ${flowId}` }], version: 1 })
       }
       if (path.startsWith('/v1/connector/actions?')) {
         connectorRequests.push(path)
@@ -77,6 +78,7 @@ describe('ConnectorStore', () => {
               actionId: 'mail.send',
               authenticated: false,
               description: `Send for ${flowId}.`,
+              homepageUrl: 'https://mail.example',
               inputs: {},
               name: 'Send',
               outputs: {},
@@ -100,7 +102,9 @@ describe('ConnectorStore', () => {
       const firstActions = await connectors.provideAddNodeOptionChoices('connector-provider:mail', signal)
 
       expect(firstProviders?.[0]?.label).toBe('Mail flow-a')
+      expect(firstProviders?.[0]?.icon).toBe(providerIcon({ homepageUrl: 'https://mail.example', serviceId: 'mail', serviceName: 'Mail flow-a' }))
       expect(firstActions?.[0]?.description).toBe('Send for flow-a.')
+      expect(firstActions?.[0]?.icon).toBe(providerIcon({ homepageUrl: 'https://mail.example', serviceId: 'mail', serviceName: 'Mail flow-a' }))
       expect(connectors.$.actions.value['mail.send']?.description).toBe('Send for flow-a.')
 
       await workspace.selectFlow(flows[1]!.flowId)

--- a/packages/open-flow/src/workbench/browser/runtime/stores/connectorStore.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/connectorStore.ts
@@ -12,6 +12,7 @@ import type { WorkspaceStore } from './workspaceStore.ts'
 import { compute, derive, val } from 'value-enhancer'
 import { flowDependencies } from '../../../../flow/common/semantics.ts'
 import { createI18n } from '../i18n.ts'
+import { providerIcon } from '../providerIcon.ts'
 import { connectionCatalog } from '../workspace.ts'
 import { Latest } from './latest.ts'
 import { errorNotice } from './workbenchNotice.ts'
@@ -73,7 +74,7 @@ function option(action: ConnectorAction, t: TFunction): AddNodeOption {
         ? t('addNode.connectorNeedsConnection', { description: action.description, service: action.serviceName })
         : action.description,
     group: t('addNode.connectorActions'),
-    icon: action.icon ?? ':carbon:connection-signal:',
+    icon: providerIcon(action),
     id: `connector:${action.actionId}`,
     inputs: ports(action.inputs),
     kind: 'connector',
@@ -101,7 +102,7 @@ function providerOptions(actions: readonly ConnectorAction[], t: TFunction): rea
         choices,
         description: t(choices.length == 1 ? 'addNode.connectorActionCountOne' : 'addNode.connectorActionCount', { count: choices.length }),
         group: t('addNode.connectorActions'),
-        icon: first.icon ?? ':carbon:connection-signal:',
+        icon: providerIcon(first),
         id: `connector-provider:${first.serviceId}`,
         inputs: [],
         kind: 'connector-group',
@@ -117,7 +118,7 @@ function providerOption(provider: ConnectorProvider, t: TFunction): AddNodeOptio
     choices: [],
     description: t('addNode.connectorBrowseActions'),
     group: t('addNode.connectorActions'),
-    icon: provider.icon ?? ':carbon:connection-signal:',
+    icon: providerIcon(provider),
     id: `connector-provider:${provider.serviceId}`,
     inputs: [],
     kind: 'connector-group',

--- a/packages/open-flow/src/workbench/browser/runtime/stores/triggerStore.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/triggerStore.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { WorkbenchClient } from '../api.ts'
+import { providerIcon } from '../providerIcon.ts'
 import { TriggerStore } from './triggerStore.ts'
 import { WorkspaceStore } from './workspaceStore.ts'
 
@@ -93,6 +94,7 @@ describe('TriggerStore', () => {
 
       expect(options).toHaveLength(1)
       expect(options?.[0]).toMatchObject({
+        icon: providerIcon({ serviceId: 'github', serviceName: 'github' }),
         id: 'trigger:github.on_repo_event',
         outputs: [{ handle: 'payload' }],
         trigger: { kind: 'catalog' },

--- a/packages/open-flow/src/workbench/browser/runtime/stores/triggerStore.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/triggerStore.ts
@@ -11,6 +11,7 @@ import type { WorkspaceStore } from './workspaceStore.ts'
 
 import { compute, derive, val } from 'value-enhancer'
 import { createI18n } from '../i18n.ts'
+import { providerIcon } from '../providerIcon.ts'
 import { connectionCatalog } from '../workspace.ts'
 import { Latest } from './latest.ts'
 import { errorNotice } from './workbenchNotice.ts'
@@ -64,6 +65,7 @@ function option(definition: TriggerKeySnapshot, i18n: I18n): AddNodeOption {
   return {
     description: i18n.t('addNode.triggerNeedsConnection', { provider: definition.provider }),
     group: i18n.t('addNode.triggers'),
+    icon: providerIcon({ serviceId: definition.provider, serviceName: definition.provider }),
     id: `${optionPrefix}${definition.key}`,
     inputs: [],
     kind: 'trigger',

--- a/packages/open-flow/src/workbench/browser/runtime/workspace.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/workspace.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { providerIcon } from './providerIcon.ts'
 import { designerGraph, setFlowViewport, setNodePositions } from './workspace.ts'
 
 describe('Designer port projection', () => {
@@ -184,6 +185,7 @@ describe('Designer port projection', () => {
     ]).nodes[0]
 
     expect(node).toMatchObject({
+      icon: providerIcon({ serviceId: 'github', serviceName: 'github' }),
       kind: 'trigger',
       presentation: {
         config: [expect.objectContaining({ invalid: true, name: 'owner' }), expect.objectContaining({ invalid: false, name: 'repo' })],

--- a/packages/open-flow/src/workbench/browser/runtime/workspace.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/workspace.ts
@@ -16,6 +16,7 @@ import type { ResolvedNode, ResolvedSelection, RevisionView } from './revisionVi
 
 import { FLOW_DISPLAY_MODES } from '../../../designer/common/flowDisplay.ts'
 import { variableInputCompatible } from '../../../flow/common/semantics.ts'
+import { providerIcon } from './providerIcon.ts'
 import { revisionView } from './revisionView.ts'
 
 export interface Point {
@@ -662,7 +663,11 @@ function triggerDesignerNode(triggerId: string, trigger: TriggerNode, position: 
   return {
     description: trigger.description,
     diagnostics: triggerDiagnosticCount(triggerId, diagnostics),
-    icon: trigger.icon ?? triggerIcon(trigger),
+    icon:
+      trigger.icon ??
+      (trigger.kind == 'integration' || trigger.kind == 'poll'
+        ? providerIcon({ serviceId: trigger.definition.provider, serviceName: trigger.definition.provider })
+        : triggerIcon(trigger)),
     id: triggerId,
     inputs: [],
     kind: 'trigger',
@@ -694,7 +699,7 @@ function semanticDesignerNode(nodeId: string, resolved: ResolvedNode, ports: Nod
     concurrency: node.concurrency,
     description: node.description,
     diagnostics: nodeDiagnosticCount(context.target, resolved, context.diagnostics),
-    icon: node.icon ?? connectorAction?.icon ?? nodeIcon(resolved),
+    icon: node.icon ?? (connectorAction == null ? nodeIcon(resolved) : providerIcon(connectorAction)),
     id: nodeId,
     inputs,
     outputs,

--- a/packages/open-flow/vitest.config.ts
+++ b/packages/open-flow/vitest.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from 'vitest/config'
+import { providerIconsPlugin } from './src/build/node/providerIcons.ts'
 import { twemojiCollectionPlugin } from './src/build/node/twemojiCollection.ts'
 
 export default defineConfig({
-  plugins: [twemojiCollectionPlugin()],
+  plugins: [providerIconsPlugin({ iconUrls: { github: 'https://static.oomol.com/logo/third-party/github.svg' } }), twemojiCollectionPlugin()],
   test: {
     coverage: {
       include: [


### PR DESCRIPTION
## Summary

- bundle the OOMOL provider icon catalog at build time
- resolve Connector icons through the OpenConnector fallback chain: provider icon, bundled catalog, homepage favicon, then initials
- use the same provider icon resolver for provider-backed Trigger options and existing Trigger nodes
- preserve provider homepage metadata through the Connector Control API for favicon fallback
- fall back to provider initials when a remote icon fails to load

## Testing

- bun run check
- bun run test
- bun run build
- bun run test:package