### PR TITLE
perf(workbench): keep loaded state during refresh

### DIFF
--- a/packages/open-flow/src/workbench/browser/runtime/publications/publicationStore.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/publications/publicationStore.test.ts
@@ -213,4 +213,46 @@ describe('PublicationStore', () => {
       workspace.dispose()
     }
   })
+
+  it('clears refreshing when an operation refresh replaces a warm load and fails', async () => {
+    const warmLive = Promise.withResolvers<Response>()
+    const oldPublication = { ...publication, publicationId: 'publication-old', revisionId: 'revision-old' }
+    let liveReads = 0
+    const request = vi.fn(async (path: string) => {
+      if (path == '/v1/flows/flow-1/live') {
+        liveReads += 1
+        if (liveReads == 2) return await warmLive.promise
+        if (liveReads == 3) throw new Error('Refresh failed')
+        return Response.json({ flowId: 'flow-1', hasUnpublishedChanges: false, publication, revision: 1, status: 'runnable', version: 1 })
+      }
+      if (path == '/v1/flows/flow-1/publications?limit=50&includeTotal=true') {
+        return Response.json({ publications: [publication], total: 1, version: 1 })
+      }
+      if (path == '/v1/flows/flow-1/triggers') return Response.json({ bindings: [], flowId: 'flow-1', version: 1 })
+      if (path == `/v1/flows/flow-1/publications/${oldPublication.publicationId}/rollback`) return Response.json(oldPublication)
+      throw new Error(`Unexpected request: ${path}`)
+    })
+    const client = new WorkbenchClient(request)
+    const workspace = new WorkspaceStore(client, vi.fn())
+    const store = new PublicationStore(client, workspace, vi.fn(), { getItem: () => null, setItem: vi.fn() })
+
+    try {
+      await store.load('flow-1')
+
+      const loading = store.load('flow-1')
+      await vi.waitFor(() => expect(liveReads).toBe(2))
+      expect(store.$.refreshing.value).toBe(true)
+
+      expect(await store.rollback(oldPublication)).toBe(false)
+      expect(store.$.refreshing.value).toBe(false)
+      expect(store.$.publications.value).toEqual([publication])
+
+      warmLive.resolve(Response.json({ flowId: 'flow-1', hasUnpublishedChanges: false, publication, revision: 1, status: 'runnable', version: 1 }))
+      await loading
+      expect(store.$.refreshing.value).toBe(false)
+    } finally {
+      store.dispose()
+      workspace.dispose()
+    }
+  })
 })

--- a/packages/open-flow/src/workbench/browser/runtime/publications/publicationStore.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/publications/publicationStore.test.ts
@@ -161,4 +161,56 @@ describe('PublicationStore', () => {
       workspace.dispose()
     }
   })
+
+  it('does not let an older operation refresh replace a newer load', async () => {
+    const oldRefresh = Promise.withResolvers<Response>()
+    const oldPublication = { ...publication, publicationId: 'publication-old', revisionId: 'revision-old' }
+    const nextPublication = { ...publication, publicationId: 'publication-next', revisionId: 'revision-next' }
+    let liveReads = 0
+    let publicationReads = 0
+    const request = vi.fn(async (path: string) => {
+      if (path == '/v1/flows/flow-1/live') {
+        liveReads += 1
+        if (liveReads == 2) return await oldRefresh.promise
+        const current = liveReads == 1 ? publication : nextPublication
+        return Response.json({ flowId: 'flow-1', hasUnpublishedChanges: false, publication: current, revision: liveReads, status: 'runnable', version: 1 })
+      }
+      if (path == '/v1/flows/flow-1/publications?limit=50&includeTotal=true') {
+        publicationReads += 1
+        const publications = publicationReads == 1 ? [publication] : publicationReads == 2 ? [oldPublication] : [nextPublication]
+        return Response.json({ publications, total: 1, version: 1 })
+      }
+      if (path == '/v1/flows/flow-1/triggers') return Response.json({ bindings: [], flowId: 'flow-1', version: 1 })
+      if (path == `/v1/flows/flow-1/publications/${oldPublication.publicationId}/rollback`) return Response.json(oldPublication)
+      throw new Error(`Unexpected request: ${path}`)
+    })
+    const client = new WorkbenchClient(request)
+    const workspace = new WorkspaceStore(client, vi.fn())
+    vi.spyOn(workspace, 'refreshFlows').mockResolvedValue()
+    const updateLive = vi.spyOn(workspace, 'updateLive')
+    const store = new PublicationStore(client, workspace, vi.fn(), { getItem: () => null, setItem: vi.fn() })
+
+    try {
+      await store.load('flow-1')
+
+      const rollback = store.rollback(oldPublication)
+      await vi.waitFor(() => expect(liveReads).toBe(2))
+      await store.load('flow-1')
+
+      expect(store.$.live.value?.publication?.publicationId).toBe(nextPublication.publicationId)
+      expect(store.$.publications.value).toEqual([nextPublication])
+
+      oldRefresh.resolve(
+        Response.json({ flowId: 'flow-1', hasUnpublishedChanges: false, publication: oldPublication, revision: 2, status: 'runnable', version: 1 }),
+      )
+      await rollback
+
+      expect(store.$.live.value?.publication?.publicationId).toBe(nextPublication.publicationId)
+      expect(store.$.publications.value).toEqual([nextPublication])
+      expect(updateLive).toHaveBeenLastCalledWith(expect.objectContaining({ publication: nextPublication }))
+    } finally {
+      store.dispose()
+      workspace.dispose()
+    }
+  })
 })

--- a/packages/open-flow/src/workbench/browser/runtime/publications/publicationStore.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/publications/publicationStore.test.ts
@@ -116,4 +116,49 @@ describe('PublicationStore', () => {
       workspace.dispose()
     }
   })
+
+  it('keeps loaded Publications visible while refreshing the same Flow', async () => {
+    const refreshed = Promise.withResolvers<Response>()
+    let liveReads = 0
+    const nextPublication = { ...publication, publicationId: 'publication-2' }
+    const request = vi.fn(async (path: string) => {
+      if (path == '/v1/flows/flow-1/live') {
+        liveReads += 1
+        if (liveReads == 1) {
+          return Response.json({ flowId: 'flow-1', hasUnpublishedChanges: false, publication, revision: 1, status: 'runnable', version: 1 })
+        }
+        return await refreshed.promise
+      }
+      if (path == '/v1/flows/flow-1/publications?limit=50&includeTotal=true') {
+        return Response.json({ publications: liveReads == 1 ? [publication] : [nextPublication, publication], total: liveReads, version: 1 })
+      }
+      if (path == '/v1/flows/flow-1/triggers') return Response.json({ bindings: [], flowId: 'flow-1', version: 1 })
+      throw new Error(`Unexpected request: ${path}`)
+    })
+    const client = new WorkbenchClient(request)
+    const workspace = new WorkspaceStore(client, vi.fn())
+    const store = new PublicationStore(client, workspace, vi.fn(), { getItem: () => null, setItem: vi.fn() })
+
+    try {
+      await store.load('flow-1')
+
+      const refreshing = store.load('flow-1')
+      expect(store.$.loading.value).toBe(false)
+      expect(store.$.refreshing.value).toBe(true)
+      expect(store.$.publications.value).toEqual([publication])
+      expect(store.$.live.value?.publication?.publicationId).toBe(publication.publicationId)
+
+      refreshed.resolve(
+        Response.json({ flowId: 'flow-1', hasUnpublishedChanges: false, publication: nextPublication, revision: 2, status: 'runnable', version: 1 }),
+      )
+      await refreshing
+
+      expect(store.$.refreshing.value).toBe(false)
+      expect(store.$.publications.value.map((item) => item.publicationId)).toEqual(['publication-2', 'publication-1'])
+      expect(store.$.live.value?.publication?.publicationId).toBe(nextPublication.publicationId)
+    } finally {
+      store.dispose()
+      workspace.dispose()
+    }
+  })
 })

--- a/packages/open-flow/src/workbench/browser/runtime/publications/publicationStore.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/publications/publicationStore.ts
@@ -481,10 +481,10 @@ export class PublicationStore {
   }
 
   async #refresh(target: Target): Promise<void> {
-    this.#loads.invalidate()
+    const current = this.#loads.begin()
     const [live, page, bindings] = await this.#read(target)
-    this.#workspace.updateLive(live)
-    if (sameTarget(this.#state.value.target, target)) {
+    if (current()) this.#workspace.updateLive(live)
+    if (current() && sameTarget(this.#state.value.target, target)) {
       this.#set({
         bindings,
         live,

--- a/packages/open-flow/src/workbench/browser/runtime/publications/publicationStore.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/publications/publicationStore.ts
@@ -482,7 +482,10 @@ export class PublicationStore {
 
   async #refresh(target: Target): Promise<void> {
     const current = this.#loads.begin()
-    const [live, page, bindings] = await this.#read(target)
+    const [live, page, bindings] = await this.#read(target).catch((error) => {
+      if (current() && sameTarget(this.#state.value.target, target)) this.#set({ refreshing: false })
+      throw error
+    })
     if (current()) this.#workspace.updateLive(live)
     if (current() && sameTarget(this.#state.value.target, target)) {
       this.#set({

--- a/packages/open-flow/src/workbench/browser/runtime/publications/publicationStore.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/publications/publicationStore.ts
@@ -40,6 +40,7 @@ interface PublicationState {
   readonly detail?: TriggerBindingDetail
   readonly detailLoading: boolean
   readonly live?: Live
+  readonly loaded: boolean
   readonly loadFailed: boolean
   readonly loading: boolean
   readonly loadMoreFailed: boolean
@@ -48,6 +49,7 @@ interface PublicationState {
   readonly operation?: PublishOperation
   readonly publications: readonly Publication[]
   readonly publishing: boolean
+  readonly refreshing: boolean
   readonly rollingBackPublicationId?: string
   readonly selectedTriggerId?: string
   readonly target?: Target
@@ -90,6 +92,7 @@ export interface Publication$ {
   readonly operation: ReadonlyVal<PublishOperation | undefined>
   readonly publications: ReadonlyVal<readonly Publication[]>
   readonly publishing: ReadonlyVal<boolean>
+  readonly refreshing: ReadonlyVal<boolean>
   readonly rollingBackPublicationId: ReadonlyVal<string | undefined>
   readonly selectedTriggerId: ReadonlyVal<string | undefined>
   readonly testingTriggerId: ReadonlyVal<string | undefined>
@@ -104,12 +107,14 @@ const initialState: PublicationState = {
   activitiesLoadingMore: false,
   bindings: [],
   detailLoading: false,
+  loaded: false,
   loadFailed: false,
   loading: false,
   loadMoreFailed: false,
   loadingMore: false,
   publications: [],
   publishing: false,
+  refreshing: false,
 }
 
 const activityPageLimit = 20
@@ -169,6 +174,7 @@ export class PublicationStore {
       operation: derive(this.#state, (state) => state.operation),
       publications: derive(this.#state, (state) => state.publications),
       publishing: derive(this.#state, (state) => state.publishing),
+      refreshing: derive(this.#state, (state) => state.refreshing),
       rollingBackPublicationId: derive(this.#state, (state) => state.rollingBackPublicationId),
       selectedTriggerId: derive(this.#state, (state) => state.selectedTriggerId),
       testingTriggerId: derive(this.#state, (state) => state.testingTriggerId),
@@ -197,34 +203,42 @@ export class PublicationStore {
 
   public async load(flowId: string): Promise<void> {
     const target = { flowId }
+    const state = this.#state.value
+    const warm = state.loaded && sameTarget(state.target, target)
     const current = this.#loads.begin()
-    if (!sameTarget(this.#state.value.target, target)) {
+    if (!sameTarget(state.target, target)) {
       this.#operation.invalidate()
       this.#attempt = undefined
     }
-    this.#setNotice(undefined)
-    this.#state.set({ ...initialState, loading: true, target })
+    if (warm) {
+      this.#set({ loadFailed: false, loadingMore: false, loadMoreFailed: false, refreshing: true })
+    } else {
+      this.#setNotice(undefined)
+      this.#state.set({ ...initialState, loading: true, target })
+    }
     try {
-      const operation = await this.#storedOperation(target)
+      const operation = warm ? state.operation : await this.#storedOperation(target)
       const [live, page, bindings] = await this.#read(target)
       if (!current()) return
+      this.#workspace.updateLive(live)
       this.#set({
         bindings,
         live,
+        loaded: true,
         loading: false,
         nextCursor: page.nextCursor,
-        operation,
         publications: page.publications,
-        publishing: operation?.status == 'pending',
+        refreshing: false,
         total: page.total,
+        ...(warm ? {} : { operation, publishing: operation?.status == 'pending' }),
       })
-      if (operation?.status == 'pending') {
+      if (!warm && operation?.status == 'pending') {
         const flow = this.#workspace.$.targetFlow.value
         void this.#observe(target, operation, this.#operation.begin(), flow?.flowId == target.flowId ? flow.name : target.flowId)
       }
     } catch (error) {
       if (!current()) return
-      this.#set({ loadFailed: true, loading: false })
+      this.#set({ loadFailed: !warm, loading: false, refreshing: false })
       this.#setNotice(errorNotice(error, this.#i18n.t))
     }
   }
@@ -467,12 +481,23 @@ export class PublicationStore {
   }
 
   async #refresh(target: Target): Promise<void> {
+    this.#loads.invalidate()
     const [live, page, bindings] = await this.#read(target)
     this.#workspace.updateLive(live)
-    await this.#workspace.refreshFlows()
     if (sameTarget(this.#state.value.target, target)) {
-      this.#set({ bindings, live, loadFailed: false, nextCursor: page.nextCursor, publications: page.publications, total: page.total })
+      this.#set({
+        bindings,
+        live,
+        loaded: true,
+        loadFailed: false,
+        loadingMore: false,
+        nextCursor: page.nextCursor,
+        publications: page.publications,
+        refreshing: false,
+        total: page.total,
+      })
     }
+    await this.#workspace.refreshFlows()
   }
 
   async #recover(target: Target): Promise<void> {

--- a/packages/open-flow/src/workbench/browser/runtime/publications/publicationsView.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/publications/publicationsView.tsx
@@ -179,415 +179,414 @@ export function PublicationsView({ store }: { readonly store: WorkbenchStore }):
   const invalid = diagnostics?.valid == false
   const currentPublicationId = live?.publication?.publicationId
 
+  const panel = (
+    <section
+      aria-busy={loading || refreshing}
+      aria-labelledby="workspace-tab-publications"
+      className="publication-view"
+      id="workspace-panel-publications"
+      role="tabpanel"
+      tabIndex={0}
+    >
+      <section className="publication-summary">
+        <div className="publication-summary-heading">
+          <div>
+            <h2>{t('publication.live')}</h2>
+            <p>{t('publication.liveDescription')}</p>
+          </div>
+          {(loading || refreshing) && (
+            <span aria-hidden="true" className="publication-loading">
+              {t('publication.loading')}
+            </span>
+          )}
+        </div>
+
+        {loadFailed ? (
+          <div className="publication-load-error">
+            <span>{t('publication.loadFailed')}</span>
+            <Button disabled={flowId == null} onClick={() => flowId != null && void store.publications.load(flowId)} size="sm" variant="outline">
+              {t('empty.retry')}
+            </Button>
+          </div>
+        ) : !loading ? (
+          <div className="publication-precondition">
+            {operation != null && operation.status != 'succeeded' && (
+              <div className={`publication-progress ${operation.status}`} role={operation.status == 'failed' ? 'alert' : 'status'}>
+                <span className={`status-dot ${operationClass}`} />
+                <div>
+                  <strong>{operationLabel}</strong>
+                  {operationDetail}
+                </div>
+              </div>
+            )}
+            <div className="publication-overview">
+              {live != null && (
+                <div className="publication-overview-main">
+                  <span className={`status-dot ${live.hasUnpublishedChanges ? 'running' : 'success'}`} />
+                  <div className="publication-overview-body">
+                    <div className="publication-overview-heading">
+                      <div className="publication-overview-result">
+                        <strong>{t(live.hasUnpublishedChanges ? 'workspace.unpublishedChanges' : 'publication.upToDate')}</strong>
+                        {live.hasUnpublishedChanges && <span>{t(invalid ? 'workspace.fixIssuesToPublish' : 'publication.publishDescription')}</span>}
+                      </div>
+                      <div className="publication-overview-actions">
+                        <span className="publication-status">
+                          <span className={`status-dot ${liveClass(live)}`} />
+                          {liveLabel(live, t)}
+                        </span>
+                        {draft != null && live.hasUnpublishedChanges && (
+                          <Button disabled={busy != null || invalid} onClick={() => void store.publications.publish()}>
+                            <Icon data-icon="inline-start" name="publish" />
+                            {t(publishing ? 'workspace.publishing' : 'publication.publishDraft')}
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                    <dl className="publication-overview-meta">
+                      <div>
+                        <dt>{t('publication.draftRevision')}</dt>
+                        <dd>{draft == null ? t('publication.noDraft') : <CompactId value={draft.revisionId} />}</dd>
+                      </div>
+                      <div>
+                        <dt>{t('publication.livePublication')}</dt>
+                        <dd>{live.publication == null ? t('publication.none') : <CompactId value={live.publication.publicationId} />}</dd>
+                      </div>
+                      <div>
+                        <dt>{t('publication.liveRevision')}</dt>
+                        <dd>{live.publication == null ? '—' : <CompactId value={live.publication.revisionId} />}</dd>
+                      </div>
+                      <div>
+                        <dt>{t('publication.liveVersion')}</dt>
+                        <dd>{live.revision}</dd>
+                      </div>
+                    </dl>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        ) : null}
+      </section>
+
+      <section className="publication-triggers">
+        <header>
+          <div>
+            <h2>{t('publication.triggers')}</h2>
+            <span>{t('publication.triggerDescription')}</span>
+          </div>
+        </header>
+        {loading ? (
+          <div className="publication-trigger-empty">{t('publication.loading')}</div>
+        ) : loadFailed ? (
+          <div className="publication-trigger-empty">{t('publication.loadFailed')}</div>
+        ) : bindings.length == 0 ? (
+          <div className="publication-trigger-empty">{t('publication.triggerEmpty')}</div>
+        ) : (
+          <div className="trigger-binding-list">
+            {bindings.map((binding) => {
+              const changing = changingTriggerId == binding.triggerNodeId
+              const selected = selectedTriggerId == binding.triggerNodeId
+              const resumable = binding.operatorState == 'paused'
+              return (
+                <Fragment key={binding.triggerNodeId}>
+                  <div className="trigger-binding-row">
+                    <Button
+                      aria-expanded={selected}
+                      className="trigger-binding-summary"
+                      onClick={() => (selected ? store.publications.closeTrigger() : void store.publications.openTrigger(binding.triggerNodeId))}
+                      type="button"
+                      variant="ghost"
+                    >
+                      <span className={`status-dot ${triggerClass(binding)}`} />
+                      <strong title={binding.triggerNodeId}>{triggerName(binding, revision)}</strong>
+                      <span className={'trigger-binding-state ' + triggerClass(binding)}>{triggerLabel(binding, t)}</span>
+                      <code className="trigger-binding-kind">{binding.kind}</code>
+                      <span className="trigger-binding-detail-label">{t(selected ? 'publication.hideTriggerDetails' : 'publication.triggerDetails')}</span>
+                      <Icon name={selected ? 'chevron-up' : 'chevron-down'} />
+                    </Button>
+                    {binding.currentPublicationId != null && (
+                      <Button
+                        disabled={busy != null || changingTriggerId != null}
+                        onClick={() => void store.publications.toggleTrigger(binding)}
+                        size="sm"
+                        variant="outline"
+                      >
+                        {t(
+                          changing
+                            ? resumable
+                              ? 'publication.resumingTrigger'
+                              : 'publication.pausingTrigger'
+                            : resumable
+                              ? 'publication.resumeTrigger'
+                              : 'publication.pauseTrigger',
+                        )}
+                      </Button>
+                    )}
+                  </div>
+                  {selected && (
+                    <div className="trigger-binding-detail">
+                      {detailLoading ? (
+                        <div className="publication-trigger-empty">{t('publication.loadingTrigger')}</div>
+                      ) : detail != null ? (
+                        <>
+                          <dl>
+                            <div>
+                              <dt>{t('publication.triggerKind')}</dt>
+                              <dd>{detail.binding.kind}</dd>
+                            </div>
+                            <div>
+                              <dt>{t('publication.runtimeVersion')}</dt>
+                              <dd>{detail.binding.runtimeVersion}</dd>
+                            </div>
+                            <div>
+                              <dt>{t('publication.triggerHealth')}</dt>
+                              <dd>{triggerLabel(detail.binding, t)}</dd>
+                            </div>
+                            <div>
+                              <dt>{t('publication.operatorState')}</dt>
+                              <dd>
+                                <span>{t(detail.binding.operatorState == 'paused' ? 'publication.suspended' : 'publication.active')}</span>{' '}
+                                <code>{detail.binding.operatorState}</code>
+                              </dd>
+                            </div>
+                            <div>
+                              <dt>{t('publication.updatedAt')}</dt>
+                              <dd>{new Date(detail.binding.updatedAt).toLocaleString(language)}</dd>
+                            </div>
+                            {detail.binding.lastErrorCode != null && (
+                              <div>
+                                <dt>{t('publication.lastError')}</dt>
+                                <dd>{detail.binding.lastErrorCode}</dd>
+                              </div>
+                            )}
+                          </dl>
+                          {detail.binding.health == 'needs_reauth' && <p className="trigger-recovery">{t('publication.needsReauthDescription')}</p>}
+                          {detail.binding.endpointUrl != null && (
+                            <div className="trigger-webhook">
+                              <span>{t('publication.webhookUrl')}</span>
+                              <div>
+                                <code title={detail.binding.endpointUrl}>{detail.binding.endpointUrl}</code>
+                                <Button
+                                  onClick={async () => {
+                                    await navigator.clipboard.writeText(detail.binding.endpointUrl!)
+                                    setCopiedEndpoint(detail.binding.endpointUrl)
+                                  }}
+                                  size="sm"
+                                  variant="outline"
+                                >
+                                  {t(copiedEndpoint == detail.binding.endpointUrl ? 'publication.webhookCopied' : 'publication.webhookCopy')}
+                                </Button>
+                              </div>
+                            </div>
+                          )}
+                          <div className="trigger-binding-detail-sections">
+                            {detail.binding.kind == 'poll' && detail.binding.currentPublicationId != null && (
+                              <section className="trigger-test">
+                                <header>
+                                  <div>
+                                    <h3>{t('publication.pollTest')}</h3>
+                                    <p>{t('publication.pollTestDescription')}</p>
+                                  </div>
+                                  <Button disabled={testingTriggerId != null} onClick={() => void store.publications.testTrigger()} size="sm" variant="outline">
+                                    {t(testingTriggerId == detail.binding.triggerNodeId ? 'publication.pollTesting' : 'publication.pollTest')}
+                                  </Button>
+                                </header>
+                                {testResult != null && (
+                                  <div className="trigger-test-result">
+                                    <strong>{t('publication.pollTestResult')}</strong>
+                                    <div className="trigger-test-summary">
+                                      <span>{t('publication.pollTestEvents', { count: testResult.events.length })}</span>
+                                      <span>{t('publication.pollTestFiltered', { count: testResult.filtered })}</span>
+                                      {testResult.hasMore && <span>{t('publication.pollTestHasMore')}</span>}
+                                    </div>
+                                    {testResult.events.length == 0 ? (
+                                      <p>{t('publication.pollTestNoEvents')}</p>
+                                    ) : (
+                                      <div className="trigger-test-events">
+                                        <JSONViewer data={testResult.events} shouldExpandNode={collapseAllNested} />
+                                      </div>
+                                    )}
+                                  </div>
+                                )}
+                              </section>
+                            )}
+                            <section className="trigger-activities">
+                              <h3>{t('publication.activities')}</h3>
+                              <p className="trigger-activities-description">{t('publication.activitiesDescription')}</p>
+                              {activitiesLoading ? (
+                                <div className="trigger-activities-empty">{t('publication.loadingTriggerActivities')}</div>
+                              ) : activities.length == 0 ? (
+                                <div className="trigger-activities-empty">
+                                  {t(activitiesLoadFailed ? 'publication.activitiesLoadFailed' : 'publication.activitiesEmpty')}
+                                </div>
+                              ) : (
+                                <div className="trigger-activity-list">
+                                  {activities.map((activity) => (
+                                    <div className="trigger-activity" key={activity.activityId}>
+                                      <span className="status-dot neutral" />
+                                      <div>
+                                        <strong>{activityLabel(activity.kind, t)}</strong>
+                                        {activity.errorCode != null && <code>{activity.errorCode}</code>}
+                                        {activity.errorMessage != null && <p className="trigger-activity-message">{activity.errorMessage}</p>}
+                                      </div>
+                                      <time dateTime={activity.createdAt}>{new Date(activity.createdAt).toLocaleString(language)}</time>
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
+                              {(activitiesNextCursor != null || activitiesLoadFailed) && !activitiesLoading && (
+                                <Button
+                                  className="trigger-activities-more"
+                                  disabled={activitiesLoadingMore}
+                                  onClick={() =>
+                                    void (activitiesNextCursor == null
+                                      ? store.publications.openTrigger(detail.binding.triggerNodeId)
+                                      : store.publications.loadMoreTriggerActivities())
+                                  }
+                                  size="sm"
+                                  variant="outline"
+                                >
+                                  {t(
+                                    activitiesLoadingMore
+                                      ? 'publication.loadingTriggerActivities'
+                                      : activitiesLoadFailed
+                                        ? 'empty.retry'
+                                        : 'publication.loadMoreActivities',
+                                  )}
+                                </Button>
+                              )}
+                            </section>
+                          </div>
+                        </>
+                      ) : null}
+                    </div>
+                  )}
+                </Fragment>
+              )
+            })}
+          </div>
+        )}
+      </section>
+
+      <section className="publication-history">
+        <header>
+          <div>
+            <h2>{t('publication.history')}</h2>
+            <span>{t('publication.historyCount', { count: total ?? publications.length })}</span>
+          </div>
+        </header>
+        {loading ? (
+          <div className="publication-history-loading">{t('publication.loading')}</div>
+        ) : publications.length == 0 ? (
+          <Empty className="h-full rounded-none">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <Icon name="publish" />
+              </EmptyMedia>
+              <EmptyTitle>{t('publication.historyEmpty')}</EmptyTitle>
+              <EmptyDescription>{t('publication.historyEmptyDescription')}</EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          <div className="publication-table-wrap">
+            <table className="publication-table">
+              <thead>
+                <tr>
+                  <th>{t('publication.operation')}</th>
+                  <th>{t('publication.revision')}</th>
+                  <th>{t('publication.actor')}</th>
+                  <th>{t('publication.createdAt')}</th>
+                  <th aria-label={t('publication.actions')} />
+                </tr>
+              </thead>
+              <tbody>
+                {publications.map((publication) => {
+                  const current = publication.publicationId == currentPublicationId
+                  const confirm = confirming == publication.publicationId
+                  return (
+                    <Fragment key={publication.publicationId}>
+                      <tr>
+                        <td data-label={t('publication.operation')}>
+                          <span className="publication-operation">
+                            {t(publication.operation == 'publish' ? 'publication.published' : 'publication.rolledBack')}
+                            {current && <Badge variant="secondary">{t('publication.current')}</Badge>}
+                          </span>
+                          <CompactId value={publication.publicationId} />
+                        </td>
+                        <td data-label={t('publication.revision')}>
+                          <CompactId value={publication.revisionId} />
+                          {publication.sourcePublicationId != null && (
+                            <span title={publication.sourcePublicationId}>
+                              {t('publication.fromPublication', { id: compactId(publication.sourcePublicationId) })}
+                            </span>
+                          )}
+                        </td>
+                        <td data-label={t('publication.actor')}>
+                          <CompactId value={publication.actorId} />
+                        </td>
+                        <td data-label={t('publication.createdAt')}>
+                          <time dateTime={publication.createdAt}>{new Date(publication.createdAt).toLocaleString(language)}</time>
+                        </td>
+                        <td data-label={t('publication.actions')}>
+                          {!current && currentPublicationId != null && (
+                            <Button
+                              disabled={busy != null}
+                              onClick={() => setConfirming(confirm ? undefined : publication.publicationId)}
+                              size="sm"
+                              variant="outline"
+                            >
+                              {t('publication.rollback')}
+                            </Button>
+                          )}
+                        </td>
+                      </tr>
+                      {confirm && (
+                        <tr className="publication-confirm-row">
+                          <td colSpan={5}>
+                            <div className="publication-confirm" role="group" aria-label={t('publication.rollback')}>
+                              <div>
+                                <strong>{t('publication.rollbackConfirm')}</strong>
+                                <span>
+                                  {t('publication.rollbackTarget', {
+                                    publication: compactId(publication.publicationId),
+                                    revision: compactId(publication.revisionId),
+                                  })}
+                                </span>
+                              </div>
+                              <div>
+                                <Button disabled={rollingBackPublicationId != null} onClick={() => setConfirming(undefined)} size="sm" variant="outline">
+                                  {t('common.cancel')}
+                                </Button>
+                                <Button disabled={busy != null} onClick={() => void store.publications.rollback(publication)} size="sm" variant="destructive">
+                                  {t(rollingBackPublicationId == publication.publicationId ? 'publication.rollingBack' : 'publication.rollback')}
+                                </Button>
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+        {nextCursor != null && (
+          <Button className="m-2" disabled={loadingMore} onClick={() => void store.publications.loadMore()} size="lg" variant="outline">
+            {t(loadingMore ? 'run.loadingMore' : loadMoreFailed ? 'run.retryLoadMore' : 'run.loadMore')}
+          </Button>
+        )}
+      </section>
+    </section>
+  )
+
   return (
     <>
       <span className="sr-only" role="status">
         {loading || refreshing ? t('publication.loading') : ''}
       </span>
-      <section
-        aria-busy={loading || refreshing}
-        aria-labelledby="workspace-tab-publications"
-        className="publication-view"
-        id="workspace-panel-publications"
-        role="tabpanel"
-        tabIndex={0}
-      >
-        <section className="publication-summary">
-          <div className="publication-summary-heading">
-            <div>
-              <h2>{t('publication.live')}</h2>
-              <p>{t('publication.liveDescription')}</p>
-            </div>
-            {(loading || refreshing) && (
-              <span aria-hidden="true" className="publication-loading">
-                {t('publication.loading')}
-              </span>
-            )}
-          </div>
-
-          {loadFailed ? (
-            <div className="publication-load-error">
-              <span>{t('publication.loadFailed')}</span>
-              <Button disabled={flowId == null} onClick={() => flowId != null && void store.publications.load(flowId)} size="sm" variant="outline">
-                {t('empty.retry')}
-              </Button>
-            </div>
-          ) : !loading ? (
-            <div className="publication-precondition">
-              {operation != null && operation.status != 'succeeded' && (
-                <div className={`publication-progress ${operation.status}`} role={operation.status == 'failed' ? 'alert' : 'status'}>
-                  <span className={`status-dot ${operationClass}`} />
-                  <div>
-                    <strong>{operationLabel}</strong>
-                    {operationDetail}
-                  </div>
-                </div>
-              )}
-              <div className="publication-overview">
-                {live != null && (
-                  <div className="publication-overview-main">
-                    <span className={`status-dot ${live.hasUnpublishedChanges ? 'running' : 'success'}`} />
-                    <div className="publication-overview-body">
-                      <div className="publication-overview-heading">
-                        <div className="publication-overview-result">
-                          <strong>{t(live.hasUnpublishedChanges ? 'workspace.unpublishedChanges' : 'publication.upToDate')}</strong>
-                          {live.hasUnpublishedChanges && <span>{t(invalid ? 'workspace.fixIssuesToPublish' : 'publication.publishDescription')}</span>}
-                        </div>
-                        <div className="publication-overview-actions">
-                          <span className="publication-status">
-                            <span className={`status-dot ${liveClass(live)}`} />
-                            {liveLabel(live, t)}
-                          </span>
-                          {draft != null && live.hasUnpublishedChanges && (
-                            <Button disabled={busy != null || invalid} onClick={() => void store.publications.publish()}>
-                              <Icon data-icon="inline-start" name="publish" />
-                              {t(publishing ? 'workspace.publishing' : 'publication.publishDraft')}
-                            </Button>
-                          )}
-                        </div>
-                      </div>
-                      <dl className="publication-overview-meta">
-                        <div>
-                          <dt>{t('publication.draftRevision')}</dt>
-                          <dd>{draft == null ? t('publication.noDraft') : <CompactId value={draft.revisionId} />}</dd>
-                        </div>
-                        <div>
-                          <dt>{t('publication.livePublication')}</dt>
-                          <dd>{live.publication == null ? t('publication.none') : <CompactId value={live.publication.publicationId} />}</dd>
-                        </div>
-                        <div>
-                          <dt>{t('publication.liveRevision')}</dt>
-                          <dd>{live.publication == null ? '—' : <CompactId value={live.publication.revisionId} />}</dd>
-                        </div>
-                        <div>
-                          <dt>{t('publication.liveVersion')}</dt>
-                          <dd>{live.revision}</dd>
-                        </div>
-                      </dl>
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
-          ) : null}
-        </section>
-
-        <section className="publication-triggers">
-          <header>
-            <div>
-              <h2>{t('publication.triggers')}</h2>
-              <span>{t('publication.triggerDescription')}</span>
-            </div>
-          </header>
-          {loading ? (
-            <div className="publication-trigger-empty">{t('publication.loading')}</div>
-          ) : loadFailed ? (
-            <div className="publication-trigger-empty">{t('publication.loadFailed')}</div>
-          ) : bindings.length == 0 ? (
-            <div className="publication-trigger-empty">{t('publication.triggerEmpty')}</div>
-          ) : (
-            <div className="trigger-binding-list">
-              {bindings.map((binding) => {
-                const changing = changingTriggerId == binding.triggerNodeId
-                const selected = selectedTriggerId == binding.triggerNodeId
-                const resumable = binding.operatorState == 'paused'
-                return (
-                  <Fragment key={binding.triggerNodeId}>
-                    <div className="trigger-binding-row">
-                      <Button
-                        aria-expanded={selected}
-                        className="trigger-binding-summary"
-                        onClick={() => (selected ? store.publications.closeTrigger() : void store.publications.openTrigger(binding.triggerNodeId))}
-                        type="button"
-                        variant="ghost"
-                      >
-                        <span className={`status-dot ${triggerClass(binding)}`} />
-                        <strong title={binding.triggerNodeId}>{triggerName(binding, revision)}</strong>
-                        <span className={'trigger-binding-state ' + triggerClass(binding)}>{triggerLabel(binding, t)}</span>
-                        <code className="trigger-binding-kind">{binding.kind}</code>
-                        <span className="trigger-binding-detail-label">{t(selected ? 'publication.hideTriggerDetails' : 'publication.triggerDetails')}</span>
-                        <Icon name={selected ? 'chevron-up' : 'chevron-down'} />
-                      </Button>
-                      {binding.currentPublicationId != null && (
-                        <Button
-                          disabled={busy != null || changingTriggerId != null}
-                          onClick={() => void store.publications.toggleTrigger(binding)}
-                          size="sm"
-                          variant="outline"
-                        >
-                          {t(
-                            changing
-                              ? resumable
-                                ? 'publication.resumingTrigger'
-                                : 'publication.pausingTrigger'
-                              : resumable
-                                ? 'publication.resumeTrigger'
-                                : 'publication.pauseTrigger',
-                          )}
-                        </Button>
-                      )}
-                    </div>
-                    {selected && (
-                      <div className="trigger-binding-detail">
-                        {detailLoading ? (
-                          <div className="publication-trigger-empty">{t('publication.loadingTrigger')}</div>
-                        ) : detail != null ? (
-                          <>
-                            <dl>
-                              <div>
-                                <dt>{t('publication.triggerKind')}</dt>
-                                <dd>{detail.binding.kind}</dd>
-                              </div>
-                              <div>
-                                <dt>{t('publication.runtimeVersion')}</dt>
-                                <dd>{detail.binding.runtimeVersion}</dd>
-                              </div>
-                              <div>
-                                <dt>{t('publication.triggerHealth')}</dt>
-                                <dd>{triggerLabel(detail.binding, t)}</dd>
-                              </div>
-                              <div>
-                                <dt>{t('publication.operatorState')}</dt>
-                                <dd>
-                                  <span>{t(detail.binding.operatorState == 'paused' ? 'publication.suspended' : 'publication.active')}</span>{' '}
-                                  <code>{detail.binding.operatorState}</code>
-                                </dd>
-                              </div>
-                              <div>
-                                <dt>{t('publication.updatedAt')}</dt>
-                                <dd>{new Date(detail.binding.updatedAt).toLocaleString(language)}</dd>
-                              </div>
-                              {detail.binding.lastErrorCode != null && (
-                                <div>
-                                  <dt>{t('publication.lastError')}</dt>
-                                  <dd>{detail.binding.lastErrorCode}</dd>
-                                </div>
-                              )}
-                            </dl>
-                            {detail.binding.health == 'needs_reauth' && <p className="trigger-recovery">{t('publication.needsReauthDescription')}</p>}
-                            {detail.binding.endpointUrl != null && (
-                              <div className="trigger-webhook">
-                                <span>{t('publication.webhookUrl')}</span>
-                                <div>
-                                  <code title={detail.binding.endpointUrl}>{detail.binding.endpointUrl}</code>
-                                  <Button
-                                    onClick={async () => {
-                                      await navigator.clipboard.writeText(detail.binding.endpointUrl!)
-                                      setCopiedEndpoint(detail.binding.endpointUrl)
-                                    }}
-                                    size="sm"
-                                    variant="outline"
-                                  >
-                                    {t(copiedEndpoint == detail.binding.endpointUrl ? 'publication.webhookCopied' : 'publication.webhookCopy')}
-                                  </Button>
-                                </div>
-                              </div>
-                            )}
-                            <div className="trigger-binding-detail-sections">
-                              {detail.binding.kind == 'poll' && detail.binding.currentPublicationId != null && (
-                                <section className="trigger-test">
-                                  <header>
-                                    <div>
-                                      <h3>{t('publication.pollTest')}</h3>
-                                      <p>{t('publication.pollTestDescription')}</p>
-                                    </div>
-                                    <Button
-                                      disabled={testingTriggerId != null}
-                                      onClick={() => void store.publications.testTrigger()}
-                                      size="sm"
-                                      variant="outline"
-                                    >
-                                      {t(testingTriggerId == detail.binding.triggerNodeId ? 'publication.pollTesting' : 'publication.pollTest')}
-                                    </Button>
-                                  </header>
-                                  {testResult != null && (
-                                    <div className="trigger-test-result">
-                                      <strong>{t('publication.pollTestResult')}</strong>
-                                      <div className="trigger-test-summary">
-                                        <span>{t('publication.pollTestEvents', { count: testResult.events.length })}</span>
-                                        <span>{t('publication.pollTestFiltered', { count: testResult.filtered })}</span>
-                                        {testResult.hasMore && <span>{t('publication.pollTestHasMore')}</span>}
-                                      </div>
-                                      {testResult.events.length == 0 ? (
-                                        <p>{t('publication.pollTestNoEvents')}</p>
-                                      ) : (
-                                        <div className="trigger-test-events">
-                                          <JSONViewer data={testResult.events} shouldExpandNode={collapseAllNested} />
-                                        </div>
-                                      )}
-                                    </div>
-                                  )}
-                                </section>
-                              )}
-                              <section className="trigger-activities">
-                                <h3>{t('publication.activities')}</h3>
-                                <p className="trigger-activities-description">{t('publication.activitiesDescription')}</p>
-                                {activitiesLoading ? (
-                                  <div className="trigger-activities-empty">{t('publication.loadingTriggerActivities')}</div>
-                                ) : activities.length == 0 ? (
-                                  <div className="trigger-activities-empty">
-                                    {t(activitiesLoadFailed ? 'publication.activitiesLoadFailed' : 'publication.activitiesEmpty')}
-                                  </div>
-                                ) : (
-                                  <div className="trigger-activity-list">
-                                    {activities.map((activity) => (
-                                      <div className="trigger-activity" key={activity.activityId}>
-                                        <span className="status-dot neutral" />
-                                        <div>
-                                          <strong>{activityLabel(activity.kind, t)}</strong>
-                                          {activity.errorCode != null && <code>{activity.errorCode}</code>}
-                                          {activity.errorMessage != null && <p className="trigger-activity-message">{activity.errorMessage}</p>}
-                                        </div>
-                                        <time dateTime={activity.createdAt}>{new Date(activity.createdAt).toLocaleString(language)}</time>
-                                      </div>
-                                    ))}
-                                  </div>
-                                )}
-                                {(activitiesNextCursor != null || activitiesLoadFailed) && !activitiesLoading && (
-                                  <Button
-                                    className="trigger-activities-more"
-                                    disabled={activitiesLoadingMore}
-                                    onClick={() =>
-                                      void (activitiesNextCursor == null
-                                        ? store.publications.openTrigger(detail.binding.triggerNodeId)
-                                        : store.publications.loadMoreTriggerActivities())
-                                    }
-                                    size="sm"
-                                    variant="outline"
-                                  >
-                                    {t(
-                                      activitiesLoadingMore
-                                        ? 'publication.loadingTriggerActivities'
-                                        : activitiesLoadFailed
-                                          ? 'empty.retry'
-                                          : 'publication.loadMoreActivities',
-                                    )}
-                                  </Button>
-                                )}
-                              </section>
-                            </div>
-                          </>
-                        ) : null}
-                      </div>
-                    )}
-                  </Fragment>
-                )
-              })}
-            </div>
-          )}
-        </section>
-
-        <section className="publication-history">
-          <header>
-            <div>
-              <h2>{t('publication.history')}</h2>
-              <span>{t('publication.historyCount', { count: total ?? publications.length })}</span>
-            </div>
-          </header>
-          {loading ? (
-            <div className="publication-history-loading">{t('publication.loading')}</div>
-          ) : publications.length == 0 ? (
-            <Empty className="h-full rounded-none">
-              <EmptyHeader>
-                <EmptyMedia variant="icon">
-                  <Icon name="publish" />
-                </EmptyMedia>
-                <EmptyTitle>{t('publication.historyEmpty')}</EmptyTitle>
-                <EmptyDescription>{t('publication.historyEmptyDescription')}</EmptyDescription>
-              </EmptyHeader>
-            </Empty>
-          ) : (
-            <div className="publication-table-wrap">
-              <table className="publication-table">
-                <thead>
-                  <tr>
-                    <th>{t('publication.operation')}</th>
-                    <th>{t('publication.revision')}</th>
-                    <th>{t('publication.actor')}</th>
-                    <th>{t('publication.createdAt')}</th>
-                    <th aria-label={t('publication.actions')} />
-                  </tr>
-                </thead>
-                <tbody>
-                  {publications.map((publication) => {
-                    const current = publication.publicationId == currentPublicationId
-                    const confirm = confirming == publication.publicationId
-                    return (
-                      <Fragment key={publication.publicationId}>
-                        <tr>
-                          <td data-label={t('publication.operation')}>
-                            <span className="publication-operation">
-                              {t(publication.operation == 'publish' ? 'publication.published' : 'publication.rolledBack')}
-                              {current && <Badge variant="secondary">{t('publication.current')}</Badge>}
-                            </span>
-                            <CompactId value={publication.publicationId} />
-                          </td>
-                          <td data-label={t('publication.revision')}>
-                            <CompactId value={publication.revisionId} />
-                            {publication.sourcePublicationId != null && (
-                              <span title={publication.sourcePublicationId}>
-                                {t('publication.fromPublication', { id: compactId(publication.sourcePublicationId) })}
-                              </span>
-                            )}
-                          </td>
-                          <td data-label={t('publication.actor')}>
-                            <CompactId value={publication.actorId} />
-                          </td>
-                          <td data-label={t('publication.createdAt')}>
-                            <time dateTime={publication.createdAt}>{new Date(publication.createdAt).toLocaleString(language)}</time>
-                          </td>
-                          <td data-label={t('publication.actions')}>
-                            {!current && currentPublicationId != null && (
-                              <Button
-                                disabled={busy != null}
-                                onClick={() => setConfirming(confirm ? undefined : publication.publicationId)}
-                                size="sm"
-                                variant="outline"
-                              >
-                                {t('publication.rollback')}
-                              </Button>
-                            )}
-                          </td>
-                        </tr>
-                        {confirm && (
-                          <tr className="publication-confirm-row">
-                            <td colSpan={5}>
-                              <div className="publication-confirm" role="group" aria-label={t('publication.rollback')}>
-                                <div>
-                                  <strong>{t('publication.rollbackConfirm')}</strong>
-                                  <span>
-                                    {t('publication.rollbackTarget', {
-                                      publication: compactId(publication.publicationId),
-                                      revision: compactId(publication.revisionId),
-                                    })}
-                                  </span>
-                                </div>
-                                <div>
-                                  <Button disabled={rollingBackPublicationId != null} onClick={() => setConfirming(undefined)} size="sm" variant="outline">
-                                    {t('common.cancel')}
-                                  </Button>
-                                  <Button disabled={busy != null} onClick={() => void store.publications.rollback(publication)} size="sm" variant="destructive">
-                                    {t(rollingBackPublicationId == publication.publicationId ? 'publication.rollingBack' : 'publication.rollback')}
-                                  </Button>
-                                </div>
-                              </div>
-                            </td>
-                          </tr>
-                        )}
-                      </Fragment>
-                    )
-                  })}
-                </tbody>
-              </table>
-            </div>
-          )}
-          {nextCursor != null && (
-            <Button className="m-2" disabled={loadingMore} onClick={() => void store.publications.loadMore()} size="lg" variant="outline">
-              {t(loadingMore ? 'run.loadingMore' : loadMoreFailed ? 'run.retryLoadMore' : 'run.loadMore')}
-            </Button>
-          )}
-        </section>
-      </section>
+      {panel}
     </>
   )
 }

--- a/packages/open-flow/src/workbench/browser/runtime/publications/publicationsView.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/publications/publicationsView.tsx
@@ -130,6 +130,7 @@ export function PublicationsView({ store }: { readonly store: WorkbenchStore }):
   const publications = useVal(store.publications.$.publications)
   const flowId = useVal(store.workspace.$.flowId)
   const publishing = useVal(store.publications.$.publishing)
+  const refreshing = useVal(store.publications.$.refreshing)
   const rollingBackPublicationId = useVal(store.publications.$.rollingBackPublicationId)
   const revision = useVal(store.workspace.$.revision)
   const selectedTriggerId = useVal(store.publications.$.selectedTriggerId)
@@ -179,14 +180,25 @@ export function PublicationsView({ store }: { readonly store: WorkbenchStore }):
   const currentPublicationId = live?.publication?.publicationId
 
   return (
-    <section aria-labelledby="workspace-tab-publications" className="publication-view" id="workspace-panel-publications" role="tabpanel" tabIndex={0}>
+    <section
+      aria-busy={loading || refreshing}
+      aria-labelledby="workspace-tab-publications"
+      className="publication-view"
+      id="workspace-panel-publications"
+      role="tabpanel"
+      tabIndex={0}
+    >
       <section className="publication-summary">
         <div className="publication-summary-heading">
           <div>
             <h2>{t('publication.live')}</h2>
             <p>{t('publication.liveDescription')}</p>
           </div>
-          {loading && <span className="publication-loading">{t('publication.loading')}</span>}
+          {(loading || refreshing) && (
+            <span aria-live="polite" className="publication-loading">
+              {t('publication.loading')}
+            </span>
+          )}
         </div>
 
         {loadFailed ? (

--- a/packages/open-flow/src/workbench/browser/runtime/publications/publicationsView.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/publications/publicationsView.tsx
@@ -180,404 +180,414 @@ export function PublicationsView({ store }: { readonly store: WorkbenchStore }):
   const currentPublicationId = live?.publication?.publicationId
 
   return (
-    <section
-      aria-busy={loading || refreshing}
-      aria-labelledby="workspace-tab-publications"
-      className="publication-view"
-      id="workspace-panel-publications"
-      role="tabpanel"
-      tabIndex={0}
-    >
-      <section className="publication-summary">
-        <div className="publication-summary-heading">
-          <div>
-            <h2>{t('publication.live')}</h2>
-            <p>{t('publication.liveDescription')}</p>
-          </div>
-          {(loading || refreshing) && (
-            <span aria-live="polite" className="publication-loading">
-              {t('publication.loading')}
-            </span>
-          )}
-        </div>
-
-        {loadFailed ? (
-          <div className="publication-load-error">
-            <span>{t('publication.loadFailed')}</span>
-            <Button disabled={flowId == null} onClick={() => flowId != null && void store.publications.load(flowId)} size="sm" variant="outline">
-              {t('empty.retry')}
-            </Button>
-          </div>
-        ) : !loading ? (
-          <div className="publication-precondition">
-            {operation != null && operation.status != 'succeeded' && (
-              <div className={`publication-progress ${operation.status}`} role={operation.status == 'failed' ? 'alert' : 'status'}>
-                <span className={`status-dot ${operationClass}`} />
-                <div>
-                  <strong>{operationLabel}</strong>
-                  {operationDetail}
-                </div>
-              </div>
+    <>
+      <span className="sr-only" role="status">
+        {loading || refreshing ? t('publication.loading') : ''}
+      </span>
+      <section
+        aria-busy={loading || refreshing}
+        aria-labelledby="workspace-tab-publications"
+        className="publication-view"
+        id="workspace-panel-publications"
+        role="tabpanel"
+        tabIndex={0}
+      >
+        <section className="publication-summary">
+          <div className="publication-summary-heading">
+            <div>
+              <h2>{t('publication.live')}</h2>
+              <p>{t('publication.liveDescription')}</p>
+            </div>
+            {(loading || refreshing) && (
+              <span aria-hidden="true" className="publication-loading">
+                {t('publication.loading')}
+              </span>
             )}
-            <div className="publication-overview">
-              {live != null && (
-                <div className="publication-overview-main">
-                  <span className={`status-dot ${live.hasUnpublishedChanges ? 'running' : 'success'}`} />
-                  <div className="publication-overview-body">
-                    <div className="publication-overview-heading">
-                      <div className="publication-overview-result">
-                        <strong>{t(live.hasUnpublishedChanges ? 'workspace.unpublishedChanges' : 'publication.upToDate')}</strong>
-                        {live.hasUnpublishedChanges && <span>{t(invalid ? 'workspace.fixIssuesToPublish' : 'publication.publishDescription')}</span>}
-                      </div>
-                      <div className="publication-overview-actions">
-                        <span className="publication-status">
-                          <span className={`status-dot ${liveClass(live)}`} />
-                          {liveLabel(live, t)}
-                        </span>
-                        {draft != null && live.hasUnpublishedChanges && (
-                          <Button disabled={busy != null || invalid} onClick={() => void store.publications.publish()}>
-                            <Icon data-icon="inline-start" name="publish" />
-                            {t(publishing ? 'workspace.publishing' : 'publication.publishDraft')}
-                          </Button>
-                        )}
-                      </div>
-                    </div>
-                    <dl className="publication-overview-meta">
-                      <div>
-                        <dt>{t('publication.draftRevision')}</dt>
-                        <dd>{draft == null ? t('publication.noDraft') : <CompactId value={draft.revisionId} />}</dd>
-                      </div>
-                      <div>
-                        <dt>{t('publication.livePublication')}</dt>
-                        <dd>{live.publication == null ? t('publication.none') : <CompactId value={live.publication.publicationId} />}</dd>
-                      </div>
-                      <div>
-                        <dt>{t('publication.liveRevision')}</dt>
-                        <dd>{live.publication == null ? '—' : <CompactId value={live.publication.revisionId} />}</dd>
-                      </div>
-                      <div>
-                        <dt>{t('publication.liveVersion')}</dt>
-                        <dd>{live.revision}</dd>
-                      </div>
-                    </dl>
+          </div>
+
+          {loadFailed ? (
+            <div className="publication-load-error">
+              <span>{t('publication.loadFailed')}</span>
+              <Button disabled={flowId == null} onClick={() => flowId != null && void store.publications.load(flowId)} size="sm" variant="outline">
+                {t('empty.retry')}
+              </Button>
+            </div>
+          ) : !loading ? (
+            <div className="publication-precondition">
+              {operation != null && operation.status != 'succeeded' && (
+                <div className={`publication-progress ${operation.status}`} role={operation.status == 'failed' ? 'alert' : 'status'}>
+                  <span className={`status-dot ${operationClass}`} />
+                  <div>
+                    <strong>{operationLabel}</strong>
+                    {operationDetail}
                   </div>
                 </div>
               )}
-            </div>
-          </div>
-        ) : null}
-      </section>
-
-      <section className="publication-triggers">
-        <header>
-          <div>
-            <h2>{t('publication.triggers')}</h2>
-            <span>{t('publication.triggerDescription')}</span>
-          </div>
-        </header>
-        {loading ? (
-          <div className="publication-trigger-empty">{t('publication.loading')}</div>
-        ) : loadFailed ? (
-          <div className="publication-trigger-empty">{t('publication.loadFailed')}</div>
-        ) : bindings.length == 0 ? (
-          <div className="publication-trigger-empty">{t('publication.triggerEmpty')}</div>
-        ) : (
-          <div className="trigger-binding-list">
-            {bindings.map((binding) => {
-              const changing = changingTriggerId == binding.triggerNodeId
-              const selected = selectedTriggerId == binding.triggerNodeId
-              const resumable = binding.operatorState == 'paused'
-              return (
-                <Fragment key={binding.triggerNodeId}>
-                  <div className="trigger-binding-row">
-                    <Button
-                      aria-expanded={selected}
-                      className="trigger-binding-summary"
-                      onClick={() => (selected ? store.publications.closeTrigger() : void store.publications.openTrigger(binding.triggerNodeId))}
-                      type="button"
-                      variant="ghost"
-                    >
-                      <span className={`status-dot ${triggerClass(binding)}`} />
-                      <strong title={binding.triggerNodeId}>{triggerName(binding, revision)}</strong>
-                      <span className={'trigger-binding-state ' + triggerClass(binding)}>{triggerLabel(binding, t)}</span>
-                      <code className="trigger-binding-kind">{binding.kind}</code>
-                      <span className="trigger-binding-detail-label">{t(selected ? 'publication.hideTriggerDetails' : 'publication.triggerDetails')}</span>
-                      <Icon name={selected ? 'chevron-up' : 'chevron-down'} />
-                    </Button>
-                    {binding.currentPublicationId != null && (
-                      <Button
-                        disabled={busy != null || changingTriggerId != null}
-                        onClick={() => void store.publications.toggleTrigger(binding)}
-                        size="sm"
-                        variant="outline"
-                      >
-                        {t(
-                          changing
-                            ? resumable
-                              ? 'publication.resumingTrigger'
-                              : 'publication.pausingTrigger'
-                            : resumable
-                              ? 'publication.resumeTrigger'
-                              : 'publication.pauseTrigger',
-                        )}
-                      </Button>
-                    )}
-                  </div>
-                  {selected && (
-                    <div className="trigger-binding-detail">
-                      {detailLoading ? (
-                        <div className="publication-trigger-empty">{t('publication.loadingTrigger')}</div>
-                      ) : detail != null ? (
-                        <>
-                          <dl>
-                            <div>
-                              <dt>{t('publication.triggerKind')}</dt>
-                              <dd>{detail.binding.kind}</dd>
-                            </div>
-                            <div>
-                              <dt>{t('publication.runtimeVersion')}</dt>
-                              <dd>{detail.binding.runtimeVersion}</dd>
-                            </div>
-                            <div>
-                              <dt>{t('publication.triggerHealth')}</dt>
-                              <dd>{triggerLabel(detail.binding, t)}</dd>
-                            </div>
-                            <div>
-                              <dt>{t('publication.operatorState')}</dt>
-                              <dd>
-                                <span>{t(detail.binding.operatorState == 'paused' ? 'publication.suspended' : 'publication.active')}</span>{' '}
-                                <code>{detail.binding.operatorState}</code>
-                              </dd>
-                            </div>
-                            <div>
-                              <dt>{t('publication.updatedAt')}</dt>
-                              <dd>{new Date(detail.binding.updatedAt).toLocaleString(language)}</dd>
-                            </div>
-                            {detail.binding.lastErrorCode != null && (
-                              <div>
-                                <dt>{t('publication.lastError')}</dt>
-                                <dd>{detail.binding.lastErrorCode}</dd>
-                              </div>
-                            )}
-                          </dl>
-                          {detail.binding.health == 'needs_reauth' && <p className="trigger-recovery">{t('publication.needsReauthDescription')}</p>}
-                          {detail.binding.endpointUrl != null && (
-                            <div className="trigger-webhook">
-                              <span>{t('publication.webhookUrl')}</span>
-                              <div>
-                                <code title={detail.binding.endpointUrl}>{detail.binding.endpointUrl}</code>
-                                <Button
-                                  onClick={async () => {
-                                    await navigator.clipboard.writeText(detail.binding.endpointUrl!)
-                                    setCopiedEndpoint(detail.binding.endpointUrl)
-                                  }}
-                                  size="sm"
-                                  variant="outline"
-                                >
-                                  {t(copiedEndpoint == detail.binding.endpointUrl ? 'publication.webhookCopied' : 'publication.webhookCopy')}
-                                </Button>
-                              </div>
-                            </div>
-                          )}
-                          <div className="trigger-binding-detail-sections">
-                            {detail.binding.kind == 'poll' && detail.binding.currentPublicationId != null && (
-                              <section className="trigger-test">
-                                <header>
-                                  <div>
-                                    <h3>{t('publication.pollTest')}</h3>
-                                    <p>{t('publication.pollTestDescription')}</p>
-                                  </div>
-                                  <Button disabled={testingTriggerId != null} onClick={() => void store.publications.testTrigger()} size="sm" variant="outline">
-                                    {t(testingTriggerId == detail.binding.triggerNodeId ? 'publication.pollTesting' : 'publication.pollTest')}
-                                  </Button>
-                                </header>
-                                {testResult != null && (
-                                  <div className="trigger-test-result">
-                                    <strong>{t('publication.pollTestResult')}</strong>
-                                    <div className="trigger-test-summary">
-                                      <span>{t('publication.pollTestEvents', { count: testResult.events.length })}</span>
-                                      <span>{t('publication.pollTestFiltered', { count: testResult.filtered })}</span>
-                                      {testResult.hasMore && <span>{t('publication.pollTestHasMore')}</span>}
-                                    </div>
-                                    {testResult.events.length == 0 ? (
-                                      <p>{t('publication.pollTestNoEvents')}</p>
-                                    ) : (
-                                      <div className="trigger-test-events">
-                                        <JSONViewer data={testResult.events} shouldExpandNode={collapseAllNested} />
-                                      </div>
-                                    )}
-                                  </div>
-                                )}
-                              </section>
-                            )}
-                            <section className="trigger-activities">
-                              <h3>{t('publication.activities')}</h3>
-                              <p className="trigger-activities-description">{t('publication.activitiesDescription')}</p>
-                              {activitiesLoading ? (
-                                <div className="trigger-activities-empty">{t('publication.loadingTriggerActivities')}</div>
-                              ) : activities.length == 0 ? (
-                                <div className="trigger-activities-empty">
-                                  {t(activitiesLoadFailed ? 'publication.activitiesLoadFailed' : 'publication.activitiesEmpty')}
-                                </div>
-                              ) : (
-                                <div className="trigger-activity-list">
-                                  {activities.map((activity) => (
-                                    <div className="trigger-activity" key={activity.activityId}>
-                                      <span className="status-dot neutral" />
-                                      <div>
-                                        <strong>{activityLabel(activity.kind, t)}</strong>
-                                        {activity.errorCode != null && <code>{activity.errorCode}</code>}
-                                        {activity.errorMessage != null && <p className="trigger-activity-message">{activity.errorMessage}</p>}
-                                      </div>
-                                      <time dateTime={activity.createdAt}>{new Date(activity.createdAt).toLocaleString(language)}</time>
-                                    </div>
-                                  ))}
-                                </div>
-                              )}
-                              {(activitiesNextCursor != null || activitiesLoadFailed) && !activitiesLoading && (
-                                <Button
-                                  className="trigger-activities-more"
-                                  disabled={activitiesLoadingMore}
-                                  onClick={() =>
-                                    void (activitiesNextCursor == null
-                                      ? store.publications.openTrigger(detail.binding.triggerNodeId)
-                                      : store.publications.loadMoreTriggerActivities())
-                                  }
-                                  size="sm"
-                                  variant="outline"
-                                >
-                                  {t(
-                                    activitiesLoadingMore
-                                      ? 'publication.loadingTriggerActivities'
-                                      : activitiesLoadFailed
-                                        ? 'empty.retry'
-                                        : 'publication.loadMoreActivities',
-                                  )}
-                                </Button>
-                              )}
-                            </section>
-                          </div>
-                        </>
-                      ) : null}
-                    </div>
-                  )}
-                </Fragment>
-              )
-            })}
-          </div>
-        )}
-      </section>
-
-      <section className="publication-history">
-        <header>
-          <div>
-            <h2>{t('publication.history')}</h2>
-            <span>{t('publication.historyCount', { count: total ?? publications.length })}</span>
-          </div>
-        </header>
-        {loading ? (
-          <div className="publication-history-loading">{t('publication.loading')}</div>
-        ) : publications.length == 0 ? (
-          <Empty className="h-full rounded-none">
-            <EmptyHeader>
-              <EmptyMedia variant="icon">
-                <Icon name="publish" />
-              </EmptyMedia>
-              <EmptyTitle>{t('publication.historyEmpty')}</EmptyTitle>
-              <EmptyDescription>{t('publication.historyEmptyDescription')}</EmptyDescription>
-            </EmptyHeader>
-          </Empty>
-        ) : (
-          <div className="publication-table-wrap">
-            <table className="publication-table">
-              <thead>
-                <tr>
-                  <th>{t('publication.operation')}</th>
-                  <th>{t('publication.revision')}</th>
-                  <th>{t('publication.actor')}</th>
-                  <th>{t('publication.createdAt')}</th>
-                  <th aria-label={t('publication.actions')} />
-                </tr>
-              </thead>
-              <tbody>
-                {publications.map((publication) => {
-                  const current = publication.publicationId == currentPublicationId
-                  const confirm = confirming == publication.publicationId
-                  return (
-                    <Fragment key={publication.publicationId}>
-                      <tr>
-                        <td data-label={t('publication.operation')}>
-                          <span className="publication-operation">
-                            {t(publication.operation == 'publish' ? 'publication.published' : 'publication.rolledBack')}
-                            {current && <Badge variant="secondary">{t('publication.current')}</Badge>}
+              <div className="publication-overview">
+                {live != null && (
+                  <div className="publication-overview-main">
+                    <span className={`status-dot ${live.hasUnpublishedChanges ? 'running' : 'success'}`} />
+                    <div className="publication-overview-body">
+                      <div className="publication-overview-heading">
+                        <div className="publication-overview-result">
+                          <strong>{t(live.hasUnpublishedChanges ? 'workspace.unpublishedChanges' : 'publication.upToDate')}</strong>
+                          {live.hasUnpublishedChanges && <span>{t(invalid ? 'workspace.fixIssuesToPublish' : 'publication.publishDescription')}</span>}
+                        </div>
+                        <div className="publication-overview-actions">
+                          <span className="publication-status">
+                            <span className={`status-dot ${liveClass(live)}`} />
+                            {liveLabel(live, t)}
                           </span>
-                          <CompactId value={publication.publicationId} />
-                        </td>
-                        <td data-label={t('publication.revision')}>
-                          <CompactId value={publication.revisionId} />
-                          {publication.sourcePublicationId != null && (
-                            <span title={publication.sourcePublicationId}>
-                              {t('publication.fromPublication', { id: compactId(publication.sourcePublicationId) })}
-                            </span>
-                          )}
-                        </td>
-                        <td data-label={t('publication.actor')}>
-                          <CompactId value={publication.actorId} />
-                        </td>
-                        <td data-label={t('publication.createdAt')}>
-                          <time dateTime={publication.createdAt}>{new Date(publication.createdAt).toLocaleString(language)}</time>
-                        </td>
-                        <td data-label={t('publication.actions')}>
-                          {!current && currentPublicationId != null && (
-                            <Button
-                              disabled={busy != null}
-                              onClick={() => setConfirming(confirm ? undefined : publication.publicationId)}
-                              size="sm"
-                              variant="outline"
-                            >
-                              {t('publication.rollback')}
+                          {draft != null && live.hasUnpublishedChanges && (
+                            <Button disabled={busy != null || invalid} onClick={() => void store.publications.publish()}>
+                              <Icon data-icon="inline-start" name="publish" />
+                              {t(publishing ? 'workspace.publishing' : 'publication.publishDraft')}
                             </Button>
                           )}
-                        </td>
-                      </tr>
-                      {confirm && (
-                        <tr className="publication-confirm-row">
-                          <td colSpan={5}>
-                            <div className="publication-confirm" role="group" aria-label={t('publication.rollback')}>
+                        </div>
+                      </div>
+                      <dl className="publication-overview-meta">
+                        <div>
+                          <dt>{t('publication.draftRevision')}</dt>
+                          <dd>{draft == null ? t('publication.noDraft') : <CompactId value={draft.revisionId} />}</dd>
+                        </div>
+                        <div>
+                          <dt>{t('publication.livePublication')}</dt>
+                          <dd>{live.publication == null ? t('publication.none') : <CompactId value={live.publication.publicationId} />}</dd>
+                        </div>
+                        <div>
+                          <dt>{t('publication.liveRevision')}</dt>
+                          <dd>{live.publication == null ? '—' : <CompactId value={live.publication.revisionId} />}</dd>
+                        </div>
+                        <div>
+                          <dt>{t('publication.liveVersion')}</dt>
+                          <dd>{live.revision}</dd>
+                        </div>
+                      </dl>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          ) : null}
+        </section>
+
+        <section className="publication-triggers">
+          <header>
+            <div>
+              <h2>{t('publication.triggers')}</h2>
+              <span>{t('publication.triggerDescription')}</span>
+            </div>
+          </header>
+          {loading ? (
+            <div className="publication-trigger-empty">{t('publication.loading')}</div>
+          ) : loadFailed ? (
+            <div className="publication-trigger-empty">{t('publication.loadFailed')}</div>
+          ) : bindings.length == 0 ? (
+            <div className="publication-trigger-empty">{t('publication.triggerEmpty')}</div>
+          ) : (
+            <div className="trigger-binding-list">
+              {bindings.map((binding) => {
+                const changing = changingTriggerId == binding.triggerNodeId
+                const selected = selectedTriggerId == binding.triggerNodeId
+                const resumable = binding.operatorState == 'paused'
+                return (
+                  <Fragment key={binding.triggerNodeId}>
+                    <div className="trigger-binding-row">
+                      <Button
+                        aria-expanded={selected}
+                        className="trigger-binding-summary"
+                        onClick={() => (selected ? store.publications.closeTrigger() : void store.publications.openTrigger(binding.triggerNodeId))}
+                        type="button"
+                        variant="ghost"
+                      >
+                        <span className={`status-dot ${triggerClass(binding)}`} />
+                        <strong title={binding.triggerNodeId}>{triggerName(binding, revision)}</strong>
+                        <span className={'trigger-binding-state ' + triggerClass(binding)}>{triggerLabel(binding, t)}</span>
+                        <code className="trigger-binding-kind">{binding.kind}</code>
+                        <span className="trigger-binding-detail-label">{t(selected ? 'publication.hideTriggerDetails' : 'publication.triggerDetails')}</span>
+                        <Icon name={selected ? 'chevron-up' : 'chevron-down'} />
+                      </Button>
+                      {binding.currentPublicationId != null && (
+                        <Button
+                          disabled={busy != null || changingTriggerId != null}
+                          onClick={() => void store.publications.toggleTrigger(binding)}
+                          size="sm"
+                          variant="outline"
+                        >
+                          {t(
+                            changing
+                              ? resumable
+                                ? 'publication.resumingTrigger'
+                                : 'publication.pausingTrigger'
+                              : resumable
+                                ? 'publication.resumeTrigger'
+                                : 'publication.pauseTrigger',
+                          )}
+                        </Button>
+                      )}
+                    </div>
+                    {selected && (
+                      <div className="trigger-binding-detail">
+                        {detailLoading ? (
+                          <div className="publication-trigger-empty">{t('publication.loadingTrigger')}</div>
+                        ) : detail != null ? (
+                          <>
+                            <dl>
                               <div>
-                                <strong>{t('publication.rollbackConfirm')}</strong>
-                                <span>
-                                  {t('publication.rollbackTarget', {
-                                    publication: compactId(publication.publicationId),
-                                    revision: compactId(publication.revisionId),
-                                  })}
-                                </span>
+                                <dt>{t('publication.triggerKind')}</dt>
+                                <dd>{detail.binding.kind}</dd>
                               </div>
                               <div>
-                                <Button disabled={rollingBackPublicationId != null} onClick={() => setConfirming(undefined)} size="sm" variant="outline">
-                                  {t('common.cancel')}
-                                </Button>
-                                <Button disabled={busy != null} onClick={() => void store.publications.rollback(publication)} size="sm" variant="destructive">
-                                  {t(rollingBackPublicationId == publication.publicationId ? 'publication.rollingBack' : 'publication.rollback')}
-                                </Button>
+                                <dt>{t('publication.runtimeVersion')}</dt>
+                                <dd>{detail.binding.runtimeVersion}</dd>
                               </div>
+                              <div>
+                                <dt>{t('publication.triggerHealth')}</dt>
+                                <dd>{triggerLabel(detail.binding, t)}</dd>
+                              </div>
+                              <div>
+                                <dt>{t('publication.operatorState')}</dt>
+                                <dd>
+                                  <span>{t(detail.binding.operatorState == 'paused' ? 'publication.suspended' : 'publication.active')}</span>{' '}
+                                  <code>{detail.binding.operatorState}</code>
+                                </dd>
+                              </div>
+                              <div>
+                                <dt>{t('publication.updatedAt')}</dt>
+                                <dd>{new Date(detail.binding.updatedAt).toLocaleString(language)}</dd>
+                              </div>
+                              {detail.binding.lastErrorCode != null && (
+                                <div>
+                                  <dt>{t('publication.lastError')}</dt>
+                                  <dd>{detail.binding.lastErrorCode}</dd>
+                                </div>
+                              )}
+                            </dl>
+                            {detail.binding.health == 'needs_reauth' && <p className="trigger-recovery">{t('publication.needsReauthDescription')}</p>}
+                            {detail.binding.endpointUrl != null && (
+                              <div className="trigger-webhook">
+                                <span>{t('publication.webhookUrl')}</span>
+                                <div>
+                                  <code title={detail.binding.endpointUrl}>{detail.binding.endpointUrl}</code>
+                                  <Button
+                                    onClick={async () => {
+                                      await navigator.clipboard.writeText(detail.binding.endpointUrl!)
+                                      setCopiedEndpoint(detail.binding.endpointUrl)
+                                    }}
+                                    size="sm"
+                                    variant="outline"
+                                  >
+                                    {t(copiedEndpoint == detail.binding.endpointUrl ? 'publication.webhookCopied' : 'publication.webhookCopy')}
+                                  </Button>
+                                </div>
+                              </div>
+                            )}
+                            <div className="trigger-binding-detail-sections">
+                              {detail.binding.kind == 'poll' && detail.binding.currentPublicationId != null && (
+                                <section className="trigger-test">
+                                  <header>
+                                    <div>
+                                      <h3>{t('publication.pollTest')}</h3>
+                                      <p>{t('publication.pollTestDescription')}</p>
+                                    </div>
+                                    <Button
+                                      disabled={testingTriggerId != null}
+                                      onClick={() => void store.publications.testTrigger()}
+                                      size="sm"
+                                      variant="outline"
+                                    >
+                                      {t(testingTriggerId == detail.binding.triggerNodeId ? 'publication.pollTesting' : 'publication.pollTest')}
+                                    </Button>
+                                  </header>
+                                  {testResult != null && (
+                                    <div className="trigger-test-result">
+                                      <strong>{t('publication.pollTestResult')}</strong>
+                                      <div className="trigger-test-summary">
+                                        <span>{t('publication.pollTestEvents', { count: testResult.events.length })}</span>
+                                        <span>{t('publication.pollTestFiltered', { count: testResult.filtered })}</span>
+                                        {testResult.hasMore && <span>{t('publication.pollTestHasMore')}</span>}
+                                      </div>
+                                      {testResult.events.length == 0 ? (
+                                        <p>{t('publication.pollTestNoEvents')}</p>
+                                      ) : (
+                                        <div className="trigger-test-events">
+                                          <JSONViewer data={testResult.events} shouldExpandNode={collapseAllNested} />
+                                        </div>
+                                      )}
+                                    </div>
+                                  )}
+                                </section>
+                              )}
+                              <section className="trigger-activities">
+                                <h3>{t('publication.activities')}</h3>
+                                <p className="trigger-activities-description">{t('publication.activitiesDescription')}</p>
+                                {activitiesLoading ? (
+                                  <div className="trigger-activities-empty">{t('publication.loadingTriggerActivities')}</div>
+                                ) : activities.length == 0 ? (
+                                  <div className="trigger-activities-empty">
+                                    {t(activitiesLoadFailed ? 'publication.activitiesLoadFailed' : 'publication.activitiesEmpty')}
+                                  </div>
+                                ) : (
+                                  <div className="trigger-activity-list">
+                                    {activities.map((activity) => (
+                                      <div className="trigger-activity" key={activity.activityId}>
+                                        <span className="status-dot neutral" />
+                                        <div>
+                                          <strong>{activityLabel(activity.kind, t)}</strong>
+                                          {activity.errorCode != null && <code>{activity.errorCode}</code>}
+                                          {activity.errorMessage != null && <p className="trigger-activity-message">{activity.errorMessage}</p>}
+                                        </div>
+                                        <time dateTime={activity.createdAt}>{new Date(activity.createdAt).toLocaleString(language)}</time>
+                                      </div>
+                                    ))}
+                                  </div>
+                                )}
+                                {(activitiesNextCursor != null || activitiesLoadFailed) && !activitiesLoading && (
+                                  <Button
+                                    className="trigger-activities-more"
+                                    disabled={activitiesLoadingMore}
+                                    onClick={() =>
+                                      void (activitiesNextCursor == null
+                                        ? store.publications.openTrigger(detail.binding.triggerNodeId)
+                                        : store.publications.loadMoreTriggerActivities())
+                                    }
+                                    size="sm"
+                                    variant="outline"
+                                  >
+                                    {t(
+                                      activitiesLoadingMore
+                                        ? 'publication.loadingTriggerActivities'
+                                        : activitiesLoadFailed
+                                          ? 'empty.retry'
+                                          : 'publication.loadMoreActivities',
+                                    )}
+                                  </Button>
+                                )}
+                              </section>
                             </div>
+                          </>
+                        ) : null}
+                      </div>
+                    )}
+                  </Fragment>
+                )
+              })}
+            </div>
+          )}
+        </section>
+
+        <section className="publication-history">
+          <header>
+            <div>
+              <h2>{t('publication.history')}</h2>
+              <span>{t('publication.historyCount', { count: total ?? publications.length })}</span>
+            </div>
+          </header>
+          {loading ? (
+            <div className="publication-history-loading">{t('publication.loading')}</div>
+          ) : publications.length == 0 ? (
+            <Empty className="h-full rounded-none">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <Icon name="publish" />
+                </EmptyMedia>
+                <EmptyTitle>{t('publication.historyEmpty')}</EmptyTitle>
+                <EmptyDescription>{t('publication.historyEmptyDescription')}</EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          ) : (
+            <div className="publication-table-wrap">
+              <table className="publication-table">
+                <thead>
+                  <tr>
+                    <th>{t('publication.operation')}</th>
+                    <th>{t('publication.revision')}</th>
+                    <th>{t('publication.actor')}</th>
+                    <th>{t('publication.createdAt')}</th>
+                    <th aria-label={t('publication.actions')} />
+                  </tr>
+                </thead>
+                <tbody>
+                  {publications.map((publication) => {
+                    const current = publication.publicationId == currentPublicationId
+                    const confirm = confirming == publication.publicationId
+                    return (
+                      <Fragment key={publication.publicationId}>
+                        <tr>
+                          <td data-label={t('publication.operation')}>
+                            <span className="publication-operation">
+                              {t(publication.operation == 'publish' ? 'publication.published' : 'publication.rolledBack')}
+                              {current && <Badge variant="secondary">{t('publication.current')}</Badge>}
+                            </span>
+                            <CompactId value={publication.publicationId} />
+                          </td>
+                          <td data-label={t('publication.revision')}>
+                            <CompactId value={publication.revisionId} />
+                            {publication.sourcePublicationId != null && (
+                              <span title={publication.sourcePublicationId}>
+                                {t('publication.fromPublication', { id: compactId(publication.sourcePublicationId) })}
+                              </span>
+                            )}
+                          </td>
+                          <td data-label={t('publication.actor')}>
+                            <CompactId value={publication.actorId} />
+                          </td>
+                          <td data-label={t('publication.createdAt')}>
+                            <time dateTime={publication.createdAt}>{new Date(publication.createdAt).toLocaleString(language)}</time>
+                          </td>
+                          <td data-label={t('publication.actions')}>
+                            {!current && currentPublicationId != null && (
+                              <Button
+                                disabled={busy != null}
+                                onClick={() => setConfirming(confirm ? undefined : publication.publicationId)}
+                                size="sm"
+                                variant="outline"
+                              >
+                                {t('publication.rollback')}
+                              </Button>
+                            )}
                           </td>
                         </tr>
-                      )}
-                    </Fragment>
-                  )
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
-        {nextCursor != null && (
-          <Button className="m-2" disabled={loadingMore} onClick={() => void store.publications.loadMore()} size="lg" variant="outline">
-            {t(loadingMore ? 'run.loadingMore' : loadMoreFailed ? 'run.retryLoadMore' : 'run.loadMore')}
-          </Button>
-        )}
+                        {confirm && (
+                          <tr className="publication-confirm-row">
+                            <td colSpan={5}>
+                              <div className="publication-confirm" role="group" aria-label={t('publication.rollback')}>
+                                <div>
+                                  <strong>{t('publication.rollbackConfirm')}</strong>
+                                  <span>
+                                    {t('publication.rollbackTarget', {
+                                      publication: compactId(publication.publicationId),
+                                      revision: compactId(publication.revisionId),
+                                    })}
+                                  </span>
+                                </div>
+                                <div>
+                                  <Button disabled={rollingBackPublicationId != null} onClick={() => setConfirming(undefined)} size="sm" variant="outline">
+                                    {t('common.cancel')}
+                                  </Button>
+                                  <Button disabled={busy != null} onClick={() => void store.publications.rollback(publication)} size="sm" variant="destructive">
+                                    {t(rollingBackPublicationId == publication.publicationId ? 'publication.rollingBack' : 'publication.rollback')}
+                                  </Button>
+                                </div>
+                              </div>
+                            </td>
+                          </tr>
+                        )}
+                      </Fragment>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {nextCursor != null && (
+            <Button className="m-2" disabled={loadingMore} onClick={() => void store.publications.loadMore()} size="lg" variant="outline">
+              {t(loadingMore ? 'run.loadingMore' : loadMoreFailed ? 'run.retryLoadMore' : 'run.loadMore')}
+            </Button>
+          )}
+        </section>
       </section>
-    </section>
+    </>
   )
 }

--- a/packages/open-flow/src/workbench/browser/runtime/runs/runStore.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/runs/runStore.test.ts
@@ -23,7 +23,7 @@ const details = {
 } as const
 
 describe('RunStore', () => {
-  it('keeps the selected Run visible while refreshing the loaded history', async () => {
+  it('keeps the selected Run visible while a notification refreshes the loaded history', async () => {
     const refreshed = Promise.withResolvers<Response>()
     let listReads = 0
     const request = vi.fn(async (path: string) => {
@@ -47,18 +47,17 @@ describe('RunStore', () => {
       await store.load('flow-1')
       await vi.waitFor(() => expect(store.$.run.value).toEqual(details))
 
-      const refreshing = store.load('flow-1')
+      store.changed(run.runId)
       expect(store.$.loading.value).toBe(false)
       expect(store.$.refreshing.value).toBe(true)
       expect(store.$.runs.value).toEqual([details])
 
       const newer = { ...run, runId: 'run-2' }
-      refreshed.resolve(Response.json({ flowId: 'flow-1', runs: [newer, run], version: 1 }))
-      await refreshing
+      refreshed.resolve(Response.json({ flowId: 'flow-1', runs: [newer], version: 1 }))
+      await vi.waitFor(() => expect(store.$.refreshing.value).toBe(false))
 
-      expect(store.$.refreshing.value).toBe(false)
-      expect(store.$.runs.value.map((item) => item.runId)).toEqual(['run-2', 'run-1'])
-      expect(store.$.runs.value[1]).toBe(store.$.run.value)
+      expect(store.$.runs.value.map((item) => item.runId)).toEqual(['run-1', 'run-2'])
+      expect(store.$.runs.value[0]).toBe(store.$.run.value)
       expect(store.$.run.value).toEqual(details)
     } finally {
       store.dispose()

--- a/packages/open-flow/src/workbench/browser/runtime/runs/runStore.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/runs/runStore.test.ts
@@ -98,4 +98,54 @@ describe('RunStore', () => {
       store.dispose()
     }
   })
+
+  it('allows pagination after a notification refresh replaces it and fails', async () => {
+    const pendingPage = Promise.withResolvers<Response>()
+    const next = { ...run, runId: 'run-2' }
+    let listReads = 0
+    let pageReads = 0
+    const request = vi.fn(async (path: string) => {
+      if (path == '/v1/flows/flow-1/runs?limit=50') {
+        listReads += 1
+        if (listReads == 1) return Response.json({ flowId: 'flow-1', nextCursor: 'page-2', runs: [run], version: 1 })
+        throw new Error('Refresh failed')
+      }
+      if (path == '/v1/flows/flow-1/runs?cursor=page-2&limit=50') {
+        pageReads += 1
+        if (pageReads == 1) return await pendingPage.promise
+        return Response.json({ flowId: 'flow-1', runs: [next], version: 1 })
+      }
+      if (path == '/v1/runs/run-1') return Response.json(details)
+      if (path == '/v1/runs/run-1/events?after=0&limit=100') {
+        return Response.json({ done: true, events: [], historyComplete: true, nextAfter: 0, runId: run.runId, version: 1 })
+      }
+      if (path == '/v1/runs/run-1/result') {
+        return Response.json({ finishedAt: timestamp, result: null, runId: run.runId, status: 'completed', version: 1 })
+      }
+      throw new Error(`Unexpected request: ${path}`)
+    })
+    const store = new RunStore(new WorkbenchClient(request), vi.fn())
+
+    try {
+      await store.load('flow-1')
+
+      const stalePage = store.loadMore()
+      expect(store.$.loadingMore.value).toBe(true)
+
+      store.changed('another-run')
+      expect(store.$.refreshing.value).toBe(true)
+      await vi.waitFor(() => expect(store.$.refreshing.value).toBe(false))
+      expect(store.$.loadingMore.value).toBe(false)
+
+      await store.loadMore()
+      expect(pageReads).toBe(2)
+      expect(store.$.runs.value.map((item) => item.runId)).toEqual(['run-1', 'run-2'])
+
+      pendingPage.resolve(Response.json({ flowId: 'flow-1', runs: [], version: 1 }))
+      await stalePage
+      expect(store.$.runs.value.map((item) => item.runId)).toEqual(['run-1', 'run-2'])
+    } finally {
+      store.dispose()
+    }
+  })
 })

--- a/packages/open-flow/src/workbench/browser/runtime/runs/runStore.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/runs/runStore.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest'
+import { WorkbenchClient } from '../api.ts'
+import { RunStore } from './runStore.ts'
+
+const timestamp = '2026-09-04T00:00:00.000Z'
+const run = {
+  createdAt: timestamp,
+  finishedAt: timestamp,
+  flowId: 'flow-1',
+  revisionId: 'revision-1',
+  runId: 'run-1',
+  source: 'draft',
+  status: 'completed',
+  version: 1,
+} as const
+const details = {
+  ...run,
+  closureDigest: 'closure-1',
+  engineContract: 'open-flow-engine/v1',
+  engineDigest: 'engine-1',
+  modelVersion: 1,
+  revisionDigest: 'digest-1',
+} as const
+
+describe('RunStore', () => {
+  it('keeps the selected Run visible while refreshing the loaded history', async () => {
+    const refreshed = Promise.withResolvers<Response>()
+    let listReads = 0
+    const request = vi.fn(async (path: string) => {
+      if (path == '/v1/flows/flow-1/runs?limit=50') {
+        listReads += 1
+        if (listReads == 1) return Response.json({ flowId: 'flow-1', runs: [run], version: 1 })
+        return await refreshed.promise
+      }
+      if (path == '/v1/runs/run-1') return Response.json(details)
+      if (path == '/v1/runs/run-1/events?after=0&limit=100') {
+        return Response.json({ done: true, events: [], historyComplete: true, nextAfter: 0, runId: run.runId, version: 1 })
+      }
+      if (path == '/v1/runs/run-1/result') {
+        return Response.json({ finishedAt: timestamp, result: null, runId: run.runId, status: 'completed', version: 1 })
+      }
+      throw new Error(`Unexpected request: ${path}`)
+    })
+    const store = new RunStore(new WorkbenchClient(request), vi.fn())
+
+    try {
+      await store.load('flow-1')
+      await vi.waitFor(() => expect(store.$.run.value).toEqual(details))
+
+      const refreshing = store.load('flow-1')
+      expect(store.$.loading.value).toBe(false)
+      expect(store.$.refreshing.value).toBe(true)
+      expect(store.$.runs.value).toEqual([details])
+
+      const newer = { ...run, runId: 'run-2' }
+      refreshed.resolve(Response.json({ flowId: 'flow-1', runs: [newer, run], version: 1 }))
+      await refreshing
+
+      expect(store.$.refreshing.value).toBe(false)
+      expect(store.$.runs.value.map((item) => item.runId)).toEqual(['run-2', 'run-1'])
+      expect(store.$.runs.value[1]).toBe(store.$.run.value)
+      expect(store.$.run.value).toEqual(details)
+    } finally {
+      store.dispose()
+    }
+  })
+
+  it('shows a newly started Run without waiting for an older history request', async () => {
+    const listed = Promise.withResolvers<Response>()
+    const request = vi.fn(async (path: string) => {
+      if (path == '/v1/flows/flow-1/runs?limit=50') return await listed.promise
+      if (path == '/v1/runs/run-1') return Response.json(details)
+      if (path == '/v1/runs/run-1/events?after=0&limit=100') {
+        return Response.json({ done: true, events: [], historyComplete: true, nextAfter: 0, runId: run.runId, version: 1 })
+      }
+      if (path == '/v1/runs/run-1/result') {
+        return Response.json({ finishedAt: timestamp, result: null, runId: run.runId, status: 'completed', version: 1 })
+      }
+      throw new Error(`Unexpected request: ${path}`)
+    })
+    const store = new RunStore(new WorkbenchClient(request), vi.fn())
+
+    try {
+      const loading = store.load('flow-1')
+      expect(store.$.loading.value).toBe(true)
+
+      const current = store.prepareStart()
+      expect(store.follow(run, current)).toBe(true)
+      expect(store.$.loading.value).toBe(false)
+      expect(store.$.run.value).toEqual(run)
+      expect(store.$.runs.value).toEqual([run])
+
+      listed.resolve(Response.json({ flowId: 'flow-1', runs: [], version: 1 }))
+      await loading
+
+      expect(store.$.run.value?.runId).toBe(run.runId)
+      expect(store.$.runs.value.map((item) => item.runId)).toEqual([run.runId])
+    } finally {
+      store.dispose()
+    }
+  })
+})

--- a/packages/open-flow/src/workbench/browser/runtime/runs/runStore.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/runs/runStore.ts
@@ -440,7 +440,7 @@ export class RunStore {
 
   async #refreshList(flowId: string): Promise<void> {
     const current = this.#lists.begin()
-    this.#set({ refreshing: true })
+    this.#set({ loadingMore: false, refreshing: true })
     try {
       const page = await this.#client.listRuns(flowId, { limit: 50 })
       if (!current() || this.#state.value.target?.flowId != flowId) return

--- a/packages/open-flow/src/workbench/browser/runtime/runs/runStore.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/runs/runStore.ts
@@ -4,7 +4,7 @@ import type { WorkbenchClient, Run, RunDetails, RunEvent, RunResult, WaitAction 
 import type { Current } from '../stores/latest.ts'
 import type { SetNotice } from '../stores/workbenchNotice.ts'
 
-import { derive, val } from 'value-enhancer'
+import { arrayShallowEqual, derive, val } from 'value-enhancer'
 import { isRunTerminal } from '../../../../execution/common/runLifecycle.ts'
 import { ApiError } from '../api.ts'
 import { createI18n } from '../i18n.ts'
@@ -19,16 +19,19 @@ interface RunState {
   readonly eventsExpiresAt?: string
   readonly externalRunId?: string
   readonly historyComplete: boolean
+  readonly loaded: boolean
   readonly loadFailed: boolean
   readonly loading: boolean
   readonly loadMoreFailed: boolean
   readonly loadingMore: boolean
   readonly nextCursor?: string
   readonly observationFailed: boolean
+  readonly refreshing: boolean
   readonly result?: RunResult
   readonly resolvingAction?: WaitAction
-  readonly run?: Run | RunDetails
-  readonly runs: readonly Run[]
+  readonly runById: ReadonlyMap<string, Run | RunDetails>
+  readonly runIds: readonly string[]
+  readonly selectedRunId?: string
   readonly target?: { readonly flowId: string }
 }
 
@@ -47,6 +50,7 @@ export interface Run$ {
   readonly loadingMore: ReadonlyVal<boolean>
   readonly nextCursor: ReadonlyVal<string | undefined>
   readonly observationFailed: ReadonlyVal<boolean>
+  readonly refreshing: ReadonlyVal<boolean>
   readonly result: ReadonlyVal<RunResult | undefined>
   readonly resolvingAction: ReadonlyVal<WaitAction | undefined>
   readonly run: ReadonlyVal<Run | RunDetails | undefined>
@@ -60,12 +64,15 @@ const initialState: RunState = {
   eventFilter: 'all',
   events: [],
   historyComplete: true,
+  loaded: false,
   loadFailed: false,
   loading: false,
   loadMoreFailed: false,
   loadingMore: false,
   observationFailed: false,
-  runs: [],
+  refreshing: false,
+  runById: new Map(),
+  runIds: [],
 }
 
 const eventPageLimit = 100
@@ -75,6 +82,21 @@ const waitingPollDelay = 60_000
 
 export function canCancelRun(run: Run | undefined): run is Run & { readonly status: 'queued' | 'running' | 'starting' | 'waiting' } {
   return run?.status == 'queued' || run?.status == 'starting' || run?.status == 'running' || run?.status == 'waiting'
+}
+
+function selectedRun(state: RunState): Run | RunDetails | undefined {
+  return state.selectedRunId == null ? undefined : state.runById.get(state.selectedRunId)
+}
+
+function listedRuns(state: RunState, runs: readonly Run[]): Pick<RunState, 'runById' | 'runIds'> {
+  const runById = new Map(runs.map((run) => [run.runId, run] as const))
+  const selected = selectedRun(state)
+  if (selected != null) runById.set(selected.runId, selected)
+  return { runById, runIds: runs.map((run) => run.runId) }
+}
+
+function replaceRun(state: RunState, run: Run | RunDetails): ReadonlyMap<string, Run | RunDetails> {
+  return new Map(state.runById).set(run.runId, run)
 }
 
 export class RunStore {
@@ -106,10 +128,19 @@ export class RunStore {
       loadingMore: derive(this.#state, (state) => state.loadingMore),
       nextCursor: derive(this.#state, (state) => state.nextCursor),
       observationFailed: derive(this.#state, (state) => state.observationFailed),
+      refreshing: derive(this.#state, (state) => state.refreshing),
       result: derive(this.#state, (state) => state.result),
       resolvingAction: derive(this.#state, (state) => state.resolvingAction),
-      run: derive(this.#state, (state) => state.run),
-      runs: derive(this.#state, (state) => state.runs),
+      run: derive(this.#state, selectedRun),
+      runs: derive(
+        this.#state,
+        (state) =>
+          state.runIds.flatMap((runId) => {
+            const run = state.runById.get(runId)
+            return run == null ? [] : [run]
+          }),
+        { equal: arrayShallowEqual },
+      ),
     }
   }
 
@@ -131,12 +162,26 @@ export class RunStore {
   }
 
   public async load(flowId: string): Promise<void> {
+    const state = this.#state.value
+    const warm = state.loaded && state.target?.flowId == flowId
     const current = this.#lists.begin()
+    if (warm) {
+      this.#set({ loadFailed: false, loadingMore: false, loadMoreFailed: false, refreshing: true })
+      try {
+        const page = await this.#client.listRuns(flowId, { limit: 50 })
+        if (!current() || this.#state.value.target?.flowId != flowId) return
+        this.#set({ ...listedRuns(this.#state.value, page.runs), nextCursor: page.nextCursor, refreshing: false })
+      } catch (error) {
+        if (!current()) return
+        this.#set({ refreshing: false })
+        this.#setNotice(errorNotice(error, this.#i18n.t))
+      }
+      return
+    }
     this.#selection.invalidate()
     this.#clearTimer()
     this.#setNotice(undefined)
-    const state = this.#state.value
-    const cancelingRunId = state.run?.flowId == flowId ? state.cancelingRunId : undefined
+    const cancelingRunId = selectedRun(state)?.flowId == flowId ? state.cancelingRunId : undefined
     if (state.cancelingRunId != null && cancelingRunId == null) this.#cancellation.invalidate()
     this.#state.set({
       ...initialState,
@@ -148,7 +193,7 @@ export class RunStore {
     try {
       const page = await this.#client.listRuns(flowId, { limit: 50 })
       if (!current()) return
-      this.#set({ loadFailed: false, loading: false, nextCursor: page.nextCursor, runs: page.runs })
+      this.#set({ ...listedRuns(this.#state.value, page.runs), loaded: true, loadFailed: false, loading: false, nextCursor: page.nextCursor })
       const first = page.runs[0]
       if (first != null) this.#observe(first)
     } catch (error) {
@@ -169,12 +214,19 @@ export class RunStore {
         limit: 50,
       })
       if (!current()) return
-      const seen = new Set(this.#state.value.runs.map((run) => run.runId))
+      const state = this.#state.value
+      const seen = new Set(state.runIds)
+      const runs = page.runs.filter((run) => !seen.has(run.runId))
+      const runById = new Map(state.runById)
+      for (const run of runs) {
+        if (run.runId != state.selectedRunId) runById.set(run.runId, run)
+      }
       this.#set({
         loadingMore: false,
         loadMoreFailed: false,
         nextCursor: page.nextCursor,
-        runs: [...this.#state.value.runs, ...page.runs.filter((run) => !seen.has(run.runId))],
+        runById,
+        runIds: [...state.runIds, ...runs.map((run) => run.runId)],
       })
     } catch (error) {
       if (!current()) return
@@ -186,13 +238,14 @@ export class RunStore {
   public changed(runId: string): void {
     const state = this.#state.value
     if (state.target == null) return
-    if (state.run?.runId == runId) this.retryObservation()
+    if (state.selectedRunId == runId) this.retryObservation()
     void this.#refreshList(state.target.flowId)
   }
 
   public select(runId: string): void {
-    const run = this.#state.value.runs.find((candidate) => candidate.runId == runId)
-    if (run != null && run.runId != this.#state.value.run?.runId) this.#observe(run)
+    const state = this.#state.value
+    const run = state.runById.get(runId)
+    if (run != null && run.runId != state.selectedRunId) this.#observe(run)
   }
 
   public async retryLoad(): Promise<void> {
@@ -201,7 +254,7 @@ export class RunStore {
   }
 
   public retryObservation(): void {
-    const run = this.#state.value.run
+    const run = selectedRun(this.#state.value)
     if (run == null) return
     const current = this.#selection.begin()
     this.#clearTimer()
@@ -214,7 +267,7 @@ export class RunStore {
   }
 
   public async cancel(): Promise<void> {
-    const run = this.#state.value.run
+    const run = selectedRun(this.#state.value)
     if (!canCancelRun(run) || this.#state.value.cancelingRunId != null || this.#state.value.resolvingAction != null) return
     const current = this.#cancellation.begin()
     this.#setNotice(undefined)
@@ -223,16 +276,14 @@ export class RunStore {
       const cancellation = await this.#client.cancelRun(run.runId)
       if (!current()) return
       const state = this.#state.value
-      const selected = state.run?.runId == run.runId
-      const selectedRun = selected ? { ...state.run!, status: cancellation.status } : undefined
-      this.#set({
-        ...(selectedRun == null ? {} : { run: selectedRun }),
-        runs: state.runs.map((candidate) => (candidate.runId == run.runId ? Object.assign({}, candidate, { status: cancellation.status }) : candidate)),
-      })
-      if (selectedRun == null) return
+      const currentRun = state.runById.get(run.runId)
+      if (currentRun == null) return
+      const nextRun = { ...currentRun, status: cancellation.status }
+      this.#set({ runById: replaceRun(state, nextRun) })
+      if (state.selectedRunId != run.runId) return
       const observation = this.#selection.begin()
       this.#clearTimer()
-      await this.#poll(selectedRun, observation)
+      await this.#poll(nextRun, observation)
     } catch (error) {
       if (current()) this.#setNotice(errorNotice(error, this.#i18n.t))
     } finally {
@@ -241,7 +292,7 @@ export class RunStore {
   }
 
   public async resolve(action: WaitAction): Promise<void> {
-    const run = this.#state.value.run
+    const run = selectedRun(this.#state.value)
     const waiting = run?.status == 'waiting' && 'waiting' in run ? run.waiting : undefined
     if (
       run == null ||
@@ -255,19 +306,17 @@ export class RunStore {
     this.#set({ resolvingAction: action })
     try {
       const resolution = await this.#client.resolveRunWait(run.runId, waiting.waitId, action)
-      const selected = this.#state.value.run
+      const state = this.#state.value
+      const selected = selectedRun(state)
       if (selected?.runId != run.runId || !('waiting' in selected) || selected.waiting?.waitId != waiting.waitId) return
       const { waiting: _, ...rest } = selected
       const next = { ...rest, status: resolution.status }
-      this.#set({
-        run: next,
-        runs: this.#state.value.runs.map((candidate) => (candidate.runId == run.runId ? { ...candidate, status: resolution.status } : candidate)),
-      })
+      this.#set({ runById: replaceRun(state, next) })
       this.retryObservation()
       const target = this.#state.value.target
       if (target != null) void this.#refreshList(target.flowId)
     } catch (error) {
-      if (this.#state.value.run?.runId == run.runId) this.#setNotice(errorNotice(error, this.#i18n.t))
+      if (this.#state.value.selectedRunId == run.runId) this.#setNotice(errorNotice(error, this.#i18n.t))
     } finally {
       if (this.#state.value.resolvingAction == action) this.#set({ resolvingAction: undefined })
     }
@@ -277,18 +326,32 @@ export class RunStore {
     const current = this.#selection.begin()
     this.#lists.invalidate()
     this.#clearTimer()
-    this.#set({ eventCursor: 0, events: [], eventsExpiresAt: undefined, historyComplete: true, result: undefined, run: undefined })
+    this.#set({
+      eventCursor: 0,
+      events: [],
+      eventsExpiresAt: undefined,
+      historyComplete: true,
+      loadFailed: false,
+      loading: false,
+      loadingMore: false,
+      refreshing: false,
+      result: undefined,
+      selectedRunId: undefined,
+    })
     return current
   }
 
   public follow(run: Run, current: Current): boolean {
     if (!current()) return false
+    const state = this.#state.value
     this.#set({
       events: [],
       externalRunId: undefined,
+      loaded: true,
       result: undefined,
-      run,
-      runs: [run, ...this.#state.value.runs.filter((candidate) => candidate.runId != run.runId)],
+      runById: replaceRun(state, run),
+      runIds: [run.runId, ...state.runIds.filter((runId) => runId != run.runId)],
+      selectedRunId: run.runId,
       target: { flowId: run.flowId },
     })
     void this.#poll(run, current)
@@ -296,7 +359,7 @@ export class RunStore {
   }
 
   public followExternal(run: Run): boolean {
-    if (this.#state.value.run?.runId == run.runId) return false
+    if (this.#state.value.selectedRunId == run.runId) return false
     const current = this.prepareStart()
     if (!this.follow(run, current)) return false
     this.#set({ externalRunId: run.runId })
@@ -306,6 +369,7 @@ export class RunStore {
   #observe(run: Run): void {
     const current = this.#selection.begin()
     this.#clearTimer()
+    const state = this.#state.value
     this.#set({
       eventCursor: 0,
       events: [],
@@ -314,7 +378,8 @@ export class RunStore {
       observationFailed: false,
       resolvingAction: undefined,
       result: undefined,
-      run,
+      runById: replaceRun(state, run),
+      selectedRunId: run.runId,
     })
     void this.#poll(run, current)
   }
@@ -327,7 +392,7 @@ export class RunStore {
         this.#client.getRunEvents(run.runId, { after, limit: eventPageLimit }),
       ])
       if (runResponse.status == 'rejected') throw runResponse.reason
-      if (!current() || this.#state.value.run?.runId != run.runId) return
+      if (!current() || this.#state.value.selectedRunId != run.runId) return
       const nextRun = runResponse.value
       this.#set({ observationFailed: false })
       if (eventsResponse.status == 'rejected') {
@@ -335,8 +400,7 @@ export class RunStore {
         this.#set({
           eventsExpiresAt: undefined,
           historyComplete: false,
-          run: nextRun,
-          runs: this.#state.value.runs.map((candidate) => (candidate.runId == nextRun.runId ? nextRun : candidate)),
+          runById: replaceRun(this.#state.value, nextRun),
         })
         await this.#loadResult(nextRun, current)
         return
@@ -347,8 +411,7 @@ export class RunStore {
         events: [...this.#state.value.events, ...page.events],
         eventsExpiresAt: page.eventsExpiresAt,
         historyComplete: page.historyComplete,
-        run: nextRun,
-        runs: this.#state.value.runs.map((candidate) => (candidate.runId == nextRun.runId ? nextRun : candidate)),
+        runById: replaceRun(this.#state.value, nextRun),
       })
       await this.#loadResult(nextRun, current)
       if (isRunTerminal(nextRun.status) && page.done) return
@@ -364,7 +427,7 @@ export class RunStore {
               : runningPollDelay
       this.#timer = globalThis.setTimeout(() => void this.#poll(nextRun, current, nextUnchangedStartingPolls), delay)
     } catch (error) {
-      if (current() && this.#state.value.run?.runId == run.runId) {
+      if (current() && this.#state.value.selectedRunId == run.runId) {
         this.#set({ observationFailed: true })
         this.#setNotice(errorNotice(error, this.#i18n.t))
       }
@@ -376,16 +439,16 @@ export class RunStore {
     try {
       const page = await this.#client.listRuns(flowId, { limit: 50 })
       if (!current() || this.#state.value.target?.flowId != flowId) return
-      this.#set({ nextCursor: page.nextCursor, runs: page.runs })
+      this.#set({ ...listedRuns(this.#state.value, page.runs), loaded: true, loadingMore: false, nextCursor: page.nextCursor, refreshing: false })
     } catch {
-      return
+      if (current() && this.#state.value.target?.flowId == flowId) this.#set({ refreshing: false })
     }
   }
 
   async #loadResult(run: Run, current: Current): Promise<void> {
     if (!isRunTerminal(run.status) || this.#state.value.result?.runId == run.runId) return
     const result = await this.#client.getRunResult(run.runId)
-    if (current() && this.#state.value.run?.runId == run.runId) this.#set({ result })
+    if (current() && this.#state.value.selectedRunId == run.runId) this.#set({ result })
   }
 
   #clearTimer(): void {

--- a/packages/open-flow/src/workbench/browser/runtime/runs/runStore.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/runs/runStore.ts
@@ -90,9 +90,13 @@ function selectedRun(state: RunState): Run | RunDetails | undefined {
 
 function listedRuns(state: RunState, runs: readonly Run[]): Pick<RunState, 'runById' | 'runIds'> {
   const runById = new Map(runs.map((run) => [run.runId, run] as const))
+  const runIds = runs.map((run) => run.runId)
   const selected = selectedRun(state)
-  if (selected != null) runById.set(selected.runId, selected)
-  return { runById, runIds: runs.map((run) => run.runId) }
+  if (selected != null) {
+    if (!runById.has(selected.runId)) runIds.unshift(selected.runId)
+    runById.set(selected.runId, selected)
+  }
+  return { runById, runIds }
 }
 
 function replaceRun(state: RunState, run: Run | RunDetails): ReadonlyMap<string, Run | RunDetails> {
@@ -436,6 +440,7 @@ export class RunStore {
 
   async #refreshList(flowId: string): Promise<void> {
     const current = this.#lists.begin()
+    this.#set({ refreshing: true })
     try {
       const page = await this.#client.listRuns(flowId, { limit: 50 })
       if (!current() || this.#state.value.target?.flowId != flowId) return

--- a/packages/open-flow/src/workbench/browser/runtime/runs/runsView.test.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/runs/runsView.test.tsx
@@ -43,6 +43,7 @@ describe('RunsView timeline', () => {
           loadingMore: val(false),
           nextCursor: val<string | undefined>(),
           observationFailed: val(false),
+          refreshing: val(false),
           result: val(result),
           run: val(run),
           runs: val([run]),

--- a/packages/open-flow/src/workbench/browser/runtime/runs/runsView.tsx
+++ b/packages/open-flow/src/workbench/browser/runtime/runs/runsView.tsx
@@ -54,6 +54,7 @@ export function RunsView({
   const loadingMore = useVal(store.runs.$.loadingMore)
   const nextCursor = useVal(store.runs.$.nextCursor)
   const result = useVal(store.runs.$.result)
+  const refreshing = useVal(store.runs.$.refreshing)
   const run = useVal(store.runs.$.run)
   const runs = useVal(store.runs.$.runs)
   const observationFailed = useVal(store.runs.$.observationFailed)
@@ -94,7 +95,7 @@ export function RunsView({
       role="tabpanel"
       tabIndex={0}
     >
-      <aside className="run-list-panel">
+      <aside aria-busy={loading || refreshing} className="run-list-panel">
         <header className="run-list-header">
           <strong>{t('run.history')}</strong>
         </header>


### PR DESCRIPTION
## Summary

- normalize Run list and detail state so polling and actions update one entity source
- keep loaded Runs and Publications visible while same-Flow data refreshes in the background
- surface newly started Runs and publication results immediately, with accessible refresh status

## Verification

- `bun run check`
- `bun run test`
- `bun run build`
- `bun run test:npm-package`
- `git diff --check`