### PR TITLE
fix(ci): set Node version for server image validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -219,6 +219,11 @@ jobs:
         with:
           bun-version-file: .bun-version
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+
       - name: Install
         run: bun install --frozen-lockfile
 


### PR DESCRIPTION
The server_image job installed dependencies without selecting the project Node version. In CI run 33938701620, installation took 81 seconds, while the server and quality jobs that set up Node 26 took about 1–2 seconds. An unmatched Node ABI can make isolated-vm fall back to source compilation; the existing logs do not isolate its installation time.

Add the same actions/setup-node step used by the other jobs, reading .node-version before bun install. This makes the image validation runner use the project Node version and its supported native prebuilds.

Validation: bun run format and bun run check passed before the branch was created. Docker validation was not rerun locally because the Docker daemon is unavailable. The actual installation speedup remains to be verified in CI.
