### PR TITLE
fix(workbench): keep Flow catalog visible while refreshing

### DIFF
--- a/packages/open-flow/src/workbench/browser/runtime/shell/resourceBrowser.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/shell/resourceBrowser.tsx
@@ -243,6 +243,7 @@ export function FlowBrowser({
   const loading = useVal(store.workspace.$.flowLoading)
   const loadingMore = useVal(store.workspace.$.flowLoadingMore)
   const nextCursor = useVal(store.workspace.$.flowNextCursor)
+  const refreshing = useVal(store.workspace.$.flowRefreshing)
   const flows = useVal(store.workspace.$.flows)
   const total = useVal(store.workspace.$.flowTotal)
   const [creating, setCreating] = useState(false)
@@ -286,13 +287,13 @@ export function FlowBrowser({
               </InputGroup>
               <Button
                 aria-label={t('common.refresh')}
-                disabled={loading || busy != null}
+                disabled={loading || refreshing || busy != null}
                 onClick={() => void store.workspace.reloadFlows()}
                 size="icon"
                 title={t('common.refresh')}
                 variant="outline"
               >
-                <Icon name="refresh" />
+                <Icon className={refreshing ? 'animate-spin' : undefined} name="refresh" />
               </Button>
               <Button className="resource-page-primary-action" disabled={busy != null} onClick={() => setCreating(true)}>
                 <Icon data-icon="inline-start" name="plus" />

--- a/packages/open-flow/src/workbench/browser/runtime/shell/resourceBrowser.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/shell/resourceBrowser.tsx
@@ -359,7 +359,7 @@ export function FlowBrowser({
           </div>
           {nextCursor != null && (
             <div className="resource-list-footer">
-              <Button disabled={loadingMore} onClick={() => void store.workspace.loadMoreFlows()} variant="outline">
+              <Button disabled={loadingMore || refreshing} onClick={() => void store.workspace.loadMoreFlows()} variant="outline">
                 {t(loadingMore ? 'resource.loadingMore' : loadMoreFailed ? 'resource.retryLoadMore' : 'resource.loadMore')}
               </Button>
             </div>

--- a/packages/open-flow/src/workbench/browser/runtime/stores/flowCatalog.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/flowCatalog.ts
@@ -123,8 +123,8 @@ export class FlowCatalog {
   }
 
   public async loadMore(): Promise<void> {
-    const { loadingMore, nextCursor } = this.#state.value
-    if (loadingMore || nextCursor == null) return
+    const { loadingMore, nextCursor, refreshing } = this.#state.value
+    if (loadingMore || refreshing || nextCursor == null) return
     const current = this.#session.capture()
     this.#set({ loadingMore: true, loadMoreFailed: false })
     try {

--- a/packages/open-flow/src/workbench/browser/runtime/stores/flowCatalog.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/flowCatalog.ts
@@ -85,16 +85,20 @@ export class FlowCatalog {
 
   public async reload(): Promise<void> {
     const current = this.#session.begin()
-    this.#set({
-      failed: false,
-      loaded: false,
-      loading: true,
-      loadingMore: false,
-      loadMoreFailed: false,
-      nextCursor: undefined,
-      flows: [],
-      total: undefined,
-    })
+    const loaded = this.#state.value.loaded
+    if (loaded) {
+      this.#set({ failed: false, loadingMore: false, loadMoreFailed: false })
+    } else {
+      this.#set({
+        failed: false,
+        loading: true,
+        loadingMore: false,
+        loadMoreFailed: false,
+        nextCursor: undefined,
+        flows: [],
+        total: undefined,
+      })
+    }
     try {
       const page = await this.#client.listFlows({ includeTotal: true, limit: pageLimit })
       if (!current()) return
@@ -107,7 +111,7 @@ export class FlowCatalog {
       })
     } catch (error) {
       if (!current()) return
-      this.#set({ failed: true, loading: false })
+      this.#set({ failed: !loaded, loading: false })
       this.#setNotice(errorNotice(error, this.#i18n.t))
     }
   }

--- a/packages/open-flow/src/workbench/browser/runtime/stores/flowCatalog.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/flowCatalog.ts
@@ -16,6 +16,7 @@ interface State {
   readonly loading: boolean
   readonly loadingMore: boolean
   readonly loadMoreFailed: boolean
+  readonly refreshing: boolean
   readonly nextCursor?: string
   readonly flows: readonly Flow[]
   readonly total?: number
@@ -26,6 +27,7 @@ export interface FlowCatalog$ {
   readonly loading: ReadonlyVal<boolean>
   readonly loadingMore: ReadonlyVal<boolean>
   readonly loadMoreFailed: ReadonlyVal<boolean>
+  readonly refreshing: ReadonlyVal<boolean>
   readonly nextCursor: ReadonlyVal<string | undefined>
   readonly flows: ReadonlyVal<readonly Flow[]>
   readonly total: ReadonlyVal<number | undefined>
@@ -37,6 +39,7 @@ const initialState: State = {
   loading: true,
   loadingMore: false,
   loadMoreFailed: false,
+  refreshing: false,
   flows: [],
 }
 
@@ -58,6 +61,7 @@ export class FlowCatalog {
       loading: derive(this.#state, (state) => state.loading),
       loadingMore: derive(this.#state, (state) => state.loadingMore),
       loadMoreFailed: derive(this.#state, (state) => state.loadMoreFailed),
+      refreshing: derive(this.#state, (state) => state.refreshing),
       nextCursor: derive(this.#state, (state) => state.nextCursor),
       flows: derive(this.#state, (state) => state.flows),
       total: derive(this.#state, (state) => state.total),
@@ -87,13 +91,14 @@ export class FlowCatalog {
     const current = this.#session.begin()
     const loaded = this.#state.value.loaded
     if (loaded) {
-      this.#set({ failed: false, loadingMore: false, loadMoreFailed: false })
+      this.#set({ failed: false, loadingMore: false, loadMoreFailed: false, refreshing: true })
     } else {
       this.#set({
         failed: false,
         loading: true,
         loadingMore: false,
         loadMoreFailed: false,
+        refreshing: false,
         nextCursor: undefined,
         flows: [],
         total: undefined,
@@ -105,13 +110,14 @@ export class FlowCatalog {
       this.#set({
         loaded: true,
         loading: false,
+        refreshing: false,
         nextCursor: page.nextCursor,
         flows: page.flows,
         total: page.total,
       })
     } catch (error) {
       if (!current()) return
-      this.#set({ failed: !loaded, loading: false })
+      this.#set({ failed: !loaded, loading: false, refreshing: false })
       this.#setNotice(errorNotice(error, this.#i18n.t))
     }
   }

--- a/packages/open-flow/src/workbench/browser/runtime/stores/workspaceModel.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/workspaceModel.ts
@@ -70,6 +70,7 @@ export interface Workspace$ {
   readonly flowLoading: ReadonlyVal<boolean>
   readonly flowLoadingMore: ReadonlyVal<boolean>
   readonly flowNextCursor: ReadonlyVal<string | undefined>
+  readonly flowRefreshing: ReadonlyVal<boolean>
   readonly flowTotal: ReadonlyVal<number | undefined>
   readonly flows: ReadonlyVal<readonly Flow[]>
   readonly inspectorDiagnostics: ReadonlyVal<readonly Diagnostic[]>
@@ -190,6 +191,7 @@ export class WorkspaceModel {
       flowLoading: flows.$.loading,
       flowLoadingMore: flows.$.loadingMore,
       flowNextCursor: flows.$.nextCursor,
+      flowRefreshing: flows.$.refreshing,
       flowTotal: flows.$.total,
       flows: flows.$.flows,
       inspectorDiagnostics: derive(this.#state, (state) =>

--- a/packages/open-flow/src/workbench/browser/runtime/stores/workspaceStore.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/workspaceStore.test.ts
@@ -42,7 +42,7 @@ describe('WorkspaceStore', () => {
     const request = vi.fn(async (path: string) => {
       if (path != '/v1/flows?limit=50&includeTotal=true') throw new Error(`Unexpected request: ${path}`)
       flowLists += 1
-      if (flowLists == 1) return Response.json({ flows: [flow], total: 1, version: 1 })
+      if (flowLists == 1) return Response.json({ flows: [flow], nextCursor: 'old', total: 1, version: 1 })
       refreshRequested.resolve()
       return await refreshed.promise
     })
@@ -64,10 +64,55 @@ describe('WorkspaceStore', () => {
       expect(store.$.flowLoading.value).toBe(false)
       expect(store.$.flowRefreshing.value).toBe(true)
       expect(store.$.flows.value).toEqual([flow])
+      await store.loadMoreFlows()
+      expect(request).toHaveBeenCalledTimes(2)
 
       refreshed.resolve(Response.json({ flows: [], total: 0, version: 1 }))
       await vi.waitFor(() => expect(store.$.flows.value).toEqual([]))
       expect(store.$.flowRefreshing.value).toBe(false)
+    } finally {
+      store.dispose()
+    }
+  })
+
+  it('discards an in-flight Flow catalog page when a notification refreshes it', async () => {
+    const page = Promise.withResolvers<Response>()
+    const pageRequested = Promise.withResolvers<void>()
+    let catalogListener: (() => void) | undefined
+    const refreshedFlow = { ...flow, name: 'Refreshed' }
+    const staleFlow = { ...flow, flowId: 'stale', name: 'Stale' }
+    const request = vi.fn(async (path: string) => {
+      if (path == '/v1/flows?limit=50&includeTotal=true') {
+        const refreshing = request.mock.calls.length > 1
+        return Response.json(refreshing ? { flows: [refreshedFlow], total: 1, version: 1 } : { flows: [flow], nextCursor: 'old', total: 2, version: 1 })
+      }
+      if (path == '/v1/flows?cursor=old&limit=50') {
+        pageRequested.resolve()
+        return await page.promise
+      }
+      throw new Error(`Unexpected request: ${path}`)
+    })
+    const client = new WorkbenchClient(
+      request,
+      () => () => {},
+      (listener) => {
+        catalogListener = listener
+        return () => {}
+      },
+    )
+    const store = new WorkspaceStore(client, vi.fn())
+
+    try {
+      await store.start()
+      const loadingMore = store.loadMoreFlows()
+      await pageRequested.promise
+      catalogListener?.()
+      await vi.waitFor(() => expect(store.$.flows.value).toEqual([refreshedFlow]))
+
+      page.resolve(Response.json({ flows: [staleFlow], total: 2, version: 1 }))
+      await loadingMore
+      expect(store.$.flows.value).toEqual([refreshedFlow])
+      expect(store.$.flowLoadingMore.value).toBe(false)
     } finally {
       store.dispose()
     }

--- a/packages/open-flow/src/workbench/browser/runtime/stores/workspaceStore.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/workspaceStore.test.ts
@@ -34,6 +34,43 @@ const draft = {
 } as const
 
 describe('WorkspaceStore', () => {
+  it('keeps the loaded Flow catalog visible while a notification refreshes it', async () => {
+    const refreshed = Promise.withResolvers<Response>()
+    const refreshRequested = Promise.withResolvers<void>()
+    let catalogListener: (() => void) | undefined
+    let flowLists = 0
+    const request = vi.fn(async (path: string) => {
+      if (path != '/v1/flows?limit=50&includeTotal=true') throw new Error(`Unexpected request: ${path}`)
+      flowLists += 1
+      if (flowLists == 1) return Response.json({ flows: [flow], total: 1, version: 1 })
+      refreshRequested.resolve()
+      return await refreshed.promise
+    })
+    const client = new WorkbenchClient(
+      request,
+      () => () => {},
+      (listener) => {
+        catalogListener = listener
+        return () => {}
+      },
+    )
+    const store = new WorkspaceStore(client, vi.fn())
+
+    try {
+      await store.start()
+      catalogListener?.()
+      await refreshRequested.promise
+
+      expect(store.$.flowLoading.value).toBe(false)
+      expect(store.$.flows.value).toEqual([flow])
+
+      refreshed.resolve(Response.json({ flows: [], total: 0, version: 1 }))
+      await vi.waitFor(() => expect(store.$.flows.value).toEqual([]))
+    } finally {
+      store.dispose()
+    }
+  })
+
   it('creates and connects a code task with the source port schema in one Draft change', async () => {
     const sourceDraft = {
       ...draft,

--- a/packages/open-flow/src/workbench/browser/runtime/stores/workspaceStore.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/workspaceStore.test.ts
@@ -62,10 +62,12 @@ describe('WorkspaceStore', () => {
       await refreshRequested.promise
 
       expect(store.$.flowLoading.value).toBe(false)
+      expect(store.$.flowRefreshing.value).toBe(true)
       expect(store.$.flows.value).toEqual([flow])
 
       refreshed.resolve(Response.json({ flows: [], total: 0, version: 1 }))
       await vi.waitFor(() => expect(store.$.flows.value).toEqual([]))
+      expect(store.$.flowRefreshing.value).toBe(false)
     } finally {
       store.dispose()
     }


### PR DESCRIPTION
## Summary

- keep an already loaded Flow catalog visible during notification and reconnect refreshes
- reserve the catalog loading and failure screens for the initial load
- disable the Refresh button and spin its icon while a background refresh is running
- add a regression test covering the WebSocket-open refresh race and refresh state

## Verification

- `bun run format`
- `bun run check`
- `bun run test`
- `bun run build`