### PR TITLE
fix(server): add SSE keepalive and exponential reconnect backoff

### DIFF
--- a/apps/server/browser/host.ts
+++ b/apps/server/browser/host.ts
@@ -1,6 +1,7 @@
 import type { FlowCatalogEvent, FlowChangeEvent, WorkbenchHost, WorkbenchNotification } from '@oomol-lab/open-flow/workbench'
 
-const reconnectDelayMs = 1_000
+const reconnectBaseMs = 1_000
+const reconnectMaxMs = 30_000
 
 export function createBrowserHost(notify: (notification: WorkbenchNotification | undefined) => void, sessionExpired: () => void): WorkbenchHost {
   return {
@@ -44,6 +45,7 @@ async function readConnections<Event>(
   signal: AbortSignal,
   sessionExpired: () => void,
 ): Promise<void> {
+  let attempt = 0
   while (!signal.aborted) {
     try {
       const response = await fetch(path, { credentials: 'same-origin', headers: { accept: 'text/event-stream' }, signal })
@@ -52,12 +54,14 @@ async function readConnections<Event>(
         return
       }
       if (!response.ok || response.body == null) throw new Error(`Notification request returned ${response.status}.`)
+      attempt = 0
       listener()
       await readEvents(response.body, listener, decode, signal)
     } catch {
       if (signal.aborted) return
     }
-    await reconnectDelay(signal)
+    await reconnectDelay(signal, attempt)
+    attempt++
   }
 }
 
@@ -107,14 +111,17 @@ function decodeFlowEvent(value: unknown): FlowChangeEvent | undefined {
   if (event.kind == 'run.created' && typeof event.runId == 'string') return event as FlowChangeEvent
 }
 
-async function reconnectDelay(signal: AbortSignal): Promise<void> {
+async function reconnectDelay(signal: AbortSignal, attempt: number): Promise<void> {
+  const delay = Math.min(reconnectBaseMs * 2 ** attempt, reconnectMaxMs)
+  const jitter = delay * 0.5 * Math.random()
+  const ms = Math.round(delay + jitter)
   await new Promise<void>((resolve) => {
     const done = (): void => {
       clearTimeout(timer)
       signal.removeEventListener('abort', done)
       resolve()
     }
-    const timer = setTimeout(done, reconnectDelayMs)
+    const timer = setTimeout(done, ms)
     signal.addEventListener('abort', done, { once: true })
   })
 }

--- a/apps/server/node/http.ts
+++ b/apps/server/node/http.ts
@@ -242,6 +242,8 @@ function notificationResponse(body: ReadableStream<Uint8Array>): Response {
   })
 }
 
+const keepaliveIntervalMs = 15_000
+
 function notifications<Event>(
   subscribe: (listener: (event: Event) => void) => () => void,
   signals: readonly (AbortSignal | undefined)[],
@@ -249,9 +251,11 @@ function notifications<Event>(
   let controller: ReadableStreamDefaultController<Uint8Array> | undefined
   let closed = false
   let unsubscribe: (() => void) | undefined
+  let keepaliveTimer: ReturnType<typeof setInterval> | undefined
   const cleanup = (): void => {
     if (closed) return
     closed = true
+    clearInterval(keepaliveTimer)
     for (const signal of signals) signal?.removeEventListener('abort', abort)
     unsubscribe?.()
   }
@@ -272,6 +276,9 @@ function notifications<Event>(
       if (signals.some((signal) => signal?.aborted)) return abort()
       for (const signal of signals) signal?.addEventListener('abort', abort, { once: true })
       streamController.enqueue(encoder.encode(': connected\n\n'))
+      keepaliveTimer = setInterval(() => {
+        if (!closed) streamController.enqueue(encoder.encode(': keepalive\n\n'))
+      }, keepaliveIntervalMs)
     },
   })
 }


### PR DESCRIPTION
## Summary

- Add periodic keepalive comments (`: keepalive`) to server-side SSE notification streams every 15 seconds to prevent proxy/LB timeouts.
- Replace fixed 1-second reconnect delay in the browser host with exponential backoff (1s base, 30s cap) plus random jitter to reduce connection churn during server outages.

## Changes

| File | Change |
|------|--------|
| `apps/server/node/http.ts` | Add keepalive timer to SSE notification streams |
| `apps/server/browser/host.ts` | Implement exponential backoff with jitter for reconnection |

## Motivation

Proxies, load balancers, and CDNs often drop idle SSE connections after 30-60 seconds. The server now sends keepalive comments to maintain the connection. On the client side, the fixed 1-second reconnect during outages creates unnecessary connection churn — exponential backoff with jitter is the standard solution.