### PR TITLE
fix: drop create code task follow schema

### DIFF
--- a/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.tsx
+++ b/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.tsx
@@ -1083,7 +1083,7 @@ function BlockQuickPickPanelPopover(props: BlockQuickPickPanelPopoverProps) {
         props.fromSource?.side === 'left' ? { x: props.position.x - 250, y: props.position.y } : props.position,
         connect,
       )
-      if (nodeId != null && props.connection) {
+      if (connect == null && nodeId != null && props.connection) {
         if (handle != null) {
           if (item.type === 'scriptlet' && props.setupScriptletNode) {
             props.setupScriptletNode(nodeId, props.connection, handle)

--- a/packages/open-flow/src/workbench/browser/runtime/designer/flowChanges.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/designer/flowChanges.test.ts
@@ -106,6 +106,33 @@ describe('Code task port changes', () => {
     expect(changed.content.modules['new-code']).toMatchObject({ name: 'New code' })
   })
 
+  it('creates a code task with connection-derived ports', () => {
+    const current = draft('export default () => {}\n')
+    const changes = addNode(
+      revisionView(current),
+      { kind: 'flow' },
+      'new-code',
+      {
+        kind: 'code',
+        name: 'New code',
+        ports: {
+          inputs: [{ description: 'Count', handle: 'value', jsonSchema: { type: 'number' }, nullable: false, value: null }],
+          outputs: [{ handle: 'result', jsonSchema: {}, nullable: true }],
+        },
+      },
+      () => 'unused',
+    )
+
+    if (changes == null) throw new Error('Expected code task changes.')
+    expect(applyFlowChanges(current, changes).content.document.graph.nodes['new-code']).toMatchObject({
+      inputs: { value: { kind: 'value', value: null } },
+      task: {
+        inputs: [{ description: 'Count', handle: 'value', jsonSchema: { type: 'number' }, nullable: false, value: null }],
+        outputs: [{ handle: 'result', jsonSchema: {}, nullable: true }],
+      },
+    })
+  })
+
   it('does not rewrite module source when ports change', () => {
     const source = [
       '//#region generated meta',

--- a/packages/open-flow/src/workbench/browser/runtime/designer/flowChanges.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/designer/flowChanges.ts
@@ -89,7 +89,7 @@ export interface SubflowSettings {
 }
 
 export type AddNodeIntent =
-  | { readonly kind: 'code'; readonly name: string }
+  | { readonly kind: 'code'; readonly name: string; readonly ports?: CodeTaskPorts }
   | { readonly action: ConnectorAction; readonly kind: 'connector' }
   | { readonly kind: 'condition'; readonly name: string }
   | { readonly kind: 'cron'; readonly name: string }
@@ -136,7 +136,7 @@ export function addNode(
 ): FlowChanges | undefined {
   switch (intent.kind) {
     case 'code':
-      return createCodeTask(target, { moduleId: nodeId, nodeId }, intent.name)
+      return createCodeTask(target, { moduleId: nodeId, nodeId }, intent.name, undefined, intent.ports)
     case 'llm':
       return createLlmTask(target, { nodeId, taskId: identity() }, intent.name, intent.mode, intent.outputDescription)
     case 'connector':

--- a/packages/open-flow/src/workbench/browser/runtime/stores/workspaceStore.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/workspaceStore.test.ts
@@ -34,6 +34,106 @@ const draft = {
 } as const
 
 describe('WorkspaceStore', () => {
+  it('creates and connects a code task with the source port schema in one Draft change', async () => {
+    const sourceDraft = {
+      ...draft,
+      content: {
+        ...draft.content,
+        document: {
+          ...draft.content.document,
+          graph: {
+            nodes: {
+              source: {
+                concurrency: 1,
+                inputs: {},
+                kind: 'value',
+                values: [{ description: 'Count', handle: 'count', jsonSchema: { type: 'number' }, nullable: false, value: 1 }],
+              },
+            },
+          },
+        },
+      },
+    } as const
+    let changeBody: { readonly operations: readonly unknown[] } | undefined
+    const request = vi.fn(async (path: string, init?: RequestInit) => {
+      if (path == '/v1/flows?limit=50&includeTotal=true') return Response.json({ flows: [flow], total: 1, version: 1 })
+      if (path == `/v1/flows/${flow.flowId}/draft`) return Response.json(sourceDraft)
+      if (path == `/v1/flows/${flow.flowId}/live`) {
+        return Response.json({ flowId: flow.flowId, hasUnpublishedChanges: true, publication: null, revision: 0, status: 'not-published', version: 1 })
+      }
+      if (path == `/v1/flows/${flow.flowId}/presentation`) {
+        if (init?.method == 'PUT') return Response.json({ revision: 2, updatedAt: timestamp, value: {}, version: 1 })
+        return Response.json({ revision: 1, updatedAt: timestamp, value: {}, version: 1 })
+      }
+      if (path == `/v1/flows/${flow.flowId}/draft/changes`) {
+        changeBody = JSON.parse(String(init?.body)) as { readonly operations: readonly unknown[] }
+        return Response.json({
+          revision: {
+            actorId: 'actor-1',
+            createdAt: timestamp,
+            digest: 'digest-2',
+            flowId: flow.flowId,
+            modelVersion: 1,
+            parentRevisionId: sourceDraft.revisionId,
+            revisionId: 'revision-2',
+            version: 1,
+          },
+          version: 1,
+        })
+      }
+      if (path.endsWith('/check')) {
+        return Response.json({
+          closureDigest: 'closure-1',
+          diagnostics: [],
+          engineContract: 'open-flow-engine/v1',
+          flowId: flow.flowId,
+          modelVersion: 1,
+          revisionDigest: path.includes('revision-2') ? 'digest-2' : sourceDraft.digest,
+          revisionId: path.includes('revision-2') ? 'revision-2' : sourceDraft.revisionId,
+          valid: true,
+          version: 1,
+        })
+      }
+      throw new Error(`Unexpected request: ${path}`)
+    })
+    const store = new WorkspaceStore(new WorkbenchClient(request), vi.fn(), () => 'code')
+
+    try {
+      await store.start(flow.flowId)
+      const option = store.$.addNodeOptions.value.find((candidate) => candidate.kind == 'new-task')
+      if (option == null) throw new Error('Expected Code Task option.')
+
+      const nodeId = await store.addNode(option, { x: 100, y: 100 }, (createdNodeId) => ({
+        source: 'source',
+        sourceHandle: 'count',
+        target: createdNodeId,
+        targetHandle: 'value',
+      }))
+
+      expect(nodeId).toBe('code')
+      expect(changeBody?.operations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ kind: 'module.create', moduleId: 'code' }),
+          expect.objectContaining({
+            kind: 'graph.node.create',
+            node: expect.objectContaining({
+              task: expect.objectContaining({
+                inputs: [{ description: 'Count', handle: 'value', jsonSchema: { type: 'number' }, nullable: false, value: null }],
+              }),
+            }),
+            nodeId: 'code',
+          }),
+          expect.objectContaining({
+            edge: { source: 'source', sourceHandle: 'count', target: 'code', targetHandle: 'value' },
+            kind: 'graph.edge.connect',
+          }),
+        ]),
+      )
+    } finally {
+      store.dispose()
+    }
+  })
+
   it('enables publishing after adding a node to a published Flow', async () => {
     const publication = {
       actorId: 'actor-1',

--- a/packages/open-flow/src/workbench/browser/runtime/stores/workspaceStore.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/workspaceStore.ts
@@ -86,6 +86,45 @@ function reconcileTarget(revision: RevisionView, target: DesignerTarget | undefi
   return target.kind == 'flow' || revision.subflow(target.id) != null ? target : { kind: 'flow' }
 }
 
+function connectedCodePorts(draft: Draft, target: DesignerTarget, nodeId: string, edge: Omit<DesignerEdge, 'id'>): CodeTaskPorts | undefined {
+  const nodes = designerGraph(draft, target).nodes
+  if (edge.target == nodeId) {
+    const source = nodes.find((node) => node.id == edge.source)
+    if (source == null || source.kind == 'comment') return
+    const port = source.outputs.find((output) => 'handle' in output && output.handle == edge.sourceHandle)
+    if (port == null || !('handle' in port)) return
+    return {
+      inputs: [
+        {
+          description: port.description,
+          handle: edge.targetHandle,
+          jsonSchema: (port.jsonSchema ?? {}) as JsonValue,
+          nullable: port.nullable ?? false,
+          value: null,
+        },
+      ],
+      outputs: [{ handle: 'result', jsonSchema: {}, nullable: true }],
+    }
+  }
+  if (edge.source == nodeId) {
+    const targetNode = nodes.find((node) => node.id == edge.target)
+    if (targetNode == null || targetNode.kind == 'comment') return
+    const port = targetNode.inputs.find((input) => 'handle' in input && input.handle == edge.targetHandle)
+    if (port == null || !('handle' in port)) return
+    return {
+      inputs: [{ handle: 'value', jsonSchema: {}, nullable: true, value: null }],
+      outputs: [
+        {
+          description: port.description,
+          handle: edge.sourceHandle,
+          jsonSchema: (port.jsonSchema ?? {}) as JsonValue,
+          nullable: port.nullable ?? false,
+        },
+      ],
+    }
+  }
+}
+
 export class WorkspaceStore {
   readonly #client: WorkbenchClient
   readonly #draftChanges: DraftChanges
@@ -345,12 +384,17 @@ export class WorkspaceStore {
     const nodeId = this.#identity()
     if (option.kind == 'comment') return await this.#addComment(target, nodeId, position)
     const revision = revisionView(draft)
-    const intent = addNodeIntent(option, revision, target, this.#i18n.t)
+    let intent = addNodeIntent(option, revision, target, this.#i18n.t)
     if (intent == null) return
+    const edge = connection?.(nodeId)
+    if (intent.kind == 'code' && edge != null) {
+      const ports = connectedCodePorts(draft, target, nodeId, edge)
+      if (ports == null) return
+      intent = { ...intent, ports }
+    }
     const nodeChanges = addFlowNode(revision, target, nodeId, intent, this.#identity)
     if (nodeChanges == null) return
-    const changes =
-      connection == null ? nodeChanges : [...nodeChanges, ...connectFlowNodes(applyFlowChanges(draft, nodeChanges).content, target, connection(nodeId))]
+    const changes = edge == null ? nodeChanges : [...nodeChanges, ...connectFlowNodes(applyFlowChanges(draft, nodeChanges).content, target, edge)]
     const change = this.#changeDraft(changes)
     this.selectNodes([nodeId])
     const move = this.moveNodes({ [nodeId]: position })


### PR DESCRIPTION
## Summary

- infer a new Code Task port schema from the existing connection endpoint before creation
- create the module, node, typed port, and edge in one Draft change
- avoid sending a redundant follow-up connection after an atomic add-node callback
- fail without creating a partial Code Task when the endpoint or handle cannot be resolved

## Verification

- `bun run format`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run test:package`