### PR TITLE
fix(server): cache ConnectorClient instance to avoid per-call allocation

### DIFF
--- a/apps/server/node/settings.ts
+++ b/apps/server/node/settings.ts
@@ -16,6 +16,7 @@ export class Settings {
   readonly #environmentOrigin?: string
   readonly #logger: Logger
   readonly #store: SettingsStore
+  #connectorCache?: { readonly client: ConnectorClient; readonly origin: string; readonly revision: number; readonly token: string }
 
   constructor(
     store: SettingsStore,
@@ -50,9 +51,14 @@ export class Settings {
   connector(): ConnectorClient | undefined {
     if (this.#environmentConnector != null) return this.#environmentConnector
     const stored = this.#store.state()
-    return stored.connectorOrigin == null || stored.connectorToken == null
-      ? undefined
-      : new ConnectorClient(stored.connectorOrigin, stored.connectorToken, 30_000, this.#logger)
+    if (stored.connectorOrigin == null || stored.connectorToken == null) return undefined
+    const cache = this.#connectorCache
+    if (cache?.origin === stored.connectorOrigin && cache?.token === stored.connectorToken && cache?.revision === stored.revision) {
+      return cache.client
+    }
+    const client = new ConnectorClient(stored.connectorOrigin, stored.connectorToken, 30_000, this.#logger)
+    this.#connectorCache = { client, origin: stored.connectorOrigin, revision: stored.revision, token: stored.connectorToken }
+    return client
   }
 
   connectorConsoleOrigin(): URL | undefined {


### PR DESCRIPTION
## Summary

The `Settings.connector()` method created a new `ConnectorClient` on every call when using store-managed configuration. This caused unnecessary object allocation and potential connection churn on every flow operation (publish, run, webhook, etc.).

Cache the `ConnectorClient` instance and invalidate only when the settings revision, origin, or token changes.

## Changes

| File | Change |
|------|--------|
| `apps/server/node/settings.ts` | Add `#connectorCache` field and reuse cached instance |

## Behavior

- First call with new/changed settings: creates a new `ConnectorClient` and caches it.
- Subsequent calls with same settings: returns the cached instance.
- Settings update via `putConnector`/`deleteConnector`: next call creates a fresh instance (revision-based invalidation).