### PR TITLE
fix(server): reject malformed UTF-8 webhook payloads

### DIFF
--- a/apps/server/node/http.ts
+++ b/apps/server/node/http.ts
@@ -345,6 +345,7 @@ function acceptsHtml(accept: string | undefined): boolean {
 
 class WebhookBodyTooLarge extends Error {}
 class WebhookRequestInvalid extends Error {}
+const webhookDecoder = new TextDecoder('utf-8', { fatal: true, ignoreBOM: false })
 
 async function integration(
   service: ServerService,
@@ -472,9 +473,10 @@ function requestHeader(request: Request, name: string): string | undefined {
 }
 
 async function readWebhookPayload(request: Request): Promise<JsonValue> {
-  const source = new TextDecoder().decode(await readBody(request, maximumWebhookBodyBytes, () => new WebhookBodyTooLarge()))
-  if (source.length == 0) return {}
+  const bytes = await readBody(request, maximumWebhookBodyBytes, () => new WebhookBodyTooLarge())
   try {
+    const source = webhookDecoder.decode(bytes)
+    if (source.length == 0) return {}
     return JSON.parse(source) as JsonValue
   } catch {
     throw new WebhookRequestInvalid()

--- a/apps/server/test/webhook.test.ts
+++ b/apps/server/test/webhook.test.ts
@@ -168,6 +168,27 @@ describe('Server Webhook Trigger admission', () => {
     expect(Number(limited.headers.get('retry-after'))).toBeGreaterThan(0)
   })
 
+  it('rejects malformed UTF-8 instead of silently rewriting the webhook payload', async () => {
+    const service = await openService(await databaseFile())
+    services.push(service)
+    const target = await publishedWebhook(service)
+    const prefix = new TextEncoder().encode('{"message":"')
+    const suffix = new TextEncoder().encode('"}')
+    const malformed = new Uint8Array(prefix.length + 2 + suffix.length)
+    malformed.set(prefix)
+    malformed.set([0xc3, 0x28], prefix.length)
+    malformed.set(suffix, prefix.length + 2)
+
+    const response = await createServerApp(service).request(`http://server.local/v1/webhooks/${target.endpointId}`, {
+      body: malformed,
+      headers: { 'content-type': 'application/json', 'idempotency-key': 'malformed-utf8' },
+      method: 'POST',
+    })
+
+    expect(response.status).toBe(400)
+    expect(service.control.listRuns(target.flowId, 10).page.runs).toHaveLength(0)
+  })
+
   it('reclaims expired callback windows without resetting active limits', async () => {
     const service = await openService(await databaseFile())
     services.push(service)


### PR DESCRIPTION
## Problem

`readWebhookPayload` decoded request bytes with the default `TextDecoder`, which replaces malformed UTF-8 sequences with `U+FFFD`. A malformed JSON request could therefore be accepted after its payload was silently rewritten, and a Run would be created with data different from the bytes sent by the caller.

## Fix

Decode Webhook bodies with a fatal UTF-8 decoder and map decoding failures to the existing `400` invalid-request response. Add a regression test that sends an invalid UTF-8 sequence and verifies that no Run is created.

This matches the strict decoder already used by the Integration callback path and the JSON UTF-8 requirement in RFC 8259 section 8.1.

## Verification

- `npx --yes bun@1.4.0 x vitest run --config vitest.config.ts test/webhook.test.ts`
- `npx --yes bun@1.4.0 x oxfmt --check apps/server/node/http.ts apps/server/test/webhook.test.ts`
- `npx --yes bun@1.4.0 x oxlint --deny-warnings apps/server/node/http.ts apps/server/test/webhook.test.ts`
- `npx --yes bun@1.4.0 x tsc --noEmit -p apps/server/tsconfig.json`