### PR TITLE
fix(server): add cache-control: no-store to JSON API responses

### DIFF
--- a/apps/server/node/http.ts
+++ b/apps/server/node/http.ts
@@ -485,7 +485,7 @@ async function readBody(request: Request, limit: number, tooLarge: () => Error):
 function json(status: number, body: unknown): Response {
   const source = JSON.stringify(body)
   return new Response(source, {
-    headers: { 'content-length': String(encoder.encode(source).byteLength), 'content-type': 'application/json; charset=utf-8' },
+    headers: { 'cache-control': 'no-store', 'content-length': String(encoder.encode(source).byteLength), 'content-type': 'application/json; charset=utf-8' },
     status,
   })
 }


### PR DESCRIPTION
## Summary

The `json()` helper used by most API endpoints did not set `cache-control`, unlike the `plain()` and `text()` helpers which include `no-store`. This could allow unintended caching of API data by browsers or proxies.

## Changes

| File | Change |
|------|--------|
| `apps/server/node/http.ts` | Add `cache-control: no-store` header to `json()` response helper |

## Motivation

Consistency with `plain()` and `text()` helpers, and prevention of unintended API response caching.