### PR TITLE
fix(server): parameterize SQL condition in #recoverRunning

### DIFF
--- a/apps/server/node/store.ts
+++ b/apps/server/node/store.ts
@@ -289,7 +289,7 @@ export class Store {
   resolveVariables(bindings: Readonly<Record<string, string>>): Readonly<Record<string, string>> | undefined {
     const names = [...new Set(Object.values(bindings))]
     if (names.length == 0) return {}
-    this.#database.exec('BEGIN')
+    this.#database.exec('BEGIN IMMEDIATE')
     try {
       const rows = this.#database
         .prepare(`SELECT name, value FROM variables WHERE name IN (${names.map(() => '?').join(', ')})`)
@@ -1416,10 +1416,10 @@ export class Store {
       .run(runId, cursor, kind, JSON.stringify(payload), value === undefined ? null : JSON.stringify(value), this.#clock())
   }
 
-  #finishRun(runId: string, status: RunTerminalStatus, result: unknown, condition: string, finishedAt: number): boolean {
+  #finishRun(runId: string, status: RunTerminalStatus, result: unknown, condition: string, finishedAt: number, ...conditionParams: readonly unknown[]): boolean {
     const changed = this.#database
       .prepare(`UPDATE runs SET status = ?, result = ?, finished_at = ?, events_expires_at = ? WHERE run_id = ? AND ${condition}`)
-      .run(status, JSON.stringify(result), finishedAt, finishedAt + this.#runEventRetentionMs, runId)
+      .run(status, JSON.stringify(result), finishedAt, finishedAt + this.#runEventRetentionMs, runId, ...conditionParams)
     if (changed.changes != 1) return false
     this.#database.prepare('UPDATE run_waits SET checkpoint_json = NULL WHERE run_id = ?').run(runId)
     this.#database.prepare('DELETE FROM wait_notifications WHERE run_id = ?').run(runId)
@@ -1583,13 +1583,7 @@ export class Store {
     for (const row of resumes) {
       if (this.#checkpointValid(row.checkpointJson, row.checkpointDigest, row.checkpointBytes, row.waitId)) continue
       this.#transaction(() =>
-        this.#finishRun(
-          row.runId,
-          'indeterminate',
-          { error: { code: 'execution.resume-unavailable', message: 'The stored Wait checkpoint is unavailable.' } },
-          `status = '${row.status}'`,
-          this.#clock(),
-        ),
+        this.#finishRun(row.runId, 'indeterminate', { error: { code: 'execution.resume-unavailable', message: 'The stored Wait checkpoint is unavailable.' } }, 'status = ?', this.#clock(), row.status),
       )
     }
   }

--- a/apps/server/node/store.ts
+++ b/apps/server/node/store.ts
@@ -289,7 +289,7 @@ export class Store {
   resolveVariables(bindings: Readonly<Record<string, string>>): Readonly<Record<string, string>> | undefined {
     const names = [...new Set(Object.values(bindings))]
     if (names.length == 0) return {}
-    this.#database.exec('BEGIN IMMEDIATE')
+    this.#database.exec('BEGIN')
     try {
       const rows = this.#database
         .prepare(`SELECT name, value FROM variables WHERE name IN (${names.map(() => '?').join(', ')})`)
@@ -1416,7 +1416,7 @@ export class Store {
       .run(runId, cursor, kind, JSON.stringify(payload), value === undefined ? null : JSON.stringify(value), this.#clock())
   }
 
-  #finishRun(runId: string, status: RunTerminalStatus, result: unknown, condition: string, finishedAt: number, ...conditionParams: readonly unknown[]): boolean {
+  #finishRun(runId: string, status: RunTerminalStatus, result: unknown, condition: string, finishedAt: number, ...conditionParams: readonly string[]): boolean {
     const changed = this.#database
       .prepare(`UPDATE runs SET status = ?, result = ?, finished_at = ?, events_expires_at = ? WHERE run_id = ? AND ${condition}`)
       .run(status, JSON.stringify(result), finishedAt, finishedAt + this.#runEventRetentionMs, runId, ...conditionParams)

--- a/apps/server/node/store.ts
+++ b/apps/server/node/store.ts
@@ -1583,7 +1583,14 @@ export class Store {
     for (const row of resumes) {
       if (this.#checkpointValid(row.checkpointJson, row.checkpointDigest, row.checkpointBytes, row.waitId)) continue
       this.#transaction(() =>
-        this.#finishRun(row.runId, 'indeterminate', { error: { code: 'execution.resume-unavailable', message: 'The stored Wait checkpoint is unavailable.' } }, 'status = ?', this.#clock(), row.status),
+        this.#finishRun(
+          row.runId,
+          'indeterminate',
+          { error: { code: 'execution.resume-unavailable', message: 'The stored Wait checkpoint is unavailable.' } },
+          'status = ?',
+          this.#clock(),
+          row.status,
+        ),
       )
     }
   }


### PR DESCRIPTION
## Summary

Replace string interpolation `status = '${row.status}'` with parameterized query `status = ?` in `#recoverRunning` to prevent potential SQL injection. Update `#finishRun` signature to accept variadic condition parameters for safe parameter binding.

## Changes

| File | Change |
|------|--------|
| `apps/server/node/store.ts` | Parameterize SQL condition in `#recoverRunning` |
| `apps/server/node/store.ts` | Add `...conditionParams` to `#finishRun` |

## Motivation

The original code used string interpolation to build a SQL WHERE condition from a value read from the database. While the value comes from a CHECK-constrained column, this breaks the parameterized query pattern used consistently elsewhere and could become exploitable if constraints are relaxed.

## Testing

Verified that existing server tests pass. The change is low-risk as it improves existing patterns without changing behavior.