### PR TITLE
fix(manifest): remove silent error swallowing in sharedBlockManager

### DIFF
--- a/packages/open-flow/src/manifest/common/meta/package/sharedBlockManager.ts
+++ b/packages/open-flow/src/manifest/common/meta/package/sharedBlockManager.ts
@@ -137,8 +137,7 @@ export class SharedBlocksManager {
         break
       }
       default: {
-        // @ts-expect-error type guard
-        console.error(new Error(blockMeta.type.toString()))
+        blockMeta.blockType satisfies never
       }
     }
     this.#sharedBlocksByPath.delete(blockMeta.blockPath)
@@ -179,8 +178,7 @@ export class SharedBlocksManager {
         break
       }
       default: {
-        // @ts-expect-error type guard
-        console.error(new Error(blockMeta.type.toString()))
+        blockMeta.blockType satisfies never
       }
     }
 
@@ -213,13 +211,13 @@ export class SharedBlocksManager {
           break
         }
         default: {
-          // @ts-expect-error type guard
-          console.error(new Error(blockMeta.type.toString()))
+          blockMeta.blockType satisfies never
         }
       }
       return newBlockMeta
     } catch (e) {
-      console.error(e)
+      if (e instanceof Error) throw e
+      throw new Error(String(e))
     }
   }
 

--- a/packages/open-flow/src/manifest/common/meta/package/sharedBlockManager.ts
+++ b/packages/open-flow/src/manifest/common/meta/package/sharedBlockManager.ts
@@ -196,29 +196,24 @@ export class SharedBlocksManager {
   public async duplicateSharedBlock(blockMeta: SharedBlockMeta, newName: BlockName): Promise<SharedBlockMeta | undefined> {
     if (!this.#isInScope(blockMeta.blockPath)) return
 
-    try {
-      const newDir = (await this.ctx.copyFileDir(blockMeta.blockDir, join(dirname(blockMeta.blockDir), newName))) as BlockPath
-      const newBlockPath = join(newDir, basename(blockMeta.blockPath)) as BlockPath
+    const newDir = (await this.ctx.copyFileDir(blockMeta.blockDir, join(dirname(blockMeta.blockDir), newName))) as BlockPath
+    const newBlockPath = join(newDir, basename(blockMeta.blockPath)) as BlockPath
 
-      let newBlockMeta: SharedBlockMeta | undefined
-      switch (blockMeta.blockType) {
-        case 'subflow': {
-          newBlockMeta = await this.refreshSubflowBlock(newBlockPath)
-          break
-        }
-        case 'task': {
-          newBlockMeta = await this.refreshTaskBlock(newBlockPath)
-          break
-        }
-        default: {
-          blockMeta.blockType satisfies never
-        }
+    let newBlockMeta: SharedBlockMeta | undefined
+    switch (blockMeta.blockType) {
+      case 'subflow': {
+        newBlockMeta = await this.refreshSubflowBlock(newBlockPath)
+        break
       }
-      return newBlockMeta
-    } catch (e) {
-      if (e instanceof Error) throw e
-      throw new Error(String(e))
+      case 'task': {
+        newBlockMeta = await this.refreshTaskBlock(newBlockPath)
+        break
+      }
+      default: {
+        blockMeta.blockType satisfies never
+      }
     }
+    return newBlockMeta
   }
 
   public async isBlockNameAvailable(blockName: string): Promise<boolean> {


### PR DESCRIPTION
## Summary

Replace `console.error` in switch default branches with TypeScript `satisfies never` exhaustive type checks. Remove the `try/catch` wrapper in `duplicateSharedBlock` that was swallowing errors.

## Changes

| File | Change |
|------|--------|
| `packages/open-flow/src/manifest/common/meta/package/sharedBlockManager.ts` | Replace 3 `console.error` default branches with `satisfies never` |
| | Remove `try/catch` in `duplicateSharedBlock` to let errors propagate |

## Motivation

`console.error` in default branches silently swallows unknown block type errors. `satisfies never` provides compile-time exhaustiveness checking. The `try/catch` was hiding real errors from callers.