### PR TITLE
fix(designer): skip value connections when source node is unavailable

### DIFF
--- a/packages/open-flow/src/designer/browser/stores/designer/designer.store.test.ts
+++ b/packages/open-flow/src/designer/browser/stores/designer/designer.store.test.ts
@@ -1,6 +1,8 @@
-import type { NodeId } from '../../../../schema/index.ts'
+import type { HandleName, NodeId } from '../../../../schema/index.ts'
+import type { RFHandleName } from '../../base/rfHelpers.ts'
 import type { NodeStatus, NodeType } from '../node/constants.ts'
 import type { NodeStoreDisplay$ } from '../node/node.store.ts'
+import type { TaskNodeStoreDisplay$ } from '../node/taskNode.store.ts'
 import type { InteractiveMode } from './designer.store.ts'
 
 import { val } from 'value-enhancer'
@@ -9,6 +11,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { CommentNodeStore } from '../node/commentNode.store.ts'
 import { NODE_STATUS, NODE_TYPE } from '../node/constants.ts'
 import { NodeStore } from '../node/node.store.ts'
+import { TaskNodeStore } from '../node/taskNode.store.ts'
 import { DesignerStore } from './designer.store.ts'
 import { DesignerUIStore } from './designerUI.store.ts'
 import { NodeMiniMapPhase } from './nodeMiniMap.ts'
@@ -18,7 +21,9 @@ import { DESIGNER_TYPE, FLOW_RUN_STATUS } from './typings.ts'
 interface TestSetup {
   readonly store: DesignerStore
   readonly nodes: ReturnType<typeof reactiveMap<NodeId, NodeStore>>
+  readonly onConnect: ReturnType<typeof vi.fn>
   createNode(nodeId: NodeId, nodeType?: NodeType): NodeStore
+  createTaskNode(nodeId: NodeId): TaskNodeStore
   dispose(): void
 }
 
@@ -26,6 +31,7 @@ function createTestSetup(): TestSetup {
   const nodes = reactiveMap<NodeId, NodeStore>()
   const viewport = val<{ x: number; y: number; zoom: number } | undefined>()
   const designerUIStore = new DesignerUIStore({ viewport, nodeStores: nodes })
+  const onConnect = vi.fn()
   const store = new DesignerStore(DESIGNER_TYPE.Flow, true, {
     lang$: val('en'),
     rfCommand: createRFCommand(nodes),
@@ -40,7 +46,7 @@ function createTestSetup(): TestSetup {
     bindValidateConnection: () => {},
     onAddNode: async () => undefined,
     onDeleteNodes: () => {},
-    onConnect: () => {},
+    onConnect,
     onDisconnect: () => {},
     onDuplicate: async () => {},
   })
@@ -48,6 +54,7 @@ function createTestSetup(): TestSetup {
   return {
     store,
     nodes,
+    onConnect,
     createNode(nodeId, nodeType = NODE_TYPE.TaskNode) {
       const display$: NodeStoreDisplay$ = {
         icon: val(),
@@ -62,6 +69,25 @@ function createTestSetup(): TestSetup {
         outputs_def: val(),
       }
       const node = new NodeStore(nodeId, nodeType, { display$, designerUIStore })
+      createdNodes.push(node)
+      return node
+    },
+    createTaskNode(nodeId) {
+      const display$: TaskNodeStoreDisplay$ = {
+        icon: val(),
+        title: val(),
+        description: val(),
+        status: val<NodeStatus>(NODE_STATUS.Idle),
+        progress: val(),
+        showSettings: val(),
+        ignore: val(),
+        sections: val([]),
+        inputs_def: val([{ handle: 'value' as HandleName, jsonSchema: {} }]),
+        outputs_def: val([]),
+        task: val(),
+        executorName: val(),
+      }
+      const node = new TaskNodeStore(nodeId, { display$, designerUIStore })
       createdNodes.push(node)
       return node
     },
@@ -113,6 +139,27 @@ describe('DesignerStore.waitNode', () => {
     setup.nodes.set(nodeId, setup.createNode(nodeId))
     await vi.runAllTimersAsync()
     expect(logError).toHaveBeenCalledTimes(1)
+    setup.dispose()
+  })
+})
+
+describe('DesignerStore.setupValueNode', () => {
+  it('does not connect when the source value node never appears', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const setup = createTestSetup()
+    const target = setup.createTaskNode('target' as NodeId)
+    setup.nodes.set(target.nodeId, target)
+
+    const operation = setup.store.setupValueNode('missing' as NodeId, {
+      target: target.rfNodeId,
+      targetHandle: 'value' as RFHandleName,
+    })
+
+    await vi.advanceTimersByTimeAsync(5000)
+    await operation
+
+    expect(setup.onConnect).not.toHaveBeenCalled()
     setup.dispose()
   })
 })

--- a/packages/open-flow/src/designer/browser/stores/designer/designer.store.ts
+++ b/packages/open-flow/src/designer/browser/stores/designer/designer.store.ts
@@ -967,7 +967,8 @@ export class DesignerStore {
       const def = targetNode.getInputHandleDef(handle)
       if (def) {
         const sourceNode = await this.waitValueNode(source)
-        sourceNode?.setupHandle(def, targetNode.getInputFrom(handle))
+        if (sourceNode == null) return
+        sourceNode.setupHandle(def, targetNode.getInputFrom(handle))
         if (OutputNodeStore.is(targetNode)) {
           this.onConnect?.({
             from: { type: 'from_node', source: { node_id: source, output_handle: handle } },


### PR DESCRIPTION
Fixes #87

## Summary

- prevent `setupValueNode` from emitting a connection when the source value node timed out or resolved to a different node type
- add a regression test covering the missing-source timeout path

## Problem

`DesignerStore.setupValueNode` waited for `waitValueNode(source)` but only guarded the subsequent `setupHandle` call. When the source node did not appear within five seconds, `waitValueNode` returned `null` and the method still called `onConnect`. That bypassed `onRFConnect` validation and could persist a dangling connection for a non-existent value node.

## Fix

Return immediately when `waitValueNode` returns `null`; emit `onConnect` only after a valid `ValueNodeStore` has been found and initialized.

## Validation

- `npx bun@1.4.0 x vitest run --config packages/open-flow/vitest.config.ts packages/open-flow/src/designer/browser/stores/designer/designer.store.test.ts`
- `npx bun@1.4.0 run --filter @oomol-lab/open-flow check:types`
- `npx bun@1.4.0 run --filter @oomol-lab/open-flow lint`
- `npx bun@1.4.0 x oxfmt --check packages/open-flow/src/designer/browser/stores/designer/designer.store.ts packages/open-flow/src/designer/browser/stores/designer/designer.store.test.ts`
- `npx bun@1.4.0 run --filter @oomol-lab/open-flow build`
- `npx bun@1.4.0 run --filter @oomol-lab/open-flow check:boundaries`

The full package test command still has two unrelated baseline failures: a Windows CRLF-sensitive style import assertion and pre-existing missing designer translation keys (`carbon`, `color`, `emoji`, `filter`, `loading`, `random`).