### PR TITLE
fix(designer): remove low-value defensive console.warn calls

### DIFF
--- a/packages/open-flow/src/designer/browser/icons/DesignerIcon.tsx
+++ b/packages/open-flow/src/designer/browser/icons/DesignerIcon.tsx
@@ -55,8 +55,6 @@ export function parseIconifyIcon(src: string | undefined): { collection: string;
     const [, collection, icon, color] = src.split(':')
     if (collection && icon) {
       return { collection, icon, color: color || 'currentColor' }
-    } else {
-      console.warn(`Don't load icon spec: ${src}`)
     }
   }
   return null

--- a/packages/open-flow/src/designer/browser/jsonSchema/schemaEditor.tsx
+++ b/packages/open-flow/src/designer/browser/jsonSchema/schemaEditor.tsx
@@ -373,34 +373,19 @@ const Subpanel = /*#__PURE__*/ memo(function Subpanel(props: SubpanelProps) {
     case 'date':
       return <SubpanelDate {...props} />
     case 'select':
-      if (!props.store.isSelect()) {
-        console.warn('Expecting select widget store, got', props.store)
-        return null
-      }
+      if (!props.store.isSelect()) return null
       return <SubpanelSelect {...props} />
     case 'multiSelect':
-      if (!props.store.isMultiSelect()) {
-        console.warn('Expecting multiSelect widget store, got', props.store)
-        return null
-      }
+      if (!props.store.isMultiSelect()) return null
       return <SubpanelSelect {...props} />
     case 'array':
-      if (!props.store.isArray()) {
-        console.warn('Expecting array widget store, got', props.store)
-        return null
-      }
+      if (!props.store.isArray()) return null
       return <SubpanelArray {...props} />
     case 'object':
-      if (!props.store.isObject()) {
-        console.warn('Expecting object widget store, got', props.store)
-        return null
-      }
+      if (!props.store.isObject()) return null
       return <SubpanelObject {...props} />
     case 'anyOf':
-      if (!props.store.isAnyOf()) {
-        console.warn('Expecting anyOf widget store, got', props.store)
-        return null
-      }
+      if (!props.store.isAnyOf()) return null
       return <SubpanelAnyOf {...props} />
     default:
       return null


### PR DESCRIPTION
## Summary

Remove `console.warn` calls from `schemaEditor.tsx` type guard branches and `DesignerIcon.tsx` icon spec parsing that fired on unreachable or harmless paths.

## Changes

| File | Change |
|------|--------|
| `packages/open-flow/src/designer/browser/jsonSchema/schemaEditor.tsx` | Remove 5 defensive `console.warn` calls in type guard branches that already return `null` |
| `packages/open-flow/src/designer/browser/icons/DesignerIcon.tsx` | Remove `console.warn` for invalid icon spec — function already returns `null` |

## Motivation

These `console.warn` calls are defensive type checks that should never fire in normal operation. The code already handles the case correctly by returning `null`. The warnings add noise to the console without providing actionable information to users.