### PR TITLE
fix(server): reject malformed UTF-8 Connector responses

### DIFF
--- a/apps/server/node/connector.ts
+++ b/apps/server/node/connector.ts
@@ -10,6 +10,7 @@ const maxResponseBytes = 1024 * 1024
 const maxActionCatalogBytes = 8 * 1024 * 1024
 const catalogConcurrency = 16
 const readinessTimeoutMs = 1_000
+const responseDecoder = new TextDecoder('utf-8', { fatal: true, ignoreBOM: false })
 
 interface RuntimeAction {
   readonly description: string
@@ -487,7 +488,7 @@ async function readJson(
     reader.releaseLock()
   }
   try {
-    return JSON.parse(Buffer.concat(chunks, bytes).toString('utf8')) as unknown
+    return JSON.parse(responseDecoder.decode(Buffer.concat(chunks, bytes))) as unknown
   } catch (error) {
     throw unavailable(error instanceof Error ? error.message : String(error))
   }

--- a/apps/server/test/connectorClient.test.ts
+++ b/apps/server/test/connectorClient.test.ts
@@ -190,6 +190,22 @@ describe('Server Connector client', () => {
     expect(new ConnectorClient('https://connector.oomol.com', '').teamSupported()).toBe(false)
   })
 
+  it('rejects malformed UTF-8 in Connector JSON responses', async () => {
+    const prefix = new TextEncoder().encode('{"teams":[{"id":"team-1","name":"')
+    const suffix = new TextEncoder().encode('","status":"normal","system_created":true}]}')
+    const malformed = new Uint8Array(prefix.length + 2 + suffix.length)
+    malformed.set(prefix)
+    malformed.set([0xc3, 0x28], prefix.length)
+    malformed.set(suffix, prefix.length + 2)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(malformed, { headers: { 'content-type': 'application/json' }, status: 200 })),
+    )
+
+    const connector = new ConnectorClient('https://connector.oomol.dev', 'runtime-token')
+    await expect(connector.listTeams()).rejects.toMatchObject({ code: 'connector.unavailable' })
+  })
+
   it('checks Connector readiness without using the runtime token', async () => {
     let status = 200
     const requests: { readonly authorization?: string; readonly path: string }[] = []


### PR DESCRIPTION
## Problem

`ConnectorClient` decoded upstream response bytes with `Buffer.toString('utf8')`. Malformed UTF-8 was replaced with `U+FFFD` before JSON parsing, so a response such as a Team/Provider name could be accepted with data different from the bytes returned by the Connector service.

## Fix

Decode Connector JSON responses with a fatal UTF-8 decoder. The existing `connector.unavailable` error mapping remains unchanged. Add a regression test using an invalid UTF-8 sequence in a Teams response.

This matches the strict decoding used by Integration callbacks and follows the JSON UTF-8 requirement in RFC 8259 section 8.1.

## Verification

- `npx --yes bun@1.4.0 x vitest run --config vitest.config.ts test/connectorClient.test.ts -t "malformed UTF-8"`
- `npx --yes bun@1.4.0 x oxfmt --check apps/server/node/connector.ts apps/server/test/connectorClient.test.ts`
- `npx --yes bun@1.4.0 x oxlint --deny-warnings apps/server/node/connector.ts apps/server/test/connectorClient.test.ts`
- `npx --yes bun@1.4.0 x tsc --noEmit -p apps/server/tsconfig.json`