### PR TITLE
fix(designer): keep store active across effect cleanup

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,7 @@
     },
     "packages/command": {
       "name": "@oomol-lab/open-flow-command",
-      "version": "0.1.0-beta.8",
+      "version": "0.1.0-beta.9",
       "dependencies": {
         "@oomol-lab/open-flow": "workspace:*",
         "@wopjs/cast": "^0.1.16",
@@ -63,7 +63,7 @@
     },
     "packages/open-flow": {
       "name": "@oomol-lab/open-flow",
-      "version": "0.1.0-beta.8",
+      "version": "0.1.0-beta.9",
       "devDependencies": {
         "@babel/parser": "8.0.4",
         "@babel/traverse": "8.0.4",

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oomol-lab/open-flow-command",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "description": "Open Flow command runtime and immutable Command Artifact builder.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/open-flow/package.json
+++ b/packages/open-flow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oomol-lab/open-flow",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "description": "Portable contracts and shared browser runtime for Open Flow.",
   "keywords": [
     "ai",

--- a/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.test.tsx
+++ b/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.test.tsx
@@ -23,6 +23,7 @@ const hooks = vi.hoisted(() => ({
   effectIndex: 0,
   effects: [] as (readonly unknown[] | undefined)[],
   memo: undefined as unknown,
+  memoDependencies: undefined as readonly unknown[] | undefined,
   refIndex: 0,
   refs: [] as { current: unknown }[],
 }))
@@ -41,6 +42,7 @@ vi.mock('react', async (importOriginal) => {
       dependencies.length != previous.length ||
       dependencies.some((dependency, dependencyIndex) => dependency !== previous[dependencyIndex])
     ) {
+      hooks.cleanups[index]?.()
       const cleanup = callback()
       hooks.cleanups[index] = typeof cleanup == 'function' ? cleanup : undefined
     }
@@ -50,10 +52,21 @@ vi.mock('react', async (importOriginal) => {
     useCallback: <T,>(callback: T) => callback,
     useEffect: effect,
     useLayoutEffect: effect,
-    useMemo: <T,>(factory: () => T) => {
+    useMemo: <T,>(factory: () => T, dependencies?: readonly unknown[]) => {
       hooks.effectIndex = 0
       hooks.refIndex = 0
-      return (hooks.memo ??= factory()) as T
+      const previous = hooks.memoDependencies
+      if (
+        hooks.memo === undefined ||
+        dependencies == null ||
+        previous == null ||
+        dependencies.length != previous.length ||
+        dependencies.some((dependency, dependencyIndex) => dependency !== previous[dependencyIndex])
+      ) {
+        hooks.memo = factory()
+        hooks.memoDependencies = dependencies
+      }
+      return hooks.memo as T
     },
     useRef: <T,>(value: T) => {
       const index = hooks.refIndex++
@@ -185,6 +198,7 @@ describe('FlowDesignerView model synchronization', () => {
     hooks.effectIndex = 0
     hooks.effects = []
     hooks.memo = undefined
+    hooks.memoDependencies = undefined
     hooks.refIndex = 0
     hooks.refs = []
   })
@@ -206,6 +220,18 @@ describe('FlowDesignerView model synchronization', () => {
       error.mockRestore()
       view.props.flowDesignerStore.dispose()
     }
+  })
+
+  it('disposes the adapter replaced by a new identity', () => {
+    const first = FlowDesignerView(props(model([]))) as React.ReactElement<FlowDesignerProps>
+    const disposed = vi.fn()
+    first.props.flowDesignerStore.dispose.add(disposed)
+
+    const second = FlowDesignerView(props(model([]), { identity: 'flow:next' })) as React.ReactElement<FlowDesignerProps>
+
+    expect(second.props.flowDesignerStore).not.toBe(first.props.flowDesignerStore)
+    expect(disposed).toHaveBeenCalledOnce()
+    second.props.flowDesignerStore.dispose()
   })
 
   it('does not publish unchanged Variable projections while mounting', () => {

--- a/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.test.tsx
+++ b/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.test.tsx
@@ -25,7 +25,6 @@ const hooks = vi.hoisted(() => ({
   memo: undefined as unknown,
   refIndex: 0,
   refs: [] as { current: unknown }[],
-  setups: [] as (() => void | (() => void))[],
 }))
 
 vi.mock('virtual:uno.css', () => ({}))
@@ -36,7 +35,6 @@ vi.mock('react', async (importOriginal) => {
     const index = hooks.effectIndex++
     const previous = hooks.effects[index]
     hooks.effects[index] = dependencies
-    hooks.setups[index] = callback
     if (
       dependencies == null ||
       previous == null ||
@@ -166,14 +164,6 @@ function captureIdleValidation(): () => void {
   }
 }
 
-function replayEffects(): void {
-  for (const cleanup of hooks.cleanups) cleanup?.()
-  for (const [index, setup] of hooks.setups.entries()) {
-    const cleanup = setup()
-    hooks.cleanups[index] = typeof cleanup == 'function' ? cleanup : undefined
-  }
-}
-
 function firstInput(store: FlowDesignerProps['flowDesignerStore']) {
   const node = [...store.$.nodes.values()][0]
   if (node == null) throw new Error('Expected a node.')
@@ -197,17 +187,16 @@ describe('FlowDesignerView model synchronization', () => {
     hooks.memo = undefined
     hooks.refIndex = 0
     hooks.refs = []
-    hooks.setups = []
   })
 
-  it('continues reconciling after React replays effect cleanup', () => {
+  it('continues reconciling while React has effects unmounted', () => {
     vi.useFakeTimers()
     const initial = props(model([task([])]), { editable: false })
     const view = FlowDesignerView(initial) as React.ReactElement<FlowDesignerProps>
     const error = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     try {
-      replayEffects()
+      for (const cleanup of hooks.cleanups) cleanup?.()
       vi.runOnlyPendingTimers()
       FlowDesignerView(props(model([task([])]), { editable: true }))
 
@@ -217,20 +206,6 @@ describe('FlowDesignerView model synchronization', () => {
       error.mockRestore()
       view.props.flowDesignerStore.dispose()
     }
-  })
-
-  it('disposes the Designer store after a real effect cleanup', async () => {
-    vi.useFakeTimers()
-    const view = FlowDesignerView(props(model([task([])]))) as React.ReactElement<FlowDesignerProps>
-    const store = view.props.flowDesignerStore
-
-    expect(store.dispose.size()).toBeGreaterThan(0)
-    for (const cleanup of hooks.cleanups) cleanup?.()
-    await Promise.resolve()
-    expect(store.dispose.size()).toBeGreaterThan(0)
-    vi.runOnlyPendingTimers()
-
-    expect(store.dispose.size()).toBe(0)
   })
 
   it('does not publish unchanged Variable projections while mounting', () => {

--- a/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.tsx
+++ b/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.tsx
@@ -53,6 +53,7 @@ export function FlowDesignerView(props: FlowDesignerViewProps): ReactElement {
       ),
     [props.identity],
   )
+  const previousAdapter = useRef(adapter)
   const propsRef = useRef(props)
   const selectedEdge = useRef<string>()
   propsRef.current = props
@@ -101,7 +102,12 @@ export function FlowDesignerView(props: FlowDesignerViewProps): ReactElement {
   }, [])
   const onDropAddItem = useCallback((itemId: string, position: FlowDesignerViewPosition) => adapter.addNode(itemId, position), [adapter])
 
-  useEffect(() => () => adapter.cancelPendingDisconnects(), [adapter])
+  useEffect(() => {
+    const previous = previousAdapter.current
+    previousAdapter.current = adapter
+    if (previous !== adapter) previous.store.dispose()
+    return () => adapter.cancelPendingDisconnects()
+  }, [adapter])
   useLayoutEffect(() => adapter.setCallbacks(callbacksFromProps(props)))
   useLayoutEffect(() => {
     adapter.reconcile(props.model, props.editable, props.language ?? 'en', props.addItems)

--- a/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.tsx
+++ b/packages/open-flow/src/designer/browser/graph/FlowDesigner/FlowDesignerView.tsx
@@ -101,7 +101,7 @@ export function FlowDesignerView(props: FlowDesignerViewProps): ReactElement {
   }, [])
   const onDropAddItem = useCallback((itemId: string, position: FlowDesignerViewPosition) => adapter.addNode(itemId, position), [adapter])
 
-  useEffect(() => adapter.mount(), [adapter])
+  useEffect(() => () => adapter.cancelPendingDisconnects(), [adapter])
   useLayoutEffect(() => adapter.setCallbacks(callbacksFromProps(props)))
   useLayoutEffect(() => {
     adapter.reconcile(props.model, props.editable, props.language ?? 'en', props.addItems)

--- a/packages/open-flow/src/designer/browser/graph/FlowDesigner/adapter.ts
+++ b/packages/open-flow/src/designer/browser/graph/FlowDesigner/adapter.ts
@@ -83,7 +83,6 @@ export class FlowDesignerViewAdapter {
   readonly #callbacks: ViewCallbacks
   readonly #createSchemaEditor: CreateSchemaEditorFn
   #disconnectTimer: ReturnType<typeof setTimeout> | undefined
-  #disposeTimer: ReturnType<typeof setTimeout> | undefined
   #entries = new Map<string, NodeEntry>()
   #language: Val<string>
   #modelPositions = new Map<string, FlowDesignerViewPosition>()
@@ -230,22 +229,10 @@ export class FlowDesignerViewAdapter {
     if (!autoLayout) designerUIStore.completeActiveLayout()
   }
 
-  #cancelPendingDisconnects(): void {
+  cancelPendingDisconnects(): void {
     if (this.#disconnectTimer != null) clearTimeout(this.#disconnectTimer)
     this.#disconnectTimer = undefined
     this.#pendingDisconnects.clear()
-  }
-
-  mount(): () => void {
-    if (this.#disposeTimer != null) clearTimeout(this.#disposeTimer)
-    this.#disposeTimer = undefined
-    return () => {
-      this.#cancelPendingDisconnects()
-      this.#disposeTimer = setTimeout(() => {
-        this.#disposeTimer = undefined
-        this.store.dispose()
-      }, 0)
-    }
   }
 
   setCallbacks(callbacks: ViewCallbacks): void {


### PR DESCRIPTION
## Summary

- keep the Flow Designer store usable when React cleans up effects while preserving component state
- limit effect cleanup to pending disconnect work and cover reconciliation while effects are unmounted
- bump `@oomol-lab/open-flow` and `@oomol-lab/open-flow-command` to `0.1.0-beta.9`

## Verification

- `bun run format`
- `bun run check`
- `bun run test` (754 Open Flow, 56 Command, and 262 Server tests)
- `bun run build`
- `bun run test:package`