### PR TITLE
fix(server): scope Run pagination cursors to their Flow

### DIFF
--- a/apps/server/node/control.ts
+++ b/apps/server/node/control.ts
@@ -78,7 +78,7 @@ export function createControlApp(service: ControlService, resolveActor?: Resolve
     const cursor = parameters.get('cursor')
     const after = cursor == null ? undefined : decodeFlowCursor(cursor)
     const { next, page } = service.listFlows(limit, after, optionalBoolean(parameters.get('includeTotal'), controlErrorCode.flowInvalid))
-    return response(200, { ...page, ...(next == null ? {} : { nextCursor: encodeCursor('flows', next) }) })
+    return response(200, { ...page, ...(next == null ? {} : { nextCursor: encodeFlowCursor(next) }) })
   })
   app.post('/flows', async (context) => {
     query(context.req.raw, [], controlErrorCode.flowInvalid)
@@ -313,15 +313,16 @@ export function createControlApp(service: ControlService, resolveActor?: Resolve
   })
   app.get('/flows/:flowId/runs', (context) => {
     const parameters = query(context.req.raw, ['cursor', 'limit', 'status'], controlErrorCode.runInvalid)
+    const flowId = context.req.param('flowId')
     const cursor = parameters.get('cursor')
-    const after = cursor == null ? undefined : decodeRunCursor(cursor)
+    const after = cursor == null ? undefined : decodeRunCursor(cursor, flowId)
     const status = parameters.get('status')
     if (status != null && !runStatusSet.has(status)) invalid(controlErrorCode.runInvalid, 'Run status is invalid.')
-    const { next, page } = service.listRuns(context.req.param('flowId'), pageSize(parameters, controlErrorCode.runInvalid), {
+    const { next, page } = service.listRuns(flowId, pageSize(parameters, controlErrorCode.runInvalid), {
       ...(after == null ? {} : { after }),
       ...(status == null ? {} : { status: status as RunStatus }),
     })
-    return response(200, { ...page, ...(next == null ? {} : { nextCursor: encodeCursor('runs', next) }) })
+    return response(200, { ...page, ...(next == null ? {} : { nextCursor: encodeRunCursor(flowId, next) }) })
   })
   app.get('/runs/:runId', (context) => response(200, service.getRun(context.req.param('runId'))))
   app.get('/runs/:runId/events', (context) => {
@@ -472,8 +473,12 @@ function idempotencyKey(request: Request, code: InvalidCode): string {
   return value
 }
 
-function encodeCursor(kind: 'flows' | 'runs', position: FlowPosition | RunPosition): string {
-  return Buffer.from(JSON.stringify({ kind, ...position })).toString('base64url')
+function encodeFlowCursor(position: FlowPosition): string {
+  return Buffer.from(JSON.stringify({ kind: 'flows', ...position })).toString('base64url')
+}
+
+function encodeRunCursor(flowId: string, position: RunPosition): string {
+  return Buffer.from(JSON.stringify({ flowId, kind: 'runs', ...position })).toString('base64url')
 }
 
 function encodePublicationCursor(flowId: string, position: PublicationPosition): string {
@@ -489,8 +494,9 @@ function decodeFlowCursor(value: string): FlowPosition {
   return { createdAt: decoded.createdAt as number, flowId: text(decoded.flowId, controlErrorCode.pageInvalidCursor) }
 }
 
-function decodeRunCursor(value: string): RunPosition {
-  const decoded = decodeCursor(value, 'runs', ['createdAt', 'kind', 'runId'])
+function decodeRunCursor(value: string, flowId: string): RunPosition {
+  const decoded = decodeCursor(value, 'runs', ['createdAt', 'flowId', 'kind', 'runId'])
+  if (decoded.flowId != flowId) invalid(controlErrorCode.pageInvalidCursor, 'Cursor is invalid.')
   return { createdAt: decoded.createdAt as number, runId: text(decoded.runId, controlErrorCode.pageInvalidCursor) }
 }
 

--- a/packages/open-flow/src/control/common/conformance.ts
+++ b/packages/open-flow/src/control/common/conformance.ts
@@ -374,6 +374,14 @@ export const controlApiConformanceCases: readonly ControlApiConformanceCase[] = 
         [runId],
         'Listed next Runs',
       )
+      const otherFlow = await createFlow(harness, 'Other Run flow', 'other-run-flow')
+      const otherFlowId = requiredString(otherFlow.flowId, 'Other Run Flow flowId')
+      await error(
+        await request(harness, `/v1/flows/${otherFlowId}/runs?limit=1&cursor=${encodeURIComponent(cursor)}`),
+        400,
+        'page.invalid-cursor',
+        'Reject Run cursor from another Flow',
+      )
       const canceled = await json(
         await request(harness, `/v1/runs/${runId}/cancel`, { body: JSON.stringify({ version: 1 }), method: 'POST' }),
         200,


### PR DESCRIPTION
## What changed

Run pagination cursors now include the Flow scope and are rejected when reused against another Flow.

## Why

The Control API contract requires pagination cursors to be opaque and scope-bound. Run cursors previously omitted `flowId`, so a cursor from Flow A could silently truncate or skip results when passed to Flow B.

## Implementation

- Encode `flowId` in Run cursors.
- Validate the cursor Flow against the route Flow and return `page.invalid-cursor` on mismatch.
- Add a shared Control API conformance regression test for cross-Flow cursor reuse.

## Verification

- `npx --yes bun@1.4.0 x vitest run --config vitest.config.ts test/controlApiConformance.test.ts` (13 passed)
- `npx --yes bun@1.4.0 x oxfmt --check apps/server/node/control.ts packages/open-flow/src/control/common/conformance.ts`
- `npx --yes bun@1.4.0 run build` (passed)

`bun run check` remains blocked by pre-existing repository-wide formatting failures unrelated to this change.