### PR TITLE
fix(command): add cleanup on extractCommandArchive failure and stable edge sort

### DIFF
--- a/packages/command/src/cli/node/support.ts
+++ b/packages/command/src/cli/node/support.ts
@@ -599,7 +599,11 @@ export function inspectedEdges(nodes: Readonly<Record<string, GraphNode>>) {
             })),
       )
     })
-    .toSorted((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)))
+    .toSorted((left, right) => {
+      const lk = `${left.target.nodeId}\0${left.input}\0${left.source.nodeId}\0${left.source.output}`
+      const rk = `${right.target.nodeId}\0${right.input}\0${right.source.nodeId}\0${right.source.output}`
+      return lk.localeCompare(rk)
+    })
 }
 
 export function requireCount(positionals: readonly string[], count: number, usage: string): void {

--- a/packages/command/src/distribution/node/commandArchive.ts
+++ b/packages/command/src/distribution/node/commandArchive.ts
@@ -279,6 +279,15 @@ export async function decodeCommandArchive(archive: Uint8Array): Promise<Decoded
 
 export async function extractCommandArchive(archive: Uint8Array, write: (entry: CommandArchiveEntry) => Promise<void>): Promise<CommandArtifactManifest> {
   const decoded = await decodeCommandArchive(archive)
-  for (const file of decoded.files) await write(file)
+  const written: CommandArchiveEntry[] = []
+  try {
+    for (const file of decoded.files) {
+      await write(file)
+      written.push(file)
+    }
+  } catch (error) {
+    for (const file of written) await write({ bytes: new Uint8Array(0), mode: file.mode, path: file.path })
+    throw error
+  }
   return decoded.manifest
 }


### PR DESCRIPTION
## Summary

- Track written files during `extractCommandArchive` and attempt cleanup by writing empty bytes on failure to reduce partial-extraction residue.
- Replace `JSON.stringify`-based edge sorting with explicit field concatenation for stable, deterministic output.

## Changes

| File | Change |
|------|--------|
| `packages/command/src/distribution/node/commandArchive.ts` | Add error recovery to `extractCommandArchive` |
| `packages/command/src/cli/node/support.ts` | Use stable key concatenation instead of `JSON.stringify` for edge sorting |

## Motivation

`extractCommandArchive` writes files sequentially with no error recovery. If `write` fails midway, partially-extracted archives are left on disk with no cleanup. The edge sorting used `JSON.stringify` which is fragile — property insertion order changes affect sort order.