### PR TITLE
fix(workbench): avoid duplicate Flow after create

### DIFF
--- a/packages/open-flow/src/workbench/browser/runtime/stores/flowCatalog.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/flowCatalog.ts
@@ -146,10 +146,7 @@ export class FlowCatalog {
   public async create(name: string): Promise<Flow | undefined> {
     const flow = await this.#client.createFlow(name)
     if (this.#disposed) return
-    this.#set({
-      flows: [...this.#state.value.flows, flow],
-      total: this.#state.value.total == null ? undefined : this.#state.value.total + 1,
-    })
+    this.insert(flow)
     return flow
   }
 

--- a/packages/open-flow/src/workbench/browser/runtime/stores/workspaceStore.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/workspaceStore.test.ts
@@ -158,6 +158,45 @@ describe('WorkspaceStore', () => {
     }
   })
 
+  it('does not duplicate a created Flow when its catalog notification reloads first', async () => {
+    const created = Promise.withResolvers<Response>()
+    let catalogListener: (() => void) | undefined
+    let flowLists = 0
+    const request = vi.fn(async (path: string, init?: RequestInit) => {
+      if (path == '/v1/flows?limit=50&includeTotal=true') {
+        flowLists += 1
+        return Response.json(flowLists == 1 ? { flows: [], total: 0, version: 1 } : { flows: [flow], total: 1, version: 1 })
+      }
+      if (path == '/v1/flows' && init?.method == 'POST') return await created.promise
+      throw new Error(`Unexpected request: ${path}`)
+    })
+    const client = new WorkbenchClient(
+      request,
+      () => () => {},
+      (listener) => {
+        catalogListener = listener
+        return () => {}
+      },
+    )
+    const store = new WorkspaceStore(client, vi.fn())
+
+    try {
+      await store.start()
+      const creating = store.createFlow(flow.name)
+      await vi.waitFor(() => expect(request).toHaveBeenCalledWith('/v1/flows', expect.objectContaining({ method: 'POST' })))
+
+      catalogListener?.()
+      await vi.waitFor(() => expect(store.$.flows.value).toEqual([flow]))
+      created.resolve(Response.json(flow, { status: 201 }))
+      await expect(creating).resolves.toEqual(flow)
+
+      expect(store.$.flows.value).toEqual([flow])
+      expect(store.$.flowTotal.value).toBe(1)
+    } finally {
+      store.dispose()
+    }
+  })
+
   it('creates and connects a code task with the source port schema in one Draft change', async () => {
     const sourceDraft = {
       ...draft,


### PR DESCRIPTION
## Summary

- reuse the idempotent Flow catalog insertion path after creation
- avoid duplicate Flow rows and an inflated total when a catalog notification reload completes first
- add a deterministic regression test for the notification/create race

## Motivation

The Server publishes `flows.changed` before returning the create response. If the Workbench reloads the catalog before `FlowCatalog.create()` resumes, the previous implementation appended the same Flow again and incremented `total` twice.

## Verification

- `bun run --cwd packages/open-flow check`
- `bun run test`
- `bun run build`
- regression test verified red against the previous implementation