### PR TITLE
fix(server): reject malformed UTF-8 Control API bodies

### DIFF
--- a/apps/server/node/config.ts
+++ b/apps/server/node/config.ts
@@ -4,6 +4,7 @@ import { Settings } from './settings.ts'
 
 const maxRequestBytes = 4 * 1024
 const encoder = new TextEncoder()
+const decoder = new TextDecoder('utf-8', { fatal: true, ignoreBOM: false })
 
 export function createConfigApp(settings: Settings, authenticate: (request: Request) => Promise<string>, changed: () => void = () => {}): Hono {
   const app = new Hono()
@@ -140,7 +141,7 @@ async function objectRequest(request: Request): Promise<Record<string, unknown> 
   }
   let value: unknown
   try {
-    value = JSON.parse(new TextDecoder().decode(bytes)) as unknown
+    value = JSON.parse(decoder.decode(bytes)) as unknown
   } catch {
     return
   }

--- a/apps/server/node/control.ts
+++ b/apps/server/node/control.ts
@@ -26,6 +26,7 @@ const maxPageSize = 100
 const defaultPageSize = 50
 const runStatusSet: ReadonlySet<string> = new Set(runStatuses)
 const encoder = new TextEncoder()
+const controlDecoder = new TextDecoder('utf-8', { fatal: true, ignoreBOM: false })
 
 export function createControlApp(service: ControlService, resolveActor?: ResolveControlActor): Hono<Environment> {
   const app = new Hono<Environment>()
@@ -382,7 +383,7 @@ async function requestObject(request: Request, code: InvalidCode): Promise<Recor
       bytes.set(chunk, offset)
       offset += chunk.byteLength
     }
-    return record(JSON.parse(new TextDecoder().decode(bytes)) as unknown, code)
+    return record(JSON.parse(controlDecoder.decode(bytes)) as unknown, code)
   } catch {
     return invalid(code, 'Request body must be valid JSON.')
   }

--- a/apps/server/test/config.test.ts
+++ b/apps/server/test/config.test.ts
@@ -213,3 +213,29 @@ it('authenticates configuration requests, hides tokens, and rejects stale or env
     await closeService(service)
   }
 })
+
+it('rejects malformed UTF-8 in configuration JSON bodies', async () => {
+  const file = await databaseFile()
+  const service = await openService(file)
+  const configured = settings(file)
+  const app = createServerApp(service, { resolveControlActor: () => 'operator', settings: configured })
+  try {
+    const prefix = new TextEncoder().encode('{"expectedRevision":1,"origin":"https://models.example.com","token":"')
+    const suffix = new TextEncoder().encode('","version":1}')
+    const malformed = new Uint8Array(prefix.length + 2 + suffix.length)
+    malformed.set(prefix)
+    malformed.set([0xc3, 0x28], prefix.length)
+    malformed.set(suffix, prefix.length + 2)
+
+    const response = await app.request('/config/llm', {
+      body: malformed,
+      headers: { 'content-type': 'application/json' },
+      method: 'PUT',
+    })
+
+    expect(response.status).toBe(400)
+    expect(configured.status().llm.configured).toBe(false)
+  } finally {
+    await closeService(service)
+  }
+})


### PR DESCRIPTION
## Problem

The authenticated Control API decoded JSON request bodies with the default `TextDecoder`. Malformed UTF-8 was replaced with `U+FFFD` and then accepted by `JSON.parse`, so fields such as Variable values could be silently changed before validation and persistence.

## Fix

Use a fatal UTF-8 decoder for Control API JSON bodies. Decoding failures continue to use the existing `400` invalid-request response. Add a regression test proving that malformed bytes neither succeed nor persist a Variable.

This aligns Control API input handling with the strict decoder already used by the Integration and Webhook callback paths and with RFC 8259 section 8.1.

## Verification

- `npx --yes bun@1.4.0 x vitest run --config vitest.config.ts test/control.test.ts`
- `npx --yes bun@1.4.0 x oxfmt --check apps/server/node/control.ts apps/server/test/control.test.ts`
- `npx --yes bun@1.4.0 x oxlint --deny-warnings apps/server/node/control.ts apps/server/test/control.test.ts`
- `npx --yes bun@1.4.0 x tsc --noEmit -p apps/server/tsconfig.json`