### PR TITLE
Align workflow catalog with Console

### DIFF
--- a/packages/open-flow/src/workbench/browser/runtime/openFlowWorkbench.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/openFlowWorkbench.tsx
@@ -108,6 +108,7 @@ function NotificationBridge({ host, store }: { readonly host: WorkbenchHost; rea
 }
 
 interface WorkbenchProps {
+  readonly catalogWidth?: 'default' | 'full' | undefined
   readonly createFlow?: ((name: string) => Promise<string>) | undefined
   readonly createFlowDisabled?: boolean | undefined
   readonly createFlowField?: OpenFlowWorkbenchProps['createFlowField']
@@ -125,6 +126,7 @@ interface WorkbenchProps {
 }
 
 function Workbench({
+  catalogWidth,
   createFlow,
   createFlowDisabled,
   createFlowField,
@@ -145,6 +147,7 @@ function Workbench({
     <div className="app-shell">
       {flowId == null ? (
         <FlowBrowser
+          catalogWidth={catalogWidth}
           createFlowDisabled={createFlowDisabled}
           createFlowField={createFlowField}
           flowBadges={flowBadges}
@@ -197,6 +200,7 @@ export {
 } from '../../../localization/common/languages.ts'
 
 export interface OpenFlowWorkbenchProps {
+  readonly catalogWidth?: 'default' | 'full' | undefined
   readonly createFlow?: ((name: string) => Promise<string>) | undefined
   readonly createFlowDisabled?: boolean | undefined
   readonly createFlowField?:
@@ -244,6 +248,7 @@ export interface OpenFlowWorkbenchProps {
 type SessionProps = Omit<OpenFlowWorkbenchProps, 'sessionKey'>
 
 function Session({
+  catalogWidth,
   createFlow,
   createFlowDisabled,
   createFlowField,
@@ -308,6 +313,7 @@ function Session({
       <div className="open-flow-theme open-flow-workbench" data-theme={theme}>
         <NotificationBridge host={host} store={store} />
         <Workbench
+          catalogWidth={catalogWidth}
           createFlow={createFlow}
           createFlowDisabled={createFlowDisabled}
           createFlowField={createFlowField}

--- a/packages/open-flow/src/workbench/browser/runtime/shell/resourceBrowser.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/shell/resourceBrowser.tsx
@@ -208,6 +208,7 @@ function FlowSkeleton(): ReactElement {
 }
 
 interface FlowBrowserProps extends LanguageSelectProps {
+  readonly catalogWidth?: 'default' | 'full' | undefined
   readonly createFlowDisabled?: boolean | undefined
   readonly createFlowField?: ComponentProps<typeof CreateResourceDialog>['field']
   readonly flowBadges?: Readonly<Record<string, string>> | undefined
@@ -221,6 +222,7 @@ interface FlowBrowserProps extends LanguageSelectProps {
 }
 
 export function FlowBrowser({
+  catalogWidth,
   createFlowDisabled,
   createFlowField,
   flowBadges,
@@ -259,20 +261,8 @@ export function FlowBrowser({
 
   return (
     <main className="resource-browser">
-      <div className="resource-page">
-        <header className="resource-page-header">
-          <div className="resource-heading">
-            <h1>{t('resource.flows')}</h1>
-          </div>
-          <div className="resource-page-actions">
-            <LanguageSelect language={language} onLanguageChange={onLanguageChange} />
-            <Button disabled={busy != null} onClick={() => setCreating(true)}>
-              <Icon data-icon="inline-start" name="plus" />
-              {t('resource.newFlow')}
-            </Button>
-            {hostAction != null && hostTitle != null && onHostAction != null && <HostMenu action={hostAction} onAction={onHostAction} title={hostTitle} />}
-          </div>
-        </header>
+      <div className={cn('resource-page', catalogWidth != 'default' && 'resource-page-full')}>
+        <h1 className="sr-only">{t('resource.flows')}</h1>
         <section aria-labelledby="flow-list-title" className="resource-list-section">
           <div className="resource-list-title">
             <div className="resource-list-heading">
@@ -280,6 +270,7 @@ export function FlowBrowser({
               {!loading && <span>{t('resource.flowCount', { count: total ?? flows.length })}</span>}
             </div>
             <div className="resource-list-actions">
+              <LanguageSelect language={language} onLanguageChange={onLanguageChange} />
               <InputGroup className="w-full sm:w-56">
                 <InputGroupAddon>
                   <Icon name="search" size={17} />
@@ -303,6 +294,11 @@ export function FlowBrowser({
               >
                 <Icon name="refresh" />
               </Button>
+              <Button className="resource-page-primary-action" disabled={busy != null} onClick={() => setCreating(true)}>
+                <Icon data-icon="inline-start" name="plus" />
+                {t('resource.newFlow')}
+              </Button>
+              {hostAction != null && hostTitle != null && onHostAction != null && <HostMenu action={hostAction} onAction={onHostAction} title={hostTitle} />}
             </div>
           </div>
           <div aria-hidden="true" className="resource-list-columns flow-columns">

--- a/packages/open-flow/src/workbench/browser/runtime/styles/resource-browser.css
+++ b/packages/open-flow/src/workbench/browser/runtime/styles/resource-browser.css
@@ -12,24 +12,15 @@
     padding: 32px 0 64px;
   }
 
-  .resource-page-header {
-    display: flex;
-    min-width: 0;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 24px;
+  .resource-page-full {
+    width: min(1216px, calc(100% - 64px));
+    padding: 24px 0 48px;
   }
 
-  .resource-heading {
-    min-width: 0;
-  }
-
-  .resource-page-actions {
-    display: flex;
-    min-width: 0;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 8px;
+  .resource-page-primary-action {
+    height: 36px;
+    padding: 0 12px;
+    border-radius: var(--ui-radius);
   }
 
   .resource-eyebrow,
@@ -52,15 +43,6 @@
     white-space: nowrap;
   }
 
-  .resource-heading h1 {
-    margin: 0;
-    color: var(--ui-foreground);
-    font-size: 24px;
-    font-weight: 650;
-    letter-spacing: -0.025em;
-    line-height: 32px;
-  }
-
   .resource-language {
     display: flex;
     flex: none;
@@ -77,7 +59,6 @@
 
   .resource-list-section {
     min-width: 0;
-    margin-top: 20px;
     border: 1px solid var(--ui-border);
     border-radius: var(--ui-radius);
     background: var(--ui-background);

--- a/packages/open-flow/src/workbench/browser/runtime/styles/responsive.css
+++ b/packages/open-flow/src/workbench/browser/runtime/styles/responsive.css
@@ -106,22 +106,6 @@
       padding: 24px 0 40px;
     }
 
-    .resource-page-header {
-      align-items: flex-start;
-      flex-direction: column;
-      gap: 16px;
-    }
-
-    .resource-page-actions {
-      width: 100%;
-      justify-content: flex-end;
-    }
-
-    .resource-heading h1 {
-      font-size: 22px;
-      line-height: 28px;
-    }
-
     .resource-list-title {
       align-items: stretch;
       flex-direction: column;

--- a/packages/open-flow/src/workbench/browser/runtime/styles/tokens.css
+++ b/packages/open-flow/src/workbench/browser/runtime/styles/tokens.css
@@ -7,12 +7,7 @@
   color: var(--ui-foreground);
   background: var(--ui-background);
   font-size: 14px;
-  font-family:
-    ui-sans-serif,
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    sans-serif;
+  font-family: inherit;
   font-synthesis: none;
   font-kerning: normal;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
## Summary

The workflow catalog looked like an independently mounted application inside Console: it used a narrower page frame, repeated the page title, and placed its primary action outside the resource panel. This made the page visibly misalign with Console pages such as team management.

This change keeps the Workbench as the owner of its UI while making the catalog host-aware. The catalog defaults to a Console-aligned content frame, inherits the host typography, preserves an accessible but visually hidden page heading, and places New workflow with the catalog search and refresh controls. A consumer can still opt into the compact catalog width with `catalogWidth="default"`.

## User impact

Workflow lists now begin on the same card baseline and share the same 1216px content width as Console team-management panels at desktop widths. The duplicate visual title is removed, and the primary creation action is easier to find alongside the other list controls.

## Validation

- `bun run lint`
- `bun run check`
- `bun run test`
- `bun run test:package`
- `bun run --filter @oomol-lab/open-flow build`
- `npm run build` in `console.oomol.com`
- Browser comparison against the local workflow page and the Console team-management page