### PR TITLE
feat(designer): add theme previews to lab

### DIFF
--- a/packages/open-flow/dev/designer/README.md
+++ b/packages/open-flow/dev/designer/README.md
@@ -6,4 +6,17 @@ Run the local-only Designer component playground from the repository root:
 bun run dev:designer
 ```
 
-Add component scenarios to `stories.tsx`. Keep scenarios deterministic and use the action logger instead of external services. Every story renders inside a real flow node so canvas scaling and popup placement use the same context as Designer. The Lab is a development tool and has no production build or package entry.
+The default **Workflow components** overview includes Task, Trigger, Condition, Value, Subflow and Comment nodes, grouped inputs, Variable bindings and connections. Use the canvas controls to zoom, fit the graph and switch between detail and overview. **Reset samples** restores the sample layout and selection.
+
+The **Theme Preview** group also contains:
+
+- **Node states**: idle, selected, waiting, running, success and error nodes together.
+- **Node controls**: compact inputs, switches, checkboxes, ranges, selects, dates, buttons and popups.
+- **Workbench controls**: shared buttons, inputs, choices, badges and feedback in the product theme.
+- **Theme palette**: Designer and product color tokens side by side, using the actual CSS variables.
+
+Switch light/dark mode in the toolbar to review both themes. Story URLs are shareable locally with `?story=workflow`, `?story=node-states`, `?story=node-controls`, `?story=product-controls` or `?story=palette`. Sample content stays in English; the language picker changes the actual components' translations.
+
+Designer colors live in `src/designer/browser/styles/light.module.scss` and `dark.module.scss`; product colors live in `src/ui/browser/theme.css`. Edits to these files update the previews through Vite.
+
+Add individual component scenarios to `stories.tsx`, component overviews to `overview.tsx`, and full graph samples to `workflow.tsx`. Keep scenarios deterministic and use the action logger instead of external services. Component stories render inside a real flow node so canvas scaling and popup placement use the same context as Designer. Standalone stories provide their own layout; workflow samples use `FlowDesignerView` and log authoring actions without saving or running a Flow. The Lab is a development tool and has no production build or package entry.

--- a/packages/open-flow/dev/designer/lab.tsx
+++ b/packages/open-flow/dev/designer/lab.tsx
@@ -14,7 +14,9 @@ import { ThemeProvider } from '../../src/designer/browser/theme/ThemeProvider.ts
 import { defaultUiLanguage, uiLanguageNames, uiLanguages } from '../../src/localization/common/languages.ts'
 import { TooltipProvider } from '../../src/ui/browser/tooltip.tsx'
 import { CodeEditor } from '../../src/workbench/browser/runtime/designer/codeEditor.tsx'
+import { overviewStories } from './overview.tsx'
 import { stories } from './stories.tsx'
+import { workflowStories } from './workflow.tsx'
 
 type ThemeMode = 'dark' | 'light' | 'system'
 
@@ -56,10 +58,11 @@ const codeEditorStory: DesignerStory = {
   title: 'Code Editor',
 }
 
-const labStories: readonly DesignerStory[] = [...stories, codeEditorStory]
+const labStories: readonly DesignerStory[] = [...stories, codeEditorStory, ...workflowStories, ...overviewStories]
 
 function initialStory(): DesignerStory {
-  const story = labStories.find((item) => item.id == new URLSearchParams(location.search).get('story')) ?? labStories[0]
+  const requested = new URLSearchParams(location.search).get('story')
+  const story = labStories.find((item) => item.id == requested) ?? labStories.find((item) => item.id == 'workflow') ?? labStories[0]
   if (!story) throw new Error('Designer Lab has no stories.')
   return story
 }
@@ -90,7 +93,7 @@ export function DesignerLab() {
   }
 
   return (
-    <div className="lab-shell" data-theme={dark ? 'dark' : 'light'}>
+    <div className="lab-shell open-flow-theme" data-theme={dark ? 'dark' : 'light'}>
       <aside className="lab-sidebar">
         <div className="lab-brand">
           <strong>Designer Lab</strong>
@@ -136,10 +139,12 @@ export function DesignerLab() {
         </header>
         <div className="lab-workspace">
           {story.standalone ? (
-            <div className="standalone-stage">{story.render(log, dark)}</div>
+            <div className="standalone-stage" key={story.id}>
+              {story.render(log, dark, language)}
+            </div>
           ) : (
-            <StoryStage dark={dark} i18n={i18n}>
-              {story.render(log, dark)}
+            <StoryStage dark={dark} i18n={i18n} key={story.id}>
+              {story.render(log, dark, language)}
             </StoryStage>
           )}
         </div>
@@ -213,6 +218,8 @@ function StoryStage({ children, dark, i18n }: { readonly children: React.ReactNo
                 <ReactFlow
                   colorMode={dark ? 'dark' : 'light'}
                   edges={[]}
+                  fitView
+                  fitViewOptions={{ maxZoom: 1, padding: 0.12 }}
                   maxZoom={3}
                   minZoom={0.1}
                   nodeTypes={nodeTypes}

--- a/packages/open-flow/dev/designer/overview.tsx
+++ b/packages/open-flow/dev/designer/overview.tsx
@@ -1,0 +1,227 @@
+import type { ReactNode } from 'react'
+import type { UiLanguage } from '../../src/localization/common/languages.ts'
+import type { DesignerStory, LogAction } from './stories.tsx'
+
+import { DesignerCheckbox } from '../../src/designer/browser/components/checkbox.tsx'
+import { Input as DesignerInput } from '../../src/designer/browser/components/input.tsx'
+import { Null } from '../../src/designer/browser/components/null.tsx'
+import { Range } from '../../src/designer/browser/components/range.tsx'
+import { LabeledSwitch } from '../../src/designer/browser/components/toggleSwitch.tsx'
+import { designerThemeClass } from '../../src/designer/browser/theme/designerThemeClass.ts'
+import { Alert, AlertDescription, AlertTitle } from '../../src/ui/browser/alert.tsx'
+import { Badge } from '../../src/ui/browser/badge.tsx'
+import { Button } from '../../src/ui/browser/button.tsx'
+import { Checkbox } from '../../src/ui/browser/checkbox.tsx'
+import { Input } from '../../src/ui/browser/input.tsx'
+import { Progress } from '../../src/ui/browser/progress.tsx'
+import { Switch } from '../../src/ui/browser/switch.tsx'
+import { Textarea } from '../../src/ui/browser/textarea.tsx'
+import { stories } from './stories.tsx'
+
+const designerTokens = [
+  {
+    title: 'Canvas & nodes',
+    tokens: ['--flow-bg', '--node-background-color', '--node-head-background-color', '--node-border-color', '--node-selected-border-color'],
+  },
+  {
+    title: 'Fields & popups',
+    tokens: [
+      '--widget-background',
+      '--widget-input-background',
+      '--widget-border-color',
+      '--widget-popup-background',
+      '--widget-input-selection-background-color',
+    ],
+  },
+  { title: 'Text', tokens: ['--text-1', '--text-2', '--text-3', '--text-4', '--text-5'] },
+  {
+    title: 'Connections & feedback',
+    tokens: [
+      '--edge-color',
+      '--edge-string',
+      '--edge-primitive',
+      '--edge-bin',
+      '--edge-error',
+      '--widget-success-progress-color',
+      '--widget-error-progress-color',
+      '--widget-error-input-background',
+    ],
+  },
+]
+
+const productTokens = [
+  { title: 'Surfaces', tokens: ['--ui-background', '--ui-card', '--ui-popover', '--ui-secondary', '--ui-muted', '--ui-accent'] },
+  { title: 'Text & actions', tokens: ['--ui-foreground', '--ui-muted-foreground', '--ui-primary', '--ui-primary-foreground', '--ui-destructive'] },
+  { title: 'Borders & focus', tokens: ['--ui-border', '--ui-input', '--ui-ring'] },
+]
+
+function Sample({ title, children }: { readonly title: string; readonly children: ReactNode }) {
+  return (
+    <section className="overview-sample">
+      <h2>{title}</h2>
+      <div className="overview-sample-body">{children}</div>
+    </section>
+  )
+}
+
+function ButtonSamples({ log }: { readonly log: LogAction }) {
+  return (
+    <div className="overview-buttons">
+      {(['default', 'secondary', 'outline', 'ghost', 'destructive', 'link'] as const).map((variant) => (
+        <Button key={variant} variant={variant} size="sm" onClick={() => log('button.click', variant)}>
+          {variant}
+        </Button>
+      ))}
+      <Button disabled size="sm">
+        Disabled
+      </Button>
+    </div>
+  )
+}
+
+function ControlOverview({ log, dark, language }: { readonly log: LogAction; readonly dark: boolean; readonly language: UiLanguage }) {
+  return (
+    <div className="overview-controls">
+      <Sample title="Text & validation">
+        <DesignerInput ariaLabel="Default input" value="Workflow input" onChange={(value) => log('input.change', value)} />
+        <DesignerInput ariaLabel="Empty input" placeholder="Placeholder" />
+        <DesignerInput ariaLabel="Invalid input" ariaInvalid warning="A valid value is required." value="Invalid value" />
+        <DesignerInput ariaLabel="Read-only input" readOnly value="Read-only value" />
+        <DesignerInput ariaLabel="Disabled input" disabled value="Disabled value" />
+        <DesignerInput ariaLabel="Multiline input" multiline value={'Summarize the records.\nReturn a short Markdown digest.'} />
+      </Sample>
+      <Sample title="Boolean & numeric values">
+        <LabeledSwitch label="Enabled" defaultChecked onChange={(value) => log('switch.change', value)} />
+        <LabeledSwitch label="Off" onChange={(value) => log('switch.change', value)} />
+        <LabeledSwitch label="Disabled" defaultChecked disabled />
+        <DesignerCheckbox label="Checked" defaultChecked onChange={(value) => log('checkbox.change', value)} />
+        <DesignerCheckbox label="Unchecked" onChange={(value) => log('checkbox.change', value)} />
+        <DesignerCheckbox label="Disabled" defaultChecked disabled />
+        <Range label="Temperature" min={0} max={1} step={0.1} defaultValue={0.7} onChange={(value) => log('range.change', value)} />
+        <Range label="Disabled" min={0} max={100} defaultValue={40} disabled />
+        <div>
+          Nullable value <Null />
+        </div>
+      </Sample>
+      {stories
+        .filter((story) => ['select', 'multi-select', 'date-time', 'popup'].includes(story.id))
+        .map((story) => (
+          <Sample key={story.id} title={story.title}>
+            {story.render(log, dark, language)}
+          </Sample>
+        ))}
+      <Sample title="Buttons">
+        <ButtonSamples log={log} />
+      </Sample>
+    </div>
+  )
+}
+
+function ProductOverview({ log }: { readonly log: LogAction }) {
+  return (
+    <div className="product-overview open-flow-workbench">
+      <div className="overview-controls">
+        <Sample title="Actions">
+          <ButtonSamples log={log} />
+        </Sample>
+        <Sample title="Inputs">
+          <Input aria-label="Default input" defaultValue="Daily digest" onChange={(event) => log('input.change', event.target.value)} />
+          <Input aria-label="Empty input" placeholder="Search workflows" />
+          <Input aria-label="Invalid input" aria-invalid defaultValue="Invalid value" />
+          <Input aria-label="Disabled input" disabled defaultValue="Disabled value" />
+          <Textarea aria-label="Description" defaultValue="Summarize new records and prepare a digest." />
+        </Sample>
+        <Sample title="Choices">
+          <div className="overview-inline">
+            <Switch aria-label="Enabled" defaultChecked onCheckedChange={(value) => log('switch.change', value)} />
+            <span>Enabled</span>
+          </div>
+          <div className="overview-inline">
+            <Switch aria-label="Off" />
+            <span>Off</span>
+          </div>
+          <div className="overview-inline">
+            <Switch aria-label="Disabled switch" disabled defaultChecked />
+            <span>Disabled</span>
+          </div>
+          <div className="overview-inline">
+            <Checkbox aria-label="Selected" defaultChecked onCheckedChange={(value) => log('checkbox.change', value)} />
+            <span>Selected</span>
+          </div>
+          <div className="overview-inline">
+            <Checkbox aria-label="Mixed" indeterminate />
+            <span>Mixed</span>
+          </div>
+        </Sample>
+        <Sample title="Badges">
+          <div className="overview-buttons">
+            {(['default', 'secondary', 'outline', 'destructive'] as const).map((variant) => (
+              <Badge key={variant} variant={variant}>
+                {variant}
+              </Badge>
+            ))}
+          </div>
+        </Sample>
+        <Sample title="Feedback">
+          <Alert>
+            <AlertTitle>Ready to run</AlertTitle>
+            <AlertDescription>All required inputs are configured.</AlertDescription>
+          </Alert>
+          <Alert variant="destructive">
+            <AlertTitle>Run failed</AlertTitle>
+            <AlertDescription>The sample connection is unavailable.</AlertDescription>
+          </Alert>
+          <Progress aria-label="Sample run progress" value={42} />
+        </Sample>
+      </div>
+    </div>
+  )
+}
+
+function Swatches({ groups }: { readonly groups: typeof designerTokens }) {
+  return (
+    <>
+      {groups.map((group) => (
+        <section className="palette-group" key={group.title}>
+          <h3>{group.title}</h3>
+          <div className="palette-grid">
+            {group.tokens.map((token) => (
+              <div className="palette-swatch" key={token}>
+                <div className="palette-color" style={{ background: `var(${token})` }} />
+                <code>{token}</code>
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+    </>
+  )
+}
+
+function PaletteOverview({ dark }: { readonly dark: boolean }) {
+  return (
+    <div className="palette-overview">
+      <div className={`palette-panel oo-designer-root ${designerThemeClass(dark)}`} data-theme={dark ? 'dark' : 'light'}>
+        <h2>Designer · Canvas content</h2>
+        <p>Nodes, ports, connections and compact editors.</p>
+        <Swatches groups={designerTokens} />
+      </div>
+      <div className="palette-panel open-flow-workbench">
+        <h2>Product · Workbench & canvas controls</h2>
+        <p>Shared surfaces, buttons, panels and focus rings.</p>
+        <Swatches groups={productTokens} />
+      </div>
+    </div>
+  )
+}
+
+export const overviewStories: readonly DesignerStory[] = [
+  {
+    group: 'Theme Preview',
+    id: 'node-controls',
+    title: 'Node controls',
+    render: (log, dark, language) => <ControlOverview log={log} dark={dark} language={language} />,
+  },
+  { group: 'Theme Preview', id: 'product-controls', title: 'Workbench controls', standalone: true, render: (log) => <ProductOverview log={log} /> },
+  { group: 'Theme Preview', id: 'palette', title: 'Theme palette', standalone: true, render: (_log, dark) => <PaletteOverview dark={dark} /> },
+]

--- a/packages/open-flow/dev/designer/stories.tsx
+++ b/packages/open-flow/dev/designer/stories.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import type { DesignerOption } from '../../src/designer/browser/components/select.tsx'
+import type { UiLanguage } from '../../src/localization/common/languages.ts'
 
 import { useState } from 'react'
 import { DateTimePicker } from '../../src/designer/browser/components/dateTimePicker.tsx'
@@ -25,7 +26,7 @@ export type LogAction = (name: string, value?: unknown) => void
 export interface DesignerStory {
   readonly group: string
   readonly id: string
-  readonly render: (log: LogAction, dark: boolean) => ReactNode
+  readonly render: (log: LogAction, dark: boolean, language: UiLanguage) => ReactNode
   readonly standalone?: boolean
   readonly title: string
 }
@@ -98,7 +99,7 @@ function MultiSelectStory({ log }: { readonly log: LogAction }) {
 }
 
 function DateTimeStory({ log }: { readonly log: LogAction }) {
-  const [date, setDate] = useState<Date | null>(new Date())
+  const [date, setDate] = useState<Date | null>(new Date(2026, 8, 3, 9, 30))
   return (
     <StoryColumn>
       <Field label="Date">
@@ -112,13 +113,13 @@ function DateTimeStory({ log }: { readonly log: LogAction }) {
         />
       </Field>
       <Field label="Date and time">
-        <DateTimePicker showDate showTime defaultValue={new Date()} isClearable onChange={(next) => log('datetime.change', next)} />
+        <DateTimePicker showDate showTime defaultValue={new Date(2026, 8, 3, 9, 30)} isClearable onChange={(next) => log('datetime.change', next)} />
       </Field>
       <Field label="Time">
-        <DateTimePicker showDate={false} showTime defaultValue={new Date()} onChange={(next) => log('time.change', next)} />
+        <DateTimePicker showDate={false} showTime defaultValue={new Date(2026, 8, 3, 9, 30)} onChange={(next) => log('time.change', next)} />
       </Field>
       <Field label="Disabled">
-        <DateTimePicker disabled value={new Date()} />
+        <DateTimePicker disabled value={new Date(2026, 8, 3, 9, 30)} />
       </Field>
     </StoryColumn>
   )

--- a/packages/open-flow/dev/designer/styles.css
+++ b/packages/open-flow/dev/designer/styles.css
@@ -237,6 +237,134 @@ select {
   background: var(--lab-bg);
   overflow: auto;
 }
+.workflow-story {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+}
+.overview-toolbar.open-flow-workbench {
+  width: auto;
+  height: auto;
+  min-height: 44px;
+  padding: 8px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 1px solid var(--ui-border);
+  background: var(--ui-background);
+  color: var(--ui-muted-foreground);
+  font-size: 12px;
+}
+.workflow-canvas {
+  position: relative;
+  min-height: 0;
+}
+.workflow-story .react-flow__node > div {
+  animation: none;
+}
+.overview-controls {
+  display: grid;
+  grid-template-columns: repeat(3, 320px);
+  align-items: start;
+  gap: 28px;
+}
+.overview-sample {
+  min-width: 0;
+}
+.overview-sample h2,
+.palette-panel h2 {
+  margin: 0 0 16px;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.5;
+}
+.overview-sample-body {
+  display: grid;
+  gap: 12px;
+  line-height: 1.5;
+}
+.overview-sample .story-column {
+  width: 100%;
+}
+.overview-buttons,
+.overview-inline {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.overview-buttons > button {
+  width: auto;
+}
+.product-overview.open-flow-workbench {
+  width: 100%;
+  height: 100%;
+  padding: 28px;
+  overflow: auto;
+  color: var(--ui-foreground);
+  background: var(--ui-background);
+}
+.product-overview .overview-controls {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+.palette-overview {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(320px, 1fr));
+  align-items: start;
+  gap: 20px;
+  width: 100%;
+  height: 100%;
+  padding: 20px;
+  overflow: auto;
+}
+.palette-panel,
+.palette-panel.open-flow-workbench {
+  width: 100%;
+  height: auto;
+  min-width: 0;
+  padding: 24px;
+  color: var(--ui-foreground);
+  background: var(--ui-background);
+  border: 1px solid var(--ui-border);
+  border-radius: var(--ui-radius);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.palette-panel > p {
+  margin: 0 0 24px;
+  color: var(--ui-muted-foreground);
+}
+.palette-group + .palette-group {
+  margin-top: 24px;
+}
+.palette-group h3 {
+  margin: 0 0 10px;
+  color: var(--ui-muted-foreground);
+  font-size: 12px;
+  font-weight: 500;
+}
+.palette-grid {
+  display: grid;
+  gap: 8px;
+}
+.palette-swatch {
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+}
+.palette-color {
+  height: 32px;
+  border: 1px solid var(--ui-border);
+  border-radius: 4px;
+}
+.palette-swatch code {
+  overflow-wrap: anywhere;
+  font-size: 11px;
+}
 .code-editor-story {
   border-radius: 0;
   position: relative;

--- a/packages/open-flow/dev/designer/workflow.tsx
+++ b/packages/open-flow/dev/designer/workflow.tsx
@@ -1,0 +1,214 @@
+import type { FlowDesignerViewModel } from '../../src/designer/browser/graph/FlowDesigner/model.ts'
+import type { UiLanguage } from '../../src/localization/common/languages.ts'
+import type { DesignerStory, LogAction } from './stories.tsx'
+
+import { useState } from 'react'
+import { FlowDesignerView } from '../../src/designer/browser/graph/FlowDesigner/FlowDesignerView.tsx'
+import { Button } from '../../src/ui/browser/button.tsx'
+
+const workflowViewport = { x: 35, y: 50, zoom: 0.65 }
+const workflowPositions = {
+  trigger: { x: 0, y: 0 },
+  task: { x: 560, y: 0 },
+  condition: { x: 1120, y: 0 },
+  value: { x: 0, y: 500 },
+  subflow: { x: 560, y: 640 },
+}
+const stateViewport = { x: 35, y: 60, zoom: 0.65 }
+const statePositions = Object.fromEntries(
+  ['idle', 'selected', 'waiting', 'running', 'success', 'error'].map((id, index) => [id, { x: (index % 3) * 510, y: Math.floor(index / 3) * 370 }]),
+)
+
+const workflow: FlowDesignerViewModel = {
+  viewport: workflowViewport,
+  variableNames: ['API_KEY', 'BASE_URL'],
+  variableNamesLoaded: true,
+  nodes: [
+    {
+      id: 'trigger',
+      kind: 'trigger',
+      title: 'Cron · Daily digest',
+      position: workflowPositions.trigger,
+      inputs: [],
+      outputs: [{ handle: 'tick', jsonSchema: { type: 'object' } }],
+      presentation: { kind: 'cron', schedules: [{ type: 'cron', expression: '0 9 * * *', timezone: 'Asia/Shanghai' }] },
+    },
+    {
+      id: 'task',
+      kind: 'task',
+      title: 'Task · Fetch records',
+      description: 'Grouped inputs, connected ports and a Variable binding.',
+      reference: 'lab/fetch-records',
+      executorName: 'JavaScript',
+      icon: ':carbon:code:',
+      position: workflowPositions.task,
+      inputs: [
+        { group: 'Request' },
+        { handle: 'tick', jsonSchema: { type: 'object' }, sources: [{ nodeId: 'trigger', output: 'tick' }] },
+        { handle: 'url', jsonSchema: { type: 'string' }, value: 'https://example.com/records' },
+        { handle: 'method', jsonSchema: { type: 'string', enum: ['GET', 'POST', 'PUT'] }, value: 'GET' },
+        { group: 'Options' },
+        { handle: 'limit', jsonSchema: { type: 'integer', minimum: 1, maximum: 100 }, value: 20 },
+        { handle: 'enabled', jsonSchema: { type: 'boolean' }, value: true },
+        { handle: 'token', jsonSchema: { type: 'string' }, variable: 'API_KEY', variableCompatible: true },
+      ],
+      outputs: [
+        { handle: 'records', jsonSchema: { type: 'array', items: { type: 'object' } } },
+        { handle: 'count', jsonSchema: { type: 'number' } },
+      ],
+    },
+    {
+      id: 'condition',
+      kind: 'condition',
+      title: 'Condition · Has records',
+      position: workflowPositions.condition,
+      inputs: [{ handle: 'count', jsonSchema: { type: 'number' }, sources: [{ nodeId: 'task', output: 'count' }] }],
+      outputs: [
+        { handle: 'matched', jsonSchema: { type: 'number' } },
+        { handle: 'fallback', jsonSchema: { type: 'number' } },
+      ],
+      cases: [{ expressions: [{ input: 'count', operator: '>', value: 0 }], output: 'matched', relation: 'all' }],
+      defaultOutput: 'fallback',
+    },
+    {
+      id: 'value',
+      kind: 'value',
+      title: 'Value · Settings',
+      position: workflowPositions.value,
+      inputs: [],
+      outputs: [{ handle: 'settings', jsonSchema: { type: 'object' } }],
+      values: [{ handle: 'settings', jsonSchema: { type: 'object' }, value: { channel: 'updates', format: 'markdown', retries: 3 } }],
+    },
+    {
+      id: 'subflow',
+      kind: 'subflow',
+      title: 'Subflow · Build digest',
+      reference: 'lab/build-digest',
+      position: workflowPositions.subflow,
+      inputs: [
+        { handle: 'records', jsonSchema: { type: 'array', items: { type: 'object' } }, sources: [{ nodeId: 'task', output: 'records' }] },
+        { handle: 'settings', jsonSchema: { type: 'object' }, sources: [{ nodeId: 'value', output: 'settings' }] },
+      ],
+      outputs: [{ handle: 'text', jsonSchema: { type: 'string' } }],
+    },
+    {
+      id: 'comment',
+      kind: 'comment',
+      title: 'Comment · Review notes',
+      position: { x: 1120, y: 590 },
+      content:
+        '### Workflow palette\nCompare node headers, fields, ports and connections.\n\n- Select a node to inspect its outline.\n- Switch between detail and overview.\n- Hover controls to inspect their feedback.',
+    },
+  ],
+}
+
+const states: FlowDesignerViewModel = {
+  viewport: stateViewport,
+  runStatus: 'running',
+  nodes: (
+    [
+      { id: 'idle', title: 'Idle', run: { status: 'idle' } },
+      { id: 'selected', title: 'Selected', run: { status: 'idle' } },
+      { id: 'waiting', title: 'Waiting', run: { status: 'waiting' } },
+      { id: 'running', title: 'Running · 42%', run: { status: 'running', progress: 42 } },
+      { id: 'success', title: 'Success · 3 executions', run: { status: 'success', progress: 100, successCount: 3 } },
+      { id: 'error', title: 'Error · Invalid input', run: { status: 'error' } },
+    ] as const
+  ).map((node) => ({
+    id: node.id,
+    title: node.title,
+    run: node.run,
+    diagnostics: node.id == 'error' ? 1 : undefined,
+    kind: 'task',
+    reference: 'lab/status',
+    position: statePositions[node.id],
+    inputs: [{ handle: 'message', jsonSchema: { type: 'string' }, value: 'Sample input' }],
+    outputs: [{ handle: 'result', jsonSchema: { type: 'string' } }],
+  })),
+}
+
+function WorkflowStory({
+  dark,
+  language,
+  log,
+  model,
+}: {
+  readonly dark: boolean
+  readonly language: UiLanguage
+  readonly log: LogAction
+  readonly model: FlowDesignerViewModel
+}) {
+  const [version, setVersion] = useState(0)
+  const [selected, setSelected] = useState<readonly string[]>([model == states ? 'selected' : 'task'])
+  return (
+    <div className="workflow-story">
+      <div className="overview-toolbar open-flow-workbench">
+        <span>Local samples · select, pan, zoom and switch display mode. Actions appear in the log.</span>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => {
+            setSelected([model == states ? 'selected' : 'task'])
+            setVersion((value) => value + 1)
+            log('samples.reset')
+          }}
+        >
+          Reset samples
+        </Button>
+      </div>
+      <div className="workflow-canvas">
+        <FlowDesignerView
+          key={version}
+          identity={`lab:${model == states ? 'states' : 'workflow'}:${version}`}
+          autoLayout
+          dark={dark}
+          language={language}
+          layoutMotion={false}
+          editable
+          model={model}
+          addItems={[]}
+          selectedNodeIds={selected}
+          createSchemaEditor={() => () => undefined}
+          onAddNode={(item) => {
+            log('node.add', item)
+            return undefined
+          }}
+          onConnect={(edge) => log('edge.connect', edge)}
+          onDisconnect={(edge) => log('edge.disconnect', edge)}
+          onDeleteNodes={(ids) => log('node.delete', ids)}
+          onDuplicate={(ids) => log('node.duplicate', ids)}
+          onPaste={(position) => log('canvas.paste', position)}
+          onMoveNodes={(positions) => log('node.move', positions)}
+          onMoveViewport={(viewport) => log('canvas.move', viewport)}
+          onSelectionChange={(ids, edge) => {
+            setSelected(ids)
+            log('selection.change', edge ?? ids)
+          }}
+          onChangeInput={(node, handle, value) => log('input.change', { node, handle, value })}
+          onChangeInputVariable={(node, handle, name) => log('variable.change', { node, handle, name })}
+          onChangeValue={(node, values) => log('value.change', { node, values })}
+          onChangeCondition={(node, value) => log('condition.change', { node, value })}
+          onChangeComment={(node, value) => log('comment.change', { node, value })}
+          onChangeTriggerSchedule={(node, value) => log('schedule.change', { node, value })}
+        />
+      </div>
+    </div>
+  )
+}
+
+export const workflowStories: readonly DesignerStory[] = [
+  {
+    group: 'Theme Preview',
+    id: 'workflow',
+    title: 'Workflow components',
+    standalone: true,
+    render: (log, dark, language) => <WorkflowStory dark={dark} language={language} log={log} model={workflow} />,
+  },
+  {
+    group: 'Theme Preview',
+    id: 'node-states',
+    title: 'Node states',
+    standalone: true,
+    render: (log, dark, language) => <WorkflowStory dark={dark} language={language} log={log} model={states} />,
+  },
+]

--- a/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesigner.tsx
+++ b/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesigner.tsx
@@ -15,6 +15,7 @@ export interface FlowDesignerProps {
   flowDesignerStore: FlowDesignerStore
   dark: boolean
   fitView?: boolean
+  layoutMotion?: boolean
   className?: string
   addNodeRequest?: ReactFlowContainerProps['addNodeRequest']
   addItemRequest?: ReactFlowContainerProps['addItemRequest']
@@ -29,6 +30,7 @@ export const FlowDesigner: React.FC<FlowDesignerProps> = ({
   flowDesignerStore,
   dark,
   fitView,
+  layoutMotion,
   className,
   addNodeRequest,
   addItemRequest,
@@ -57,6 +59,7 @@ export const FlowDesigner: React.FC<FlowDesignerProps> = ({
           dottedBackground
           fitView={fitView ?? !editable}
           fitViewOptions={fitViewOptions}
+          layoutMotion={layoutMotion}
           nodeTypes={NODE_TYPES}
           edgeTypes={FLOW_EDGE_TYPES}
           miniMapExpanded$={flowDesignerStore.$$.miniMapExpanded}

--- a/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.test.tsx
+++ b/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.test.tsx
@@ -1194,6 +1194,17 @@ describe('FlowDesignerView model synchronization', () => {
     view.props.flowDesignerStore.dispose()
   })
 
+  it('runs the initial graph layout when requested by the host', () => {
+    const view = FlowDesignerView(props(model([task([])]), { autoLayout: true })) as React.ReactElement<FlowDesignerProps>
+    const store = view.props.flowDesignerStore
+    const node = [...store.$.nodes.values()][0]
+    if (node == null) throw new Error('Expected a Task node.')
+    node.$$.rfNode.set({ ...node.$.rfNode.value, measured: { width: 420, height: 240 } })
+
+    expect(store.completeDisplayModeLayout()).toBe('relayout')
+    store.dispose()
+  })
+
   it('restores the saved overview viewport without replacing shared positions', () => {
     const value: FlowDesignerViewModel = {
       layouts: {

--- a/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.tsx
+++ b/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.tsx
@@ -41,7 +41,16 @@ function callbacksFromProps(props: FlowDesignerViewProps): ViewCallbacks {
 
 export function FlowDesignerView(props: FlowDesignerViewProps): ReactElement {
   const adapter = useMemo(
-    () => new FlowDesignerViewAdapter(props.model, props.editable, props.language ?? 'en', props.addItems, callbacksFromProps(props), props.createSchemaEditor),
+    () =>
+      new FlowDesignerViewAdapter(
+        props.model,
+        props.editable,
+        props.language ?? 'en',
+        props.addItems,
+        callbacksFromProps(props),
+        props.createSchemaEditor,
+        props.autoLayout,
+      ),
     [props.identity],
   )
   const propsRef = useRef(props)
@@ -115,6 +124,7 @@ export function FlowDesignerView(props: FlowDesignerViewProps): ReactElement {
       flowDesignerStore={adapter.store}
       isValidConnection={isValidConnection}
       key={props.identity}
+      layoutMotion={props.layoutMotion}
       onMoveEnd={onMoveEnd}
       onNodeDragStop={onNodeDragStop}
       onDropAddItem={onDropAddItem}

--- a/packages/open-flow/src/designer/browser/graph/FlowDesigner/adapter.ts
+++ b/packages/open-flow/src/designer/browser/graph/FlowDesigner/adapter.ts
@@ -111,6 +111,7 @@ export class FlowDesignerViewAdapter {
     addItems: readonly FlowDesignerViewAddItem[],
     callbacks: ViewCallbacks,
     createSchemaEditor: CreateSchemaEditorFn,
+    autoLayout = false,
   ) {
     this.#addItems = addItems
     this.#callbacks = callbacks
@@ -226,7 +227,7 @@ export class FlowDesignerViewAdapter {
     this.store.dispose.add(this.#language)
     this.#syncModel(model)
     designerUIStore.loadDesignerUIData({ layouts: model.layouts }, 'overview')
-    designerUIStore.completeActiveLayout()
+    if (!autoLayout) designerUIStore.completeActiveLayout()
   }
 
   #cancelPendingDisconnects(): void {

--- a/packages/open-flow/src/designer/browser/graph/FlowDesigner/model.ts
+++ b/packages/open-flow/src/designer/browser/graph/FlowDesigner/model.ts
@@ -286,6 +286,7 @@ export interface FlowDesignerViewProps {
     readonly screenPosition?: FlowDesignerViewPosition
   }
   readonly addItems: readonly FlowDesignerViewAddItem[]
+  readonly autoLayout?: boolean
   readonly className?: string
   readonly createSchemaEditor: CreateSchemaEditorFn
   readonly dark?: boolean
@@ -297,6 +298,7 @@ export interface FlowDesignerViewProps {
   readonly identity: string
   readonly isValidConnection?: (edge: Omit<FlowDesignerViewEdge, 'id'>) => boolean
   readonly language?: string
+  readonly layoutMotion?: boolean
   readonly model: FlowDesignerViewModel
   readonly onAddNode: (
     itemId: string,

--- a/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.module.scss
+++ b/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.module.scss
@@ -84,6 +84,10 @@
   }
 }
 
+.layoutPending :global(.react-flow__viewport) {
+  opacity: 0;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .switchingDisplayMode :global(.react-flow__node) {
     transition: none;

--- a/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.tsx
+++ b/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.tsx
@@ -168,6 +168,7 @@ export interface ReactFlowContainerProps {
   onAddHandle?: (options: IAddHandleOptions) => void
   fitView?: boolean
   fitViewOptions?: FitViewOptions
+  layoutMotion?: boolean
   dottedBackground?: boolean
   children?: React.ReactNode
 }
@@ -208,7 +209,7 @@ export const ReactFlowContainer: React.FC<ReactFlowContainerProps> = (props: Rea
 
 type FlowControlsProps = Pick<
   ReactFlowContainerProps,
-  'miniMapExpanded$' | 'displayMode$' | 'interactiveMode$' | 'showSettings$' | 'onRelayout' | 'onFitView' | 'dottedBackground'
+  'miniMapExpanded$' | 'displayMode$' | 'interactiveMode$' | 'showSettings$' | 'onRelayout' | 'onFitView' | 'dottedBackground' | 'layoutMotion'
 > & { onBeforeFitView?: () => void }
 
 const selector = (s: ReactFlowState) => ({
@@ -228,7 +229,7 @@ const FlowControls = /*#__PURE__*/ memo((props: FlowControlsProps) => {
   const selectedNodes = nodes.filter((node) => node.selected)
   const fitViewOptions: FitViewOptions = {
     padding: 0.15,
-    duration: 150,
+    duration: props.layoutMotion === false ? 0 : 150,
     maxZoom: 1,
   }
 
@@ -499,10 +500,16 @@ const ReactFlowContainerInner = (props: ReactFlowContainerProps) => {
   const displayModeMounted = useRef(false)
   const [switchingDisplayMode, setSwitchingDisplayMode] = useState(false)
   const [fittingView, setFittingView] = useState(false)
+  const [layoutReady, setLayoutReady] = useState(props.layoutMotion !== false || props.onDisplayModeMeasured == null)
   const onBeforeFitView = useCallback(() => setFittingView(true), [])
+
+  useLayoutEffect(() => {
+    setLayoutReady(props.layoutMotion !== false || props.onDisplayModeMeasured == null)
+  }, [overview, props.layoutMotion, props.onDisplayModeMeasured])
 
   useEffect(() => {
     let measurementFrame = 0
+    let readyFrame = 0
     let fitTimer: ReturnType<typeof setTimeout> | undefined
     let attempts = 0
     const completeLayout = () => {
@@ -511,9 +518,15 @@ const ReactFlowContainerInner = (props: ReactFlowContainerProps) => {
         measurementFrame = requestAnimationFrame(completeLayout)
       } else if (result === 'relayout') {
         onBeforeFitView()
-        fitTimer = setTimeout(() => {
-          rf.fitView({ padding: 0.15, duration: 150, maxZoom: 1 })
-        }, DISPLAY_MODE_REFLOW_DELAY)
+        fitTimer = setTimeout(
+          () => {
+            rf.fitView({ padding: 0.15, duration: props.layoutMotion === false ? 0 : 150, maxZoom: 1 })
+            readyFrame = requestAnimationFrame(() => setLayoutReady(true))
+          },
+          props.layoutMotion === false ? 0 : DISPLAY_MODE_REFLOW_DELAY,
+        )
+      } else {
+        setLayoutReady(true)
       }
     }
     const frame = requestAnimationFrame(() => {
@@ -522,7 +535,7 @@ const ReactFlowContainerInner = (props: ReactFlowContainerProps) => {
     })
     let transitionTimer: ReturnType<typeof setTimeout> | undefined
     const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-    if (displayModeMounted.current && !reduceMotion) {
+    if (displayModeMounted.current && props.layoutMotion !== false && !reduceMotion) {
       setSwitchingDisplayMode(true)
       transitionTimer = setTimeout(() => setSwitchingDisplayMode(false), DISPLAY_MODE_TRANSITION_DURATION)
     } else {
@@ -533,10 +546,11 @@ const ReactFlowContainerInner = (props: ReactFlowContainerProps) => {
     return () => {
       cancelAnimationFrame(frame)
       cancelAnimationFrame(measurementFrame)
+      cancelAnimationFrame(readyFrame)
       if (fitTimer) clearTimeout(fitTimer)
       if (transitionTimer) clearTimeout(transitionTimer)
     }
-  }, [onBeforeFitView, overview, props.onDisplayModeMeasured, rf, updateNodeInternals])
+  }, [onBeforeFitView, overview, props.layoutMotion, props.onDisplayModeMeasured, rf, updateNodeInternals])
 
   const viewport = useVal(props.viewport$)
   const nonEmptyViewport = useRef(viewport)
@@ -675,11 +689,12 @@ const ReactFlowContainerInner = (props: ReactFlowContainerProps) => {
             DESIGNER_CLASSNAME,
             interactiveMode,
             fittingView && FITTING_VIEW_CLASSNAME,
+            !layoutReady && styles.layoutPending,
             switchingDisplayMode && styles.switchingDisplayMode,
           )}
           style={
             {
-              '--display-mode-transition-duration': `${DISPLAY_MODE_TRANSITION_DURATION}ms`,
+              '--display-mode-transition-duration': `${props.layoutMotion === false ? 0 : DISPLAY_MODE_TRANSITION_DURATION}ms`,
             } as React.CSSProperties
           }
           colorMode={props.dark ? 'dark' : 'light'}
@@ -740,6 +755,7 @@ const ReactFlowContainerInner = (props: ReactFlowContainerProps) => {
             miniMapExpanded$={props.miniMapExpanded$}
             displayMode$={props.displayMode$}
             interactiveMode$={props.interactiveMode$}
+            layoutMotion={props.layoutMotion}
             onBeforeFitView={onBeforeFitView}
             onRelayout={overview ? undefined : props.onRelayout}
             onFitView={props.onFitView}

--- a/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.tsx
+++ b/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.tsx
@@ -508,6 +508,7 @@ const ReactFlowContainerInner = (props: ReactFlowContainerProps) => {
   }, [overview, props.layoutMotion, props.onDisplayModeMeasured])
 
   useEffect(() => {
+    let active = true
     let measurementFrame = 0
     let readyFrame = 0
     let fitTimer: ReturnType<typeof setTimeout> | undefined
@@ -519,8 +520,9 @@ const ReactFlowContainerInner = (props: ReactFlowContainerProps) => {
       } else if (result === 'relayout') {
         onBeforeFitView()
         fitTimer = setTimeout(
-          () => {
-            rf.fitView({ padding: 0.15, duration: props.layoutMotion === false ? 0 : 150, maxZoom: 1 })
+          async () => {
+            await rf.fitView({ padding: 0.15, duration: props.layoutMotion === false ? 0 : 150, maxZoom: 1 })
+            if (!active) return
             readyFrame = requestAnimationFrame(() => setLayoutReady(true))
           },
           props.layoutMotion === false ? 0 : DISPLAY_MODE_REFLOW_DELAY,
@@ -544,6 +546,7 @@ const ReactFlowContainerInner = (props: ReactFlowContainerProps) => {
     setEdgeContextMenu(null)
     setBlockQuickPickPanel(null)
     return () => {
+      active = false
       cancelAnimationFrame(frame)
       cancelAnimationFrame(measurementFrame)
       cancelAnimationFrame(readyFrame)


### PR DESCRIPTION
## Summary

- Add workflow component and node-state samples to the Designer Lab.
- Add control, workbench, and theme palette previews with light/dark support.
- Make sample rendering deterministic and expose language changes in stories.
- Add optional auto-layout and layout-motion controls to FlowDesigner.

## Testing

- Added coverage for initial graph layout behavior.
- Not run (not requested).