### PR TITLE
fix(server): count terminal event bytes

### DIFF
--- a/apps/server/node/store.ts
+++ b/apps/server/node/store.ts
@@ -1424,7 +1424,8 @@ export class Store {
     this.#database.prepare('UPDATE run_waits SET checkpoint_json = NULL WHERE run_id = ?').run(runId)
     this.#database.prepare('DELETE FROM wait_notifications WHERE run_id = ?').run(runId)
     this.#insertEvent(runId, `run.${status}`, { result })
-    this.#database.prepare('UPDATE runs SET event_count = event_count + 1 WHERE run_id = ?').run(runId)
+    const bytes = encoder.encode(JSON.stringify({ kind: `run.${status}`, payload: { result } })).byteLength
+    this.#database.prepare('UPDATE runs SET event_count = event_count + 1, event_bytes = event_bytes + ? WHERE run_id = ?').run(bytes, runId)
     this.#database.prepare('DELETE FROM work WHERE run_id = ?').run(runId)
     return true
   }

--- a/apps/server/test/service.test.ts
+++ b/apps/server/test/service.test.ts
@@ -14,6 +14,7 @@ import { promisify } from 'node:util'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createServerApp } from '../node/http.ts'
 import { ServerService } from '../node/service.ts'
+import { Store } from '../node/store.ts'
 import { createConnectorHost } from './connectorHost.ts'
 import { acceptRun, storeRevision } from './runFixture.ts'
 import { closeService, openService, startService } from './serviceFixture.ts'
@@ -313,6 +314,37 @@ async function waitForStatus(service: ServerService, runId: string, status: stri
 }
 
 describe('Server application service', () => {
+  it.each(['completed', 'failed', 'canceled', 'indeterminate'] as const)('counts %s event bytes exactly once', async (status) => {
+    const file = await databaseFile()
+    const service = await openService(file)
+    const store = new Store(file)
+    const database = new DatabaseSync(file)
+    try {
+      const accepted = await acceptRun(service, {
+        flowId: 'main',
+        idempotencyKey: 'terminal-bytes',
+        revision: fullFlow(),
+        revisionId: 'revision-terminal-bytes',
+      })
+      if (accepted.kind != 'accepted') throw new Error('Initial Run acceptance conflicted.')
+      expect(store.claim()?.runId).toBe(accepted.runId)
+      expect(store.start(accepted.runId, { kind: 'run.started', payload: {} })).toBe(true)
+      const counts = database.prepare('SELECT event_count AS count, event_bytes AS bytes FROM runs WHERE run_id = ?')
+      const before = counts.get(accepted.runId) as { count: number; bytes: number }
+      const result = { message: '终态结果 🎉' }
+      const bytes = new TextEncoder().encode(JSON.stringify({ kind: `run.${status}`, payload: { result } })).byteLength
+
+      expect(store.commit(accepted.runId, status, result)).toBe(true)
+      expect(counts.get(accepted.runId)).toEqual({ count: before.count + 1, bytes: before.bytes + bytes })
+      expect(store.commit(accepted.runId, status, result)).toBe(false)
+      expect(counts.get(accepted.runId)).toEqual({ count: before.count + 1, bytes: before.bytes + bytes })
+      expect(store.events(accepted.runId).filter((event) => event.kind == `run.${status}`)).toHaveLength(1)
+    } finally {
+      database.close()
+      store.close()
+    }
+  })
+
   it('requires a valid public origin only for Wait notifications', async () => {
     const file = await databaseFile()
     await expect(openService(file, { capabilities: { waitPublicOrigin: () => new URL('http://flows.example.com') } })).rejects.toThrow(


### PR DESCRIPTION
Terminal Run events increased `event_count` without updating `event_bytes`. Count their serialized UTF-8 bytes in the same transaction, using the existing event accounting convention.

Regression tests cover completed, failed, canceled, and indeterminate Runs with multibyte results, and verify repeated terminal commits do not count or insert the event twice. All four cases failed before the fix and pass afterward.

Validation: `bun run format`, `bun run check`, `bun run test` (1,087 tests), and `bun run build` passed.

Fixes #69.
