### PR TITLE
feat: support additional task inputs

### DIFF
--- a/apps/server/node/isolated-vm.ts
+++ b/apps/server/node/isolated-vm.ts
@@ -727,7 +727,15 @@ export async function invoke(source) {
     const wrapped = value != null && typeof value == 'object' && Object.hasOwn(value, 'additionalInputs') && Object.hasOwn(value, 'input')
     const inputs = wrapped ? value.input : value
     const additionalInputs = wrapped ? value.additionalInputs : {}
-    const context = Object.freeze({ ...capability, additionalInputs, inputs })
+    const context = Object.freeze({
+      ...capability,
+      additionalInputs,
+      blockId: wrapped ? value.blockId : undefined,
+      flowId: wrapped ? value.flowId : undefined,
+      inputs,
+      runId: wrapped ? value.runId : undefined,
+      signal: new AbortController().signal,
+    })
     const result = await task(inputs, context)
     return JSON.stringify({ engineDigest: ${JSON.stringify(program.engineDigest)}, ok: true, value: result })
   } catch (error) {
@@ -895,7 +903,13 @@ function executeFlow(
             executeEffect(
               {
                 executionId: request.executionId,
-                input: { additionalInputs: invocation.additionalInputs ?? {}, input: invocation.input },
+                input: {
+                  additionalInputs: invocation.additionalInputs ?? {},
+                  blockId: invocation.blockId,
+                  flowId: invocation.flowId,
+                  input: invocation.input,
+                  runId: invocation.runId,
+                },
                 invocationId: invocation.invocationId,
                 limits: request.limits,
                 program,

--- a/apps/server/node/isolated-vm.ts
+++ b/apps/server/node/isolated-vm.ts
@@ -723,7 +723,9 @@ async function compileProgram(
 import { capability } from './capability.mjs'
 export async function invoke(source) {
   try {
-    const value = await task(JSON.parse(source), capability)
+    const { additionalInputs = {}, input } = JSON.parse(source)
+    const context = Object.freeze({ ...capability, additionalInputs, inputs: input })
+    const value = await task(input, context)
     return JSON.stringify({ engineDigest: ${JSON.stringify(program.engineDigest)}, ok: true, value })
   } catch (error) {
     return JSON.stringify({ error: error instanceof Error ? error.message : String(error), ok: false })
@@ -890,7 +892,7 @@ function executeFlow(
             executeEffect(
               {
                 executionId: request.executionId,
-                input: invocation.input,
+                input: { additionalInputs: invocation.additionalInputs ?? {}, input: invocation.input },
                 invocationId: invocation.invocationId,
                 limits: request.limits,
                 program,

--- a/apps/server/node/isolated-vm.ts
+++ b/apps/server/node/isolated-vm.ts
@@ -734,7 +734,14 @@ export async function invoke(source) {
       flowId: wrapped ? value.flowId : undefined,
       inputs,
       runId: wrapped ? value.runId : undefined,
-      signal: new AbortController().signal,
+      signal: Object.freeze({
+        aborted: false,
+        addEventListener() {},
+        onabort: null,
+        reason: undefined,
+        removeEventListener() {},
+        throwIfAborted() {},
+      }),
     })
     const result = await task(inputs, context)
     return JSON.stringify({ engineDigest: ${JSON.stringify(program.engineDigest)}, ok: true, value: result })

--- a/apps/server/node/isolated-vm.ts
+++ b/apps/server/node/isolated-vm.ts
@@ -723,10 +723,13 @@ async function compileProgram(
 import { capability } from './capability.mjs'
 export async function invoke(source) {
   try {
-    const { additionalInputs = {}, input } = JSON.parse(source)
-    const context = Object.freeze({ ...capability, additionalInputs, inputs: input })
-    const value = await task(input, context)
-    return JSON.stringify({ engineDigest: ${JSON.stringify(program.engineDigest)}, ok: true, value })
+    const value = JSON.parse(source)
+    const wrapped = value != null && typeof value == 'object' && Object.hasOwn(value, 'additionalInputs') && Object.hasOwn(value, 'input')
+    const inputs = wrapped ? value.input : value
+    const additionalInputs = wrapped ? value.additionalInputs : {}
+    const context = Object.freeze({ ...capability, additionalInputs, inputs })
+    const result = await task(inputs, context)
+    return JSON.stringify({ engineDigest: ${JSON.stringify(program.engineDigest)}, ok: true, value: result })
   } catch (error) {
     return JSON.stringify({ error: error instanceof Error ? error.message : String(error), ok: false })
   }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,8 +107,7 @@ Engine Contract、部署中立 Runtime invocation、Scheduler 图执行语义、
 Engine digest、资源限制和恢复属于部署实现；`isolated-vm` RuntimeHost 只属于 Server。
 
 普通 Flow 数据通过声明的 input、output、edge 和 binding 传播，并在 Runtime invocation、Scheduler、Subflow、RunEvent 和 terminal result
-边界保持可序列化。脚本 `context` 只提供取消、日志、进度、Artifact、网络、Connector 等宿主能力和只读运行身份，不提供跨节点的动态
-Run store、Variable 查询或任意节点输出查询。部署可以为调度、调试和恢复私有保存 Run value，但不能把内部存储变成第二条用户数据通道。
+边界保持可序列化。脚本 `context` 提供取消、日志、进度、Artifact、网络、Connector 等宿主能力、只读运行身份，以及与第一个参数相同的 `inputs` 和始终为对象的 `additionalInputs`；不提供跨节点的动态 Run store、Variable 查询或任意节点输出查询。部署可以为调度、调试和恢复私有保存 Run value，但不能把内部存储变成第二条用户数据通道。
 
 Server 将一次 Flow Run 作为一个逻辑 Runtime session 交给 Executor，Scheduler 和内联 Code Task 执行都在该 session 内；SQLite、RunEvent 投影、
 外部 Task 和 Capability mediation 仍由 Host 持有。Executor process 可以承载多个并发 session，但每次 Code Task invocation 使用新的 isolate；process

--- a/packages/open-flow/dev/designer/lab.tsx
+++ b/packages/open-flow/dev/designer/lab.tsx
@@ -40,11 +40,11 @@ const codeEditorTyping = `/**
  */
 `
 
-const codeEditorSource = `export default async function (input, context) {
+const codeEditorSource = `export default async function (inputs, context) {
   await context.reportProgress(20)
   const response = await context.fetch("https://example.com")
   const text = await response.text()
-  return { result: input.value + text }
+  return { result: inputs.value + text }
 }
 `
 

--- a/packages/open-flow/src/execution/common/scheduler.ts
+++ b/packages/open-flow/src/execution/common/scheduler.ts
@@ -88,6 +88,7 @@ export interface SubflowRunResult {
 }
 
 interface TaskInvocationBase {
+  readonly additionalInputs?: Readonly<Record<string, JsonValue>>
   readonly input: Readonly<Record<string, JsonValue>>
   readonly invocationId: string
   readonly jobId: string
@@ -260,7 +261,7 @@ function nodePorts(prepared: PreparedFlow, node: ExecutableNode): Readonly<Recor
     case 'subflow':
       return portsByHandle(prepared.subflows[node.subflowId]!.inputs)
     case 'task':
-      return portsByHandle(node.task != null ? node.task.inputs : prepared.tasks[node.taskId]!.inputs)
+      return portsByHandle([...(node.task != null ? node.task.inputs : prepared.tasks[node.taskId]!.inputs), ...(node.additionalInputs ?? [])])
   }
 }
 
@@ -546,8 +547,10 @@ function runGraph(
               break
             }
             case 'task': {
+              const additional = new Set((node.additionalInputs ?? []).map((port) => port.handle))
               const result = yield* context.invokeTask({
-                input: nodeInputs,
+                additionalInputs: Object.fromEntries(Object.entries(nodeInputs).filter(([handle]) => additional.has(handle))),
+                input: Object.fromEntries(Object.entries(nodeInputs).filter(([handle]) => !additional.has(handle))),
                 invocationId: context.createId(),
                 jobId,
                 nodeId,

--- a/packages/open-flow/src/execution/common/scheduler.ts
+++ b/packages/open-flow/src/execution/common/scheduler.ts
@@ -89,6 +89,8 @@ export interface SubflowRunResult {
 
 interface TaskInvocationBase {
   readonly additionalInputs?: Readonly<Record<string, JsonValue>>
+  readonly blockId: string
+  readonly flowId: string
   readonly input: Readonly<Record<string, JsonValue>>
   readonly invocationId: string
   readonly jobId: string
@@ -550,6 +552,8 @@ function runGraph(
               const additional = new Set((node.additionalInputs ?? []).map((port) => port.handle))
               const result = yield* context.invokeTask({
                 additionalInputs: Object.fromEntries(Object.entries(nodeInputs).filter(([handle]) => additional.has(handle))),
+                blockId: node.task != null ? node.task.moduleId : node.taskId,
+                flowId: target.flowId,
                 input: Object.fromEntries(Object.entries(nodeInputs).filter(([handle]) => !additional.has(handle))),
                 invocationId: context.createId(),
                 jobId,

--- a/packages/open-flow/src/flow/common/change.test.ts
+++ b/packages/open-flow/src/flow/common/change.test.ts
@@ -44,7 +44,7 @@ describe('Flow changes', () => {
     const changed = applyFlowChanges(revision(), createCodeTask(target, { moduleId: 'module', nodeId: 'task' }, 'Code'))
     const source = changed.modules.module?.source
 
-    expect(source).toBe('export default async function (input, context) {\n  return { result: input.value }\n}\n')
+    expect(source).toBe('export default async function (inputs, context) {\n  return { result: inputs.value }\n}\n')
   })
 
   it('applies every resource lifecycle operation in order', () => {

--- a/packages/open-flow/src/flow/common/change.ts
+++ b/packages/open-flow/src/flow/common/change.ts
@@ -158,8 +158,8 @@ export interface ManagedTaskDefinition extends TaskDefinitionBase {
 export type TaskDefinition = InlineTaskDefinition | ManagedTaskDefinition
 
 export type TaskNode = GraphNodeBase & { readonly kind: 'task' } & (
-    | { readonly task: InlineTaskDefinition; readonly taskId?: never }
-    | { readonly task?: never; readonly taskId: string }
+    | { readonly additionalInputs?: readonly InputPort[]; readonly task: InlineTaskDefinition; readonly taskId?: never }
+    | { readonly additionalInputs?: readonly InputPort[]; readonly task?: never; readonly taskId: string }
   )
 
 export interface Graph {

--- a/packages/open-flow/src/flow/common/encoding.ts
+++ b/packages/open-flow/src/flow/common/encoding.ts
@@ -118,7 +118,19 @@ function canonicalNode(value: GraphNode): JsonValue {
     case 'subflow':
       return { ...common, kind: value.kind, subflowId: value.subflowId }
     case 'task':
-      return value.task != null ? { ...common, kind: value.kind, task: canonicalInlineTask(value.task) } : { ...common, kind: value.kind, taskId: value.taskId }
+      return value.task != null
+        ? {
+            ...common,
+            ...(value.additionalInputs == null ? {} : { additionalInputs: canonicalPorts(value.additionalInputs) }),
+            kind: value.kind,
+            task: canonicalInlineTask(value.task),
+          }
+        : {
+            ...common,
+            ...(value.additionalInputs == null ? {} : { additionalInputs: canonicalPorts(value.additionalInputs) }),
+            kind: value.kind,
+            taskId: value.taskId,
+          }
     case 'value':
       return { ...common, kind: value.kind, values: canonicalPorts(value.values) }
   }

--- a/packages/open-flow/src/flow/common/nodeChanges.ts
+++ b/packages/open-flow/src/flow/common/nodeChanges.ts
@@ -16,8 +16,8 @@ import type {
 
 import { applyFlowChanges } from './change.ts'
 
-const codeTaskTemplate = `export default async function (input, context) {
-  return { result: input.value }
+const codeTaskTemplate = `export default async function (inputs, context) {
+  return { result: inputs.value }
 }
 `
 

--- a/packages/open-flow/src/flow/common/semantics.ts
+++ b/packages/open-flow/src/flow/common/semantics.ts
@@ -709,6 +709,17 @@ function validateGraph(
       )
     }
     const inputPorts = nodeInputPorts(document, node)
+    if (node.kind == 'task') {
+      const ports = [...(node.task != null ? node.task.inputs : (document.tasks[node.taskId]?.inputs ?? [])), ...(node.additionalInputs ?? [])]
+      const handles = new Set<string>()
+      for (const port of ports) {
+        if (!('handle' in port)) continue
+        if (handles.has(port.handle)) {
+          diagnostics.push(graphDiagnostic('graph.input-duplicate', `Node "${nodeId}" declares input "${port.handle}" more than once.`, nodePath, { handle: port.handle, nodeId }))
+        }
+        handles.add(port.handle)
+      }
+    }
     const ports = [...Object.values(inputPorts), ...Object.values(nodeOutputPorts(document, node))]
     if (ports.some((port) => hasRetiredRef(port.jsonSchema))) {
       diagnostics.push(graphDiagnostic('graph.schema-unsupported', 'Runtime Ref schemas are not supported.', nodePath))

--- a/packages/open-flow/src/flow/common/semantics.ts
+++ b/packages/open-flow/src/flow/common/semantics.ts
@@ -715,7 +715,12 @@ function validateGraph(
       for (const port of ports) {
         if (!('handle' in port)) continue
         if (handles.has(port.handle)) {
-          diagnostics.push(graphDiagnostic('graph.input-duplicate', `Node "${nodeId}" declares input "${port.handle}" more than once.`, nodePath, { handle: port.handle, nodeId }))
+          diagnostics.push(
+            graphDiagnostic('graph.input-duplicate', `Node "${nodeId}" declares input "${port.handle}" more than once.`, nodePath, {
+              handle: port.handle,
+              nodeId,
+            }),
+          )
         }
         handles.add(port.handle)
       }

--- a/packages/open-flow/src/flow/common/semantics.ts
+++ b/packages/open-flow/src/flow/common/semantics.ts
@@ -541,7 +541,7 @@ function nodeInputPorts(document: FlowDocument, node: GraphNode): Readonly<Recor
     case 'subflow':
       return portsByHandle(document.subflows[node.subflowId]?.inputs ?? [])
     case 'task':
-      return portsByHandle(node.task != null ? node.task.inputs : (document.tasks[node.taskId]?.inputs ?? []))
+      return portsByHandle([...(node.task != null ? node.task.inputs : (document.tasks[node.taskId]?.inputs ?? [])), ...(node.additionalInputs ?? [])])
     case 'cron':
     case 'integration':
     case 'poll':

--- a/packages/open-flow/src/types/index.ts
+++ b/packages/open-flow/src/types/index.ts
@@ -61,8 +61,10 @@ export interface TaskLogger {
 }
 
 export interface TaskContext<Outputs extends object = Record<string, unknown>> {
+  readonly additionalInputs: Readonly<Record<string, unknown>>
   readonly signal: AbortSignal
   readonly flowId: string
+  readonly inputs: Readonly<Record<string, unknown>>
   readonly runId: string
   readonly blockId: string
   readonly artifact: ArtifactCapability


### PR DESCRIPTION
## Summary

- Add optional `additionalInputs` ports to task nodes and preserve them in flow encoding.
- Split task invocation data into regular inputs and additional inputs.
- Expose both `inputs` and `additionalInputs` through task context.
- Update code task templates and architecture documentation.

## Testing

- Updated the affected unit test for the renamed code task parameter.
- Not run (not requested)