### PR TITLE
fix(server): isolate public Wait action rate limits

### DIFF
--- a/apps/server/node/http.ts
+++ b/apps/server/node/http.ts
@@ -142,19 +142,18 @@ export function createServerApp(service: ServerService, options: ServerAppOption
     const capability = context.req.param('capability')
     const action = context.req.param('action')
     const requested = action == 'approve' || action == 'continue' || action == 'reject' ? (action satisfies WaitAction) : undefined
-    const retryAfter = admitCallback('wait-action')
-    if (retryAfter != null) {
-      const response = json(429, { error: { code: 'wait-action.rate-limited', message: 'Too many requests.' }, version: 1 })
-      response.headers.set('cache-control', 'no-store')
-      response.headers.set('retry-after', String(retryAfter))
-      return response
-    }
+    const admit = (digest: string): number | undefined => admitCallback(`wait-action:${digest}`)
     const result =
       requested == null || !/^[A-Za-z0-9_-]{43}$/.test(capability)
         ? undefined
         : method == 'POST'
-          ? service.resolveWaitAction(capability, requested)
-          : service.inspectWaitAction(capability, requested)
+          ? service.resolveWaitAction(capability, requested, admit)
+          : service.inspectWaitAction(capability, requested, admit)
+    if (result != null && 'retryAfter' in result) {
+      const response = json(429, { error: { code: 'wait-action.rate-limited', message: 'Too many requests.' }, version: 1 })
+      response.headers.set('retry-after', String(result.retryAfter))
+      return method == 'HEAD' ? new Response(null, { headers: response.headers, status: response.status }) : response
+    }
     const response =
       result == null
         ? json(404, { error: { code: 'wait-action.not-found', message: 'Wait action was not found.' }, version: 1 })

--- a/apps/server/node/service.ts
+++ b/apps/server/node/service.ts
@@ -1423,23 +1423,31 @@ export class ServerService {
   inspectWaitAction(
     capability: string,
     requested: WaitAction,
-  ): { readonly action: WaitAction; readonly expiresAt: string; readonly prompt: string; readonly state: 'resolved' | 'waiting' } | undefined {
-    const receipt = this.#store.waitByCapability(createHash('sha256').update(capability).digest('hex'))
+    admit: (digest: string) => number | undefined,
+  ):
+    | { readonly action: WaitAction; readonly expiresAt: string; readonly prompt: string; readonly state: 'resolved' | 'waiting' }
+    | { readonly retryAfter: number }
+    | undefined {
+    const digest = createHash('sha256').update(capability).digest('hex')
+    const receipt = this.#store.waitByCapability(digest)
     if (receipt == null) return
     const revision = this.#store.revision(receipt.flowId, receipt.revisionId)
     if (revision == null) return
     const node = (JSON.parse(revision.content) as RevisionContent).document.graph.nodes[receipt.nodeId]
     if (node?.kind != 'wait' || !node.actions.some((action) => action == requested)) return
+    if (receipt.action == null && (receipt.status != 'waiting' || receipt.expiresAt <= this.#clock())) return
+    const retryAfter = admit(digest)
+    if (retryAfter != null) return { retryAfter }
     if (receipt.action != null) {
       return { action: receipt.action, expiresAt: new Date(receipt.expiresAt).toISOString(), prompt: node.prompt, state: 'resolved' }
     }
-    if (receipt.status != 'waiting' || receipt.expiresAt <= this.#clock()) return
     return { action: requested, expiresAt: new Date(receipt.expiresAt).toISOString(), prompt: node.prompt, state: 'waiting' }
   }
 
   resolveWaitAction(
     capability: string,
     requested: WaitAction,
+    admit: (digest: string) => number | undefined,
   ):
     | {
         readonly action: WaitAction | null
@@ -1447,13 +1455,17 @@ export class ServerService {
         readonly resolvedAt: string | null
         readonly state: 'resolved' | 'unavailable' | 'waiting'
       }
+    | { readonly retryAfter: number }
     | undefined {
-    const receipt = this.#store.waitByCapability(createHash('sha256').update(capability).digest('hex'))
+    const digest = createHash('sha256').update(capability).digest('hex')
+    const receipt = this.#store.waitByCapability(digest)
     if (receipt == null) return
     const revision = this.#store.revision(receipt.flowId, receipt.revisionId)
     if (revision == null) return
     const node = (JSON.parse(revision.content) as RevisionContent).document.graph.nodes[receipt.nodeId]
     if (node?.kind != 'wait' || !node.actions.some((action) => action == requested)) return
+    const retryAfter = admit(digest)
+    if (retryAfter != null) return { retryAfter }
     const result = this.#store.resolveWait(receipt.runId, receipt.waitId, requested, node.actions)
     if (result.kind != 'resolved') return
     if (result.changed) {

--- a/apps/server/test/service.test.ts
+++ b/apps/server/test/service.test.ts
@@ -418,6 +418,18 @@ describe('Server application service', () => {
     const approveUrl = message.match(/https:\/\/flows\.example\.com\/v1\/wait-actions\/[A-Za-z0-9_-]{43}\/approve/)?.[0]
     const rejectUrl = message.match(/https:\/\/flows\.example\.com\/v1\/wait-actions\/[A-Za-z0-9_-]{43}\/reject/)?.[0]
     if (approveUrl == null || rejectUrl == null) throw new Error('Wait notification action URLs are missing.')
+    const capability = new URL(approveUrl).pathname.split('/')[3] ?? ''
+    const admit = vi.fn(() => 30)
+    expect(service.inspectWaitAction('unknown', 'approve', admit)).toBeUndefined()
+    expect(service.resolveWaitAction(capability, 'continue', admit)).toBeUndefined()
+    expect(admit).not.toHaveBeenCalled()
+    expect(service.inspectWaitAction(capability, 'approve', admit)).toEqual({ retryAfter: 30 })
+    expect(service.resolveWaitAction(capability, 'reject', admit)).toEqual({ retryAfter: 30 })
+    expect(admit).toHaveBeenCalledTimes(2)
+    expect(admit.mock.calls[0]).toEqual(admit.mock.calls[1])
+    expect(admit.mock.calls[0]).toEqual([expect.stringMatching(/^[a-f0-9]{64}$/)])
+    expect(service.run(accepted.runId)?.status).toBe('waiting')
+
     const app = createServerApp(service)
     const approvePath = new URL(approveUrl).pathname
     const rejectPath = new URL(rejectUrl).pathname
@@ -443,22 +455,73 @@ describe('Server application service', () => {
     expect(service.run(accepted.runId)?.status).toBe('completed')
   })
 
-  it('rate limits public Wait actions before capability lookup', async () => {
-    const service = await openService(await databaseFile())
-    const inspect = vi.spyOn(service, 'inspectWaitAction')
+  it('isolates Wait action limits and restores admission when the window expires', async () => {
+    const messages: string[] = []
+    const service = await openService(await databaseFile(), {
+      capabilities: {
+        connector: () =>
+          createConnectorHost({
+            execute: async (_action, _connectionId, input) => {
+              messages.push(String(input.message))
+              return null
+            },
+          }),
+        waitPublicOrigin: () => new URL('https://flows.example.com'),
+      },
+    })
+    await startService(service)
+    const runs: string[] = []
+    for (const flowId of ['first', 'second']) {
+      const accepted = await acceptRun(service, {
+        flowId,
+        idempotencyKey: flowId,
+        revision: notificationFlow(),
+        revisionId: `revision-${flowId}`,
+      })
+      if (accepted.kind != 'accepted') throw new Error('Wait notification Run was not accepted.')
+      runs.push(accepted.runId)
+      await service.waitForIdle()
+    }
+    const paths = messages.map((message) => {
+      const url = message.match(/https:\/\/flows\.example\.com\/v1\/wait-actions\/[A-Za-z0-9_-]{43}\/approve/)?.[0]
+      if (url == null) throw new Error('Wait notification action URL is missing.')
+      return new URL(url).pathname
+    })
+    expect(paths).toHaveLength(2)
+    const [first = '', second = ''] = paths
     const app = createServerApp(service, { callbackRequestsPerMinute: 1 })
+    const now = Date.now()
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(now)
+    try {
+      expect((await app.request(first, { method: 'PUT' })).status).toBe(405)
+      expect((await app.request('/v1/wait-actions/invalid/approve')).status).toBe(404)
+      expect((await app.request(`/v1/wait-actions/${'a'.repeat(43)}/approve`)).status).toBe(404)
+      expect((await app.request(first.replace('/approve', '/continue'), { method: 'POST' })).status).toBe(404)
+      expect((await app.request(first, { method: 'HEAD' })).status).toBe(200)
 
-    const unsupported = await app.request(`/v1/wait-actions/${'a'.repeat(43)}/approve`, { method: 'PUT' })
-    expect(unsupported.status).toBe(405)
-    const missing = await app.request('/v1/wait-actions/invalid/approve')
-    expect(missing.status).toBe(404)
-    const limited = await app.request(`/v1/wait-actions/${'a'.repeat(43)}/approve`)
+      const limited = await app.request(first.replace('/approve', '/reject'), { method: 'POST' })
+      expect(limited.status).toBe(429)
+      expect(limited.headers.get('cache-control')).toBe('no-store')
+      expect(limited.headers.get('retry-after')).toBe('60')
+      expect(await limited.json()).toMatchObject({ error: { code: 'wait-action.rate-limited' }, version: 1 })
+      expect(runs.map((runId) => service.run(runId)?.status)).toEqual(['waiting', 'waiting'])
+      const head = await app.request(first, { method: 'HEAD' })
+      expect(head.status).toBe(429)
+      expect(await head.text()).toBe('')
 
-    expect(limited.status).toBe(429)
-    expect(limited.headers.get('cache-control')).toBe('no-store')
-    expect(limited.headers.get('retry-after')).not.toBeNull()
-    expect(await limited.json()).toMatchObject({ error: { code: 'wait-action.rate-limited' }, version: 1 })
-    expect(inspect).not.toHaveBeenCalled()
+      const other = await app.request(second, { method: 'POST' })
+      expect(other.status).toBe(200)
+      expect(await other.json()).toMatchObject({ action: 'approve', resolutionAccepted: true })
+
+      clock.mockReturnValue(now + 60_000)
+      const restored = await app.request(first, { method: 'POST' })
+      expect(restored.status).toBe(200)
+      expect(await restored.json()).toMatchObject({ action: 'approve', resolutionAccepted: true })
+    } finally {
+      clock.mockRestore()
+    }
+    await service.waitForIdle()
+    expect(runs.map((runId) => service.run(runId)?.status)).toEqual(['completed', 'completed'])
   })
 
   it('retries a transient Wait notification failure with the same invocation identity', async () => {

--- a/apps/server/test/webhook.test.ts
+++ b/apps/server/test/webhook.test.ts
@@ -68,9 +68,9 @@ function webhookFlow(): RevisionContent {
   }
 }
 
-async function publishedWebhook(service: ServerService) {
-  const stored = await storeRevision(service, webhookFlow(), 'revision-webhook')
-  await service.control.publishFlow('test', stored.flowId, stored.revisionId, 'open-flow-engine/v1', null, 'publication-webhook')
+async function publishedWebhook(service: ServerService, key = 'webhook') {
+  const stored = await storeRevision(service, webhookFlow(), `revision-${key}`)
+  await service.control.publishFlow('test', stored.flowId, stored.revisionId, 'open-flow-engine/v1', null, `publication-${key}`)
   await service.tickMaintenance()
   const binding = service.control.getFlowTriggerBinding(stored.flowId, 'incoming', 'http://server.local')
   const endpointId = binding.endpointUrl == null ? undefined : webhookEndpointId(new URL(binding.endpointUrl))
@@ -172,6 +172,7 @@ describe('Server Webhook Trigger admission', () => {
     const service = await openService(await databaseFile())
     services.push(service)
     const target = await publishedWebhook(service)
+    const other = await publishedWebhook(service, 'other')
     const app = createServerApp(service, { callbackRequestsPerMinute: 1 })
     const url = `http://server.local/v1/webhooks/${target.endpointId}`
     const clock = vi.spyOn(Date, 'now').mockReturnValue(0)
@@ -184,12 +185,12 @@ describe('Server Webhook Trigger admission', () => {
       expect(windows.size).toBe(1)
 
       clock.mockReturnValue(30_000)
-      const waitUrl = 'http://server.local/v1/wait-actions/unknown/approve'
-      expect((await app.request(waitUrl)).status).toBe(404)
+      const otherUrl = `http://server.local/v1/webhooks/${other.endpointId}`
+      expect((await app.request(otherUrl)).status).toBe(405)
       expect(windows.size).toBe(2)
 
       clock.mockReturnValue(60_000)
-      const limited = await app.request(waitUrl)
+      const limited = await app.request(otherUrl)
       expect(limited.status).toBe(429)
       expect(limited.headers.get('retry-after')).toBe('30')
       expect(windows.has(`webhook:${target.endpointId}`)).toBe(false)
@@ -200,7 +201,7 @@ describe('Server Webhook Trigger admission', () => {
       clock.mockReturnValue(120_000)
       expect((await app.request(url)).status).toBe(405)
       expect(windows.size).toBe(1)
-      expect(windows.has('wait-action')).toBe(false)
+      expect(windows.has(`webhook:${other.endpointId}`)).toBe(false)
     } finally {
       writes.mockRestore()
       clock.mockRestore()

--- a/docs/control/contracts/control-api.md
+++ b/docs/control/contracts/control-api.md
@@ -462,3 +462,6 @@ Connection；客户端不能改用 Team ID、Connection owner 或其他外部 id
 `POST` 服从与认证 resolve route 相同的 first-writer-wins 和幂等重放语义。capability、action、固定 Revision 或 active Wait 不匹配时返回
 `404 wait-action.not-found`；其他方法返回 `405 wait-action.method-not-allowed` 并携带 `Allow: GET, HEAD, POST`。服务端只持久化
 capability 摘要；完整 capability 是 bearer credential，消费端不得把它作为普通可公开 URL 记录或转发。
+
+请求被限流时返回 `429 wait-action.rate-limited`，携带表示剩余等待秒数的 `Retry-After`；被限流的 `POST` 不提交决议。
+`HEAD` 的限流响应同样没有 response body。

--- a/docs/server/container-delivery.md
+++ b/docs/server/container-delivery.md
@@ -105,7 +105,7 @@ credential。设置 `OPEN_FLOW_TOKEN` 时环境配置锁定当前认证来源并
 | `OPEN_FLOW_MAX_PENDING_RUNS`                   | 全部署尚未 terminal 的 Run 上限；默认 `1000`。                                                              |
 | `OPEN_FLOW_MAX_CONCURRENT_RUNS`                | 全部署同时执行的 Run 上限；同一 Flow 最多执行一个；默认 `4`。                                               |
 | `OPEN_FLOW_RUN_TIMEOUT_MS`                     | 单个 Run 从开始执行到 terminal 的最长毫秒数；默认 `1800000`。                                               |
-| `OPEN_FLOW_CALLBACK_REQUESTS_PER_MINUTE`       | 每个 Webhook 或 Integration endpoint 的每分钟请求上限；默认 `120`。                                         |
+| `OPEN_FLOW_CALLBACK_REQUESTS_PER_MINUTE`       | 每个 Webhook / Integration endpoint 或 Wait capability 的每分钟请求上限；默认 `120`。                       |
 | `OPEN_FLOW_OPERATOR_LOGIN_ATTEMPTS_PER_MINUTE` | 全部署每分钟允许的 operator 登录尝试数；默认 `10`。                                                         |
 
 `OPEN_FLOW_CONNECTOR_ORIGIN` 用于启用 Connector。`OPEN_FLOW_CONNECTOR_TOKEN` 可选；Connector 本地未启用 runtime 认证时可以省略或设为空字符串，此时
@@ -146,7 +146,9 @@ setup。Operator 登录与 setup authorization 共享部署实例级限速，超
 
 达到 `OPEN_FLOW_MAX_PENDING_RUNS` 后，新 Run admission 返回 429；已接受请求的幂等重放仍返回原 Run。Cron 与 Poll 保留当前调度位置并短暂重试。
 Cron 所属 Flow 已有未终结 Run 时同样保留当前调度位置；前一个 Run 结束后只补入最早未处理 occurrence，并把下一次计划推进到当前时间之后。
-Callback 请求限流只为已存在的 endpoint 建立内存窗口，超过限制时返回 429 和 `Retry-After`。
+Callback 请求限流只为已存在的 Webhook / Integration endpoint 或验证通过的 Wait capability 建立内存窗口，超过限制时返回 429 和 `Retry-After`。
+Wait 的 `GET`、`HEAD`、`POST` 及其不同 action 共用该 capability 的额度，不同 capability 独立计数；无效 capability 或不属于该 Wait 的 action 不占用额度。
+被限流的 Wait `POST` 不提交决议。限流状态属于当前 Server app 实例，进程重启后重置。
 
 ## 5. 健康检查与停止
 


### PR DESCRIPTION
Public Wait action requests shared one rate-limit bucket, so requests using an invalid capability could exhaust the allowance for every legitimate Wait in the deployment.

Count requests per verified capability digest instead. The service validates the capability and requested action before invoking admission, and rejects a limited POST before committing a decision. Different Waits have independent allowances; methods and actions for the same capability share its allowance. Invalid capabilities do not create counter entries. Limited HEAD responses preserve the empty-body contract.

Update the configuration and response documentation, and adapt the callback cleanup regression test to use two real Webhook endpoints.

Validation:
- `bun run format` and `bun run check` passed.
- `bun run test` passed: 1,088 tests.
- `bun run build` passed with existing chunk-size and mixed-import warnings.
- Regression coverage verifies invalid-capability handling, isolation between two real Waits, shared limits across methods/actions, no decision on rejected POST, window expiry, and callback-window cleanup.

Fixes #73.
