### PR TITLE
feat: support streaming task outputs

### DIFF
--- a/apps/server/node/isolated-vm.ts
+++ b/apps/server/node/isolated-vm.ts
@@ -40,7 +40,7 @@ export const isolatedVmLimits: IsolatedVmLimits = {
   wallMs: 30_000,
 }
 
-export const isolatedVmEngineDigest = `sha256:${createHash('sha256').update('open-flow-isolated-vm/3 isolated-vm/7.0.1 node/26 web-globals/1').digest('hex')}`
+export const isolatedVmEngineDigest = `sha256:${createHash('sha256').update('open-flow-isolated-vm/4 isolated-vm/7.0.1 node/26 web-globals/1').digest('hex')}`
 
 export class IsolatedVmError extends Error {
   readonly code: 'canceled' | 'executor-crashed' | 'invalid-program' | 'limit-exceeded' | 'task-failed'
@@ -1000,7 +1000,12 @@ function executeFlow(
                 type: 'invoke',
               },
               (invocationId, capabilities, kind, payload) => {
-                if (kind == 'outputs') return outputs(payload).pipe(Effect.as({ body: null, status: 200 }))
+                if (kind == 'outputs') {
+                  if (serializedBytes(payload) > request.limits.maxResultBytes) {
+                    return Effect.fail(new IsolatedVmError('limit-exceeded', 'Runtime result exceeds the configured byte limit.'))
+                  }
+                  return outputs(payload).pipe(Effect.as({ body: null, status: 200 }))
+                }
                 return remote(call({ capabilities, invocationId, kind, payload, type: 'capability' })).pipe(
                   Effect.map((response) => response as RuntimeCapabilityResponse),
                 )

--- a/apps/server/node/isolated-vm.ts
+++ b/apps/server/node/isolated-vm.ts
@@ -40,7 +40,7 @@ export const isolatedVmLimits: IsolatedVmLimits = {
   wallMs: 30_000,
 }
 
-export const isolatedVmEngineDigest = `sha256:${createHash('sha256').update('open-flow-isolated-vm/2 isolated-vm/7.0.1 node/26 web-globals/1').digest('hex')}`
+export const isolatedVmEngineDigest = `sha256:${createHash('sha256').update('open-flow-isolated-vm/3 isolated-vm/7.0.1 node/26 web-globals/1').digest('hex')}`
 
 export class IsolatedVmError extends Error {
   readonly code: 'canceled' | 'executor-crashed' | 'invalid-program' | 'limit-exceeded' | 'task-failed'
@@ -117,7 +117,13 @@ type ExecutorMessage =
       readonly retire?: true
       readonly type: 'result'
     }
-  | { readonly executionId: number; readonly ok: true; readonly retire?: true; readonly type: 'result'; readonly value: FlowRunResult | JsonValue }
+  | {
+      readonly executionId: number
+      readonly ok: true
+      readonly retire?: true
+      readonly type: 'result'
+      readonly value: FlowRunResult | JsonValue | undefined
+    }
 
 interface PendingCapability {
   readonly deferred: Deferred.Deferred<CapabilityResult, Error>
@@ -136,7 +142,7 @@ interface PendingInvocation {
   readonly limits: IsolatedVmLimits
   readonly projectFailure: (error: unknown) => SchedulerFailure
   readonly reject: (error: unknown) => void
-  readonly resolve: (value: FlowRunResult | JsonValue) => void
+  readonly resolve: (value: FlowRunResult | JsonValue | undefined) => void
   readonly signal?: AbortSignal
 }
 
@@ -182,7 +188,7 @@ export class IsolatedVmHost {
   readonly #pending = new Map<number, PendingInvocation>()
   #stderr = ''
 
-  async invoke(invocation: RuntimeInvocation, limits: IsolatedVmLimits = isolatedVmLimits): Promise<JsonValue> {
+  async invoke(invocation: RuntimeInvocation, limits: IsolatedVmLimits = isolatedVmLimits): Promise<JsonValue | undefined> {
     return await Effect.runPromise(
       Effect.suspend(() => {
         if (this.#closed) return Effect.fail(new IsolatedVmError('executor-crashed', 'Runtime Host is closed.'))
@@ -196,7 +202,7 @@ export class IsolatedVmHost {
         }
         if (invocation.signal?.aborted) return Effect.fail(normalizedError(invocation.signal.reason))
 
-        return Effect.callback<JsonValue, Error>((resume, signal) => {
+        return Effect.callback<JsonValue | undefined, Error>((resume, signal) => {
           const child = this.#child ?? this.#start()
           const executionId = ++this.#executionId
           const cancel = (): void => {
@@ -217,7 +223,7 @@ export class IsolatedVmHost {
             limits,
             projectFailure: (error) => ({ code: 'node.failed', message: normalizedError(error).message }),
             reject: (error) => resume(Effect.fail(normalizedError(error))),
-            resolve: (value) => resume(Effect.succeed(value as JsonValue)),
+            resolve: (value) => resume(Effect.succeed(value as JsonValue | undefined)),
             signal: invocation.signal,
           })
           invocation.signal?.addEventListener('abort', cancel, { once: true })
@@ -631,6 +637,7 @@ export const capability = Object.freeze({
   }),
   connector: (input) => invoke('connector', input),
   egress: (url) => invoke('egress', { url }),
+  outputs: (value) => invoke('outputs', value),
 })`
 
 function installGlobals(
@@ -789,7 +796,9 @@ export async function invoke(source) {
       signal: cancellation.signal,
     }))
     const result = await task(inputs, context)
-    return JSON.stringify({ engineDigest: ${JSON.stringify(program.engineDigest)}, ok: true, value: result })
+    return result === undefined
+      ? JSON.stringify({ engineDigest: ${JSON.stringify(program.engineDigest)}, ok: true, void: true })
+      : JSON.stringify({ engineDigest: ${JSON.stringify(program.engineDigest)}, ok: true, value: result })
   } catch (error) {
     return JSON.stringify({ error: error instanceof Error ? error.message : String(error), ok: false })
   }
@@ -829,16 +838,30 @@ async function invokeProgram(mainModule: IsolatedVM.Module, input: JsonValue, cp
   })
 }
 
-function readResult(source: unknown, program: RuntimeProgram, maxBytes: number, preserveCapabilityFailure: boolean, capabilityFailure: unknown): JsonValue {
+function readResult(
+  source: unknown,
+  program: RuntimeProgram,
+  maxBytes: number,
+  preserveCapabilityFailure: boolean,
+  capabilityFailure: unknown,
+): JsonValue | undefined {
   if (typeof source != 'string' || encoder.encode(source).byteLength > maxBytes) {
     throw new IsolatedVmError('limit-exceeded', 'Runtime result exceeds the configured byte limit.')
   }
-  const result = JSON.parse(source) as { readonly engineDigest?: string; readonly error?: string; readonly ok?: boolean; readonly value?: JsonValue }
-  if (!result.ok || result.engineDigest != program.engineDigest || !Object.hasOwn(result, 'value')) {
+  const result = JSON.parse(source) as {
+    readonly engineDigest?: string
+    readonly error?: string
+    readonly ok?: boolean
+    readonly value?: JsonValue
+    readonly void?: boolean
+  }
+  const returnedValue = Object.hasOwn(result, 'value') && result.void === undefined
+  const returnedVoid = !Object.hasOwn(result, 'value') && result.void === true
+  if (!result.ok || result.engineDigest != program.engineDigest || (!returnedValue && !returnedVoid)) {
     if (preserveCapabilityFailure && capabilityFailure != null) throw capabilityFailure
     throw new IsolatedVmError('task-failed', result.error ?? 'User Task failed.')
   }
-  return result.value as JsonValue
+  return returnedVoid ? undefined : (result.value as JsonValue)
 }
 
 async function execute(
@@ -847,7 +870,7 @@ async function execute(
   call: (invocationId: string, capabilities: readonly ConnectorCapability[], kind: string, payload: JsonValue) => Promise<RuntimeCapabilityResponse>,
   capabilities: readonly ConnectorCapability[] = [],
   preserveCapabilityFailure = false,
-): Promise<JsonValue> {
+): Promise<JsonValue | undefined> {
   if (!('program' in request)) throw new IsolatedVmError('invalid-program', 'Runtime module invocation is incomplete.')
   const { program } = request
   const invalid = programError(program)
@@ -919,7 +942,7 @@ function executeEffect(
   ) => Effect.Effect<RuntimeCapabilityResponse, Error>,
   capabilities: readonly ConnectorCapability[] = [],
   preserveCapabilityFailure = false,
-): Effect.Effect<JsonValue, Error, Scope.Scope> {
+): Effect.Effect<JsonValue | undefined, Error, Scope.Scope> {
   return Effect.gen(function* () {
     const run = yield* FiberSet.makeRuntimePromise<never, RuntimeCapabilityResponse, Error>()
     return yield* Effect.tryPromise({
@@ -959,7 +982,7 @@ function executeFlow(
     emit: (event) => remote(call({ event, type: 'event' })).pipe(Effect.asVoid),
     flowId: flow.flowId,
     ...(flow.inputs == null ? {} : { inputs: flow.inputs }),
-    invokeTask: (invocation) =>
+    invokeTask: (invocation, outputs) =>
       Effect.gen(function* () {
         if ('moduleId' in invocation) {
           const program = createRuntimeProgram(flow.prepared, invocation.moduleId, isolatedVmEngineDigest)
@@ -976,10 +999,12 @@ function executeFlow(
                 program,
                 type: 'invoke',
               },
-              (invocationId, capabilities, kind, payload) =>
-                remote(call({ capabilities, invocationId, kind, payload, type: 'capability' })).pipe(
+              (invocationId, capabilities, kind, payload) => {
+                if (kind == 'outputs') return outputs(payload).pipe(Effect.as({ body: null, status: 200 }))
+                return remote(call({ capabilities, invocationId, kind, payload, type: 'capability' })).pipe(
                   Effect.map((response) => response as RuntimeCapabilityResponse),
-                ),
+                )
+              },
               invocation.capabilities,
               true,
             ).pipe(
@@ -1034,7 +1059,7 @@ function executeWithCapabilities(request: InvokeRequest, pending: Map<number, Pe
 
   return Effect.scoped(
     Effect.gen(function* () {
-      let value: FlowRunResult | JsonValue
+      let value: FlowRunResult | JsonValue | undefined
       if ('flow' in request) value = yield* executeFlow(request, call)
       else {
         value = yield* executeEffect(request, (invocationId, capabilities, kind, payload) =>

--- a/apps/server/node/isolated-vm.ts
+++ b/apps/server/node/isolated-vm.ts
@@ -40,7 +40,7 @@ export const isolatedVmLimits: IsolatedVmLimits = {
   wallMs: 30_000,
 }
 
-export const isolatedVmEngineDigest = `sha256:${createHash('sha256').update('open-flow-isolated-vm/4 isolated-vm/7.0.1 node/26 web-globals/1').digest('hex')}`
+export const isolatedVmEngineDigest = `sha256:${createHash('sha256').update('open-flow-isolated-vm/2 isolated-vm/7.0.1 node/26 web-globals/1').digest('hex')}`
 
 export class IsolatedVmError extends Error {
   readonly code: 'canceled' | 'executor-crashed' | 'invalid-program' | 'limit-exceeded' | 'task-failed'

--- a/apps/server/test/service.test.ts
+++ b/apps/server/test/service.test.ts
@@ -126,6 +126,30 @@ function hangingFlow(): RevisionContent {
   }
 }
 
+function oversizedOutputsFlow(): RevisionContent {
+  return {
+    document: {
+      bindings: {},
+      graph: {
+        nodes: {
+          task: {
+            concurrency: 1,
+            inputs: {},
+            kind: 'task',
+            task: { inputs: [], moduleId: 'main', name: 'Main', outputs: [{ ...port, handle: 'value' }] },
+          },
+        },
+      },
+      subflows: {},
+      tasks: {},
+    },
+    modelVersion: 1,
+    modules: {
+      main: { imports: [], name: 'Main', source: "export default async (_inputs, context) => context.outputs({ value: 'x'.repeat(2_000_000) })" },
+    },
+  }
+}
+
 function variableFlow(): RevisionContent {
   return {
     document: {
@@ -336,6 +360,26 @@ describe('Server application service', () => {
     })
     await expect(acceptRun(service, { flowId: 'main', idempotencyKey: 'full-flow', revision: fullFlow(4), revisionId: 'revision-b' })).resolves.toEqual({
       kind: 'conflict',
+    })
+    await closeService(service)
+  })
+
+  it('rejects context outputs larger than the Runtime result limit before delivery', async () => {
+    const service = await openService(await databaseFile())
+    await startService(service)
+    const accepted = await acceptRun(service, {
+      flowId: 'main',
+      idempotencyKey: 'oversized-outputs',
+      revision: oversizedOutputsFlow(),
+      revisionId: 'revision-oversized-outputs',
+    })
+    if (accepted.kind != 'accepted') throw new Error('Oversized outputs Run acceptance conflicted.')
+    await service.waitForIdle()
+
+    expect(service.run(accepted.runId)?.status).toBe('failed')
+    expect(service.events(accepted.runId).filter((event) => event.kind == 'node.output')).toHaveLength(0)
+    expect(service.events(accepted.runId).find((event) => event.kind == 'node.failed')).toMatchObject({
+      payload: { error: { code: 'node.failed', message: 'Runtime result exceeds the configured byte limit.' } },
     })
     await closeService(service)
   })

--- a/apps/server/test/service.test.ts
+++ b/apps/server/test/service.test.ts
@@ -85,12 +85,12 @@ function fullFlow(value = 2): RevisionContent {
       increment: {
         imports: [],
         name: 'Increment',
-        source: `export default (inputs, context) => {
+        source: `export default async (inputs, context) => {
   if (context.inputs !== inputs) throw new Error('Task context inputs must be the first argument.')
   if (context.blockId != 'increment' || typeof context.flowId != 'string' || typeof context.runId != 'string') throw new Error('Task identity is incomplete.')
   if (inputs.start != 'manual') throw new Error('Additional input was not passed to the Task.')
   context.signal.throwIfAborted()
-  return { value: inputs.value + 1 }
+  await context.outputs({ value: inputs.value + 1 })
 }`,
       },
     },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,7 +107,7 @@ Engine Contract、部署中立 Runtime invocation、Scheduler 图执行语义、
 Engine digest、资源限制和恢复属于部署实现；`isolated-vm` RuntimeHost 只属于 Server。
 
 普通 Flow 数据通过声明的 input、output、edge 和 binding 传播，并在 Runtime invocation、Scheduler、Subflow、RunEvent 和 terminal result
-边界保持可序列化。脚本 `context` 提供取消、日志、进度、Artifact、网络、Connector 等宿主能力、只读运行身份，以及与第一个参数相同的 `inputs`。脚本可以通过返回对象或 `context.outputs` 沿声明的 output 提交值；`context.outputs` 的每个字段复用普通 output 的事件和下游投递语义。`context` 不提供跨节点的动态 Run store、Variable 查询或任意节点输出查询。部署可以为调度、调试和恢复私有保存 Run value，但不能把内部存储变成第二条用户数据通道。
+边界保持可序列化。脚本 `context` 提供取消、日志、进度、Artifact、网络、Connector 等宿主能力、只读运行身份，以及与第一个参数相同的 `inputs`。Task 可以通过返回对象或 `context.outputs` 沿声明的 output 提交值；调用 `context.outputs` 后可以返回 `undefined` 完成，等同于返回空对象。`context.outputs` 的每个字段复用普通 output 的事件和下游投递语义。`context` 不提供跨节点的动态 Run store、Variable 查询或任意节点输出查询。部署可以为调度、调试和恢复私有保存 Run value，但不能把内部存储变成第二条用户数据通道。
 
 Server 将一次 Flow Run 作为一个逻辑 Runtime session 交给 Executor，Scheduler 和内联 Code Task 执行都在该 session 内；SQLite、RunEvent 投影、
 外部 Task 和 Capability mediation 仍由 Host 持有。Executor process 可以承载多个并发 session，但每次 Code Task invocation 使用新的 isolate；process

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,7 +107,7 @@ Engine Contract、部署中立 Runtime invocation、Scheduler 图执行语义、
 Engine digest、资源限制和恢复属于部署实现；`isolated-vm` RuntimeHost 只属于 Server。
 
 普通 Flow 数据通过声明的 input、output、edge 和 binding 传播，并在 Runtime invocation、Scheduler、Subflow、RunEvent 和 terminal result
-边界保持可序列化。脚本 `context` 提供取消、日志、进度、Artifact、网络、Connector 等宿主能力、只读运行身份，以及与第一个参数相同的 `inputs`；不提供跨节点的动态 Run store、Variable 查询或任意节点输出查询。部署可以为调度、调试和恢复私有保存 Run value，但不能把内部存储变成第二条用户数据通道。
+边界保持可序列化。脚本 `context` 提供取消、日志、进度、Artifact、网络、Connector 等宿主能力、只读运行身份，以及与第一个参数相同的 `inputs`。脚本可以通过返回对象或 `context.outputs` 沿声明的 output 提交值；`context.outputs` 的每个字段复用普通 output 的事件和下游投递语义。`context` 不提供跨节点的动态 Run store、Variable 查询或任意节点输出查询。部署可以为调度、调试和恢复私有保存 Run value，但不能把内部存储变成第二条用户数据通道。
 
 Server 将一次 Flow Run 作为一个逻辑 Runtime session 交给 Executor，Scheduler 和内联 Code Task 执行都在该 session 内；SQLite、RunEvent 投影、
 外部 Task 和 Capability mediation 仍由 Host 持有。Executor process 可以承载多个并发 session，但每次 Code Task invocation 使用新的 isolate；process

--- a/packages/open-flow/src/execution/common/runtime.ts
+++ b/packages/open-flow/src/execution/common/runtime.ts
@@ -161,14 +161,18 @@ export default () => fs.readFileSync('/etc/passwd', 'utf8')`,
         program: program(
           harness,
           `export default async (_input, context) => {
-  await context.outputs({ first: 1, second: 2 })
+  await context.outputs({ first: 1 })
+  await context.outputs({ second: 2 })
 }`,
         ),
       })
       equal(value, undefined, 'Void Task result')
       equal(
         calls.map(({ invocationId, kind, payload }) => ({ invocationId, kind, payload })),
-        [{ invocationId: 'task-outputs', kind: 'outputs', payload: { first: 1, second: 2 } }],
+        [
+          { invocationId: 'task-outputs', kind: 'outputs', payload: { first: 1 } },
+          { invocationId: 'task-outputs', kind: 'outputs', payload: { second: 2 } },
+        ],
         'Task outputs request',
       )
     },

--- a/packages/open-flow/src/execution/common/runtime.ts
+++ b/packages/open-flow/src/execution/common/runtime.ts
@@ -50,7 +50,7 @@ export interface RuntimeInvocation {
 
 export interface RuntimeHarness {
   readonly engineDigest: string
-  invoke(invocation: RuntimeInvocation): Promise<JsonValue>
+  invoke(invocation: RuntimeInvocation): Promise<JsonValue | undefined>
 }
 
 export interface RuntimeConformanceCase {
@@ -144,6 +144,32 @@ export default () => fs.readFileSync('/etc/passwd', 'utf8')`,
         calls.map(({ invocationId, kind, payload }) => ({ invocationId, kind, payload })),
         [{ invocationId: 'async-capability', kind: 'connector', payload: { action: 'read', input: { issue: 42 } } }],
         'Capability request',
+      )
+    },
+  },
+  {
+    name: 'submits Task outputs and accepts a void result',
+    async verify(harness) {
+      const calls: RuntimeCapabilityCall[] = []
+      const value = await harness.invoke({
+        capability: async (call) => {
+          calls.push(call)
+          return { body: null, status: 200 }
+        },
+        input: null,
+        invocationId: 'task-outputs',
+        program: program(
+          harness,
+          `export default async (_input, context) => {
+  await context.outputs({ first: 1, second: 2 })
+}`,
+        ),
+      })
+      equal(value, undefined, 'Void Task result')
+      equal(
+        calls.map(({ invocationId, kind, payload }) => ({ invocationId, kind, payload })),
+        [{ invocationId: 'task-outputs', kind: 'outputs', payload: { first: 1, second: 2 } }],
+        'Task outputs request',
       )
     },
   },

--- a/packages/open-flow/src/execution/common/scheduler.ts
+++ b/packages/open-flow/src/execution/common/scheduler.ts
@@ -117,7 +117,7 @@ export interface FlowRunOptions {
   readonly emit?: (event: SchedulerEvent) => Effect.Effect<void, Error>
   readonly flowId: string
   readonly inputs?: Readonly<Record<string, Readonly<Record<string, JsonValue>>>>
-  readonly invokeTask: (invocation: TaskInvocation) => Effect.Effect<unknown, Error>
+  readonly invokeTask: (invocation: TaskInvocation, outputs: (value: unknown) => Effect.Effect<void, Error>) => Effect.Effect<unknown, Error>
   readonly projectFailure?: (error: unknown) => SchedulerFailure
   readonly runId: string
   readonly trigger?: TriggerSeed
@@ -406,6 +406,7 @@ function conditionMatches(
 }
 
 function outputRecord(value: unknown, nodeId: string): Readonly<Record<string, JsonValue>> {
+  if (value === undefined) return {}
   if (value == null || typeof value != 'object' || Array.isArray(value)) throw new Error(`Node "${nodeId}" must return an object.`)
   return value as Readonly<Record<string, JsonValue>>
 }
@@ -550,22 +551,34 @@ function runGraph(
             }
             case 'task': {
               const additional = new Set((node.additionalInputs ?? []).map((port) => port.handle))
-              const result = yield* context.invokeTask({
-                additionalInputs: Object.fromEntries(Object.entries(nodeInputs).filter(([handle]) => additional.has(handle))),
-                blockId: node.task != null ? node.task.moduleId : node.taskId,
-                flowId: target.flowId,
-                input: Object.fromEntries(Object.entries(nodeInputs).filter(([handle]) => !additional.has(handle))),
-                invocationId: context.createId(),
-                jobId,
-                nodeId,
-                runId,
-                ...(node.task != null ? { capabilities: node.task.capabilities ?? [], moduleId: node.task.moduleId } : { taskId: node.taskId }),
-              })
-              outputs = yield* Effect.try({
-                try: () => outputRecord(result, nodeId),
-                catch: (error) => (error instanceof Error ? error : new Error(String(error))),
-              })
-              for (const [handle, value] of Object.entries(outputs)) yield* emitNodeOutput(nodeId, jobId, handle, value)
+              const emitted = new Map<string, JsonValue>()
+              const emitOutputs = (value: unknown): Effect.Effect<void, Error> =>
+                Effect.gen(function* () {
+                  const record = yield* Effect.try({
+                    try: () => outputRecord(value, nodeId),
+                    catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+                  })
+                  for (const [handle, output] of Object.entries(record)) {
+                    yield* emitNodeOutput(nodeId, jobId, handle, output)
+                    emitted.set(handle, output)
+                  }
+                })
+              const result = yield* context.invokeTask(
+                {
+                  additionalInputs: Object.fromEntries(Object.entries(nodeInputs).filter(([handle]) => additional.has(handle))),
+                  blockId: node.task != null ? node.task.moduleId : node.taskId,
+                  flowId: target.flowId,
+                  input: Object.fromEntries(Object.entries(nodeInputs).filter(([handle]) => !additional.has(handle))),
+                  invocationId: context.createId(),
+                  jobId,
+                  nodeId,
+                  runId,
+                  ...(node.task != null ? { capabilities: node.task.capabilities ?? [], moduleId: node.task.moduleId } : { taskId: node.taskId }),
+                },
+                emitOutputs,
+              )
+              yield* emitOutputs(result)
+              outputs = Object.fromEntries(emitted)
               break
             }
           }

--- a/packages/open-flow/src/types/index.ts
+++ b/packages/open-flow/src/types/index.ts
@@ -69,7 +69,7 @@ export interface TaskContext<Outputs extends object = Record<string, unknown>> {
   readonly artifact: ArtifactCapability
   readonly fetch: typeof fetch
   readonly logger: TaskLogger
-  output<Handle extends keyof Outputs & string>(handle: Handle, value: Outputs[Handle]): Promise<void>
+  outputs(value: Partial<Outputs>): Promise<void>
   preview(payload: PreviewPayload, id?: string): Promise<void>
   reportProgress(progress: number): Promise<void>
 }

--- a/packages/open-flow/test/scheduler.test.ts
+++ b/packages/open-flow/test/scheduler.test.ts
@@ -660,6 +660,55 @@ describe('revision graph scheduler', () => {
     ])
   })
 
+  it('propagates repeated Task outputs and treats an undefined result as empty', async () => {
+    const source = revision(
+      {
+        bindings: {},
+        graph: {
+          nodes: {
+            source: { concurrency: 1, inputs: {}, kind: 'task', task: task('source', [], ['item']) },
+            collect: {
+              concurrency: 1,
+              inputs: { item: { kind: 'sources', sources: [{ kind: 'node', nodeId: 'source', output: 'item' }] } },
+              kind: 'task',
+              task: task('collect', ['item'], ['seen']),
+            },
+          },
+        },
+        subflows: {},
+        tasks: {},
+      },
+      ['source', 'collect'],
+    )
+    const prepared = await prepareFlow(source, 'main', engine)
+    const events: SchedulerEvent[] = []
+    const result = await runFlow(prepared, {
+      emit: (event) => Effect.sync(() => void events.push(event)),
+      invokeTask(invocation, outputs) {
+        if (invocation.nodeId == 'collect') return Effect.succeed({ seen: invocation.input.item })
+        return Effect.gen(function* () {
+          yield* outputs({ item: 'first' })
+          yield* outputs({ item: 'second' })
+          return undefined
+        })
+      },
+      runId: 'run-task-outputs',
+    })
+
+    expect(
+      events.filter((event) => event.type == 'node.output' && event.nodeId == 'source').map((event) => (event.type == 'node.output' ? event.value : undefined)),
+    ).toEqual(['first', 'second'])
+    expect(result.nodes).toEqual([
+      {
+        jobs: [
+          { jobId: expect.any(String), outputs: { seen: 'first' } },
+          { jobId: expect.any(String), outputs: { seen: 'second' } },
+        ],
+        nodeId: 'collect',
+      },
+    ])
+  })
+
   it('enforces timeout and Fiber interruption for each Task invocation', async () => {
     const source = revision(
       {


### PR DESCRIPTION
## Summary

- Add `context.outputs` for submitting task outputs during execution.
- Propagate repeated outputs through scheduler events and downstream jobs.
- Accept void task results and update the isolated VM engine digest.

## Testing

- Added runtime conformance coverage for output submission and void results.
- Added scheduler coverage for repeated task outputs and undefined results.
- Updated server service coverage to use `context.outputs`.