### PR TITLE
fix(designer): cancel pending node waits on disposal

### DIFF
--- a/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.tsx
+++ b/packages/open-flow/src/designer/browser/graph/ReactFlowContainer/ReactFlowContainer.tsx
@@ -1108,7 +1108,7 @@ function BlockQuickPickPanelPopover(props: BlockQuickPickPanelPopoverProps) {
           if (item.type === 'scriptlet' && props.setupScriptletNode) {
             props.setupScriptletNode(nodeId, props.connection, handle)
           } else {
-            await props.waitNode?.(nodeId)
+            if (props.waitNode != null && (await props.waitNode(nodeId)) == null) return
             props.onConnect?.(makeConnection(props.connection, nodeId, handle))
           }
         } else if (item.type === 'value' && props.setupValueNode && 'target' in props.connection) {

--- a/packages/open-flow/src/designer/browser/stores/designer/designer.store.test.ts
+++ b/packages/open-flow/src/designer/browser/stores/designer/designer.store.test.ts
@@ -104,6 +104,53 @@ afterEach(() => {
 })
 
 describe('DesignerStore.waitNode', () => {
+  it('cancels all pending waits on disposal without logging timeouts', async () => {
+    vi.useFakeTimers()
+    const logError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const setup = createTestSetup()
+    const first = setup.store.waitNode('first' as NodeId)
+    const second = setup.store.waitNode('second' as NodeId)
+
+    setup.dispose()
+
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined])
+    expect(vi.getTimerCount()).toBe(0)
+    setup.nodes.set('first' as NodeId, setup.createNode('first' as NodeId))
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(logError).not.toHaveBeenCalled()
+    setup.dispose()
+  })
+
+  it('does not start waits or return existing nodes after disposal', async () => {
+    vi.useFakeTimers()
+    const setup = createTestSetup()
+    const node = setup.createNode('existing' as NodeId)
+    setup.nodes.set(node.nodeId, node)
+    setup.dispose()
+
+    await expect(setup.store.waitNode(node.nodeId)).resolves.toBeUndefined()
+    await expect(setup.store.waitNode('missing' as NodeId)).resolves.toBeUndefined()
+    expect(vi.getTimerCount()).toBe(0)
+    expect(setup.store.dispose.size()).toBe(0)
+  })
+
+  it.each(['success', 'timeout'] as const)('releases completed %s waits from the disposal list', async (outcome) => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const setup = createTestSetup()
+    const size = setup.store.dispose.size()
+    const nodeId = 'node' as NodeId
+    const result = setup.store.waitNode(nodeId)
+
+    if (outcome == 'success') setup.nodes.set(nodeId, setup.createNode(nodeId))
+    else await vi.advanceTimersByTimeAsync(5000)
+    await result
+
+    expect(setup.store.dispose.size()).toBe(size)
+    expect(vi.getTimerCount()).toBe(0)
+    setup.dispose()
+  })
+
   it('returns an existing node immediately', async () => {
     const setup = createTestSetup()
     const nodeId = 'existing' as NodeId
@@ -160,6 +207,54 @@ describe('DesignerStore.setupValueNode', () => {
     await operation
 
     expect(setup.onConnect).not.toHaveBeenCalled()
+    setup.dispose()
+  })
+})
+
+describe('DesignerStore pending node setup', () => {
+  it.each(['value', 'scriptlet'] as const)('cancels %s setup without connecting after disposal', async (kind) => {
+    vi.useFakeTimers()
+    const logError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const setup = createTestSetup()
+    const target = setup.createTaskNode('target' as NodeId)
+    setup.nodes.set(target.nodeId, target)
+    const connection = { target: target.rfNodeId, targetHandle: 'value' as RFHandleName }
+    const connect = vi.spyOn(setup.store, 'onRFConnect')
+    const operation =
+      kind == 'value'
+        ? setup.store.setupValueNode('missing' as NodeId, connection)
+        : setup.store.setupScriptletNode('missing' as NodeId, connection, 'value' as HandleName)
+
+    setup.dispose()
+    await operation
+
+    expect(vi.getTimerCount()).toBe(0)
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(connect).not.toHaveBeenCalled()
+    expect(setup.onConnect).not.toHaveBeenCalled()
+    expect(logError).not.toHaveBeenCalled()
+  })
+
+  it('does not connect a scriptlet when its node times out', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const setup = createTestSetup()
+    const target = setup.createTaskNode('target' as NodeId)
+    setup.nodes.set(target.nodeId, target)
+    const connect = vi.spyOn(setup.store, 'onRFConnect')
+    const operation = setup.store.setupScriptletNode(
+      'missing' as NodeId,
+      {
+        target: target.rfNodeId,
+        targetHandle: 'value' as RFHandleName,
+      },
+      'value' as HandleName,
+    )
+
+    await vi.advanceTimersByTimeAsync(5000)
+    await operation
+
+    expect(connect).not.toHaveBeenCalled()
     setup.dispose()
   })
 })

--- a/packages/open-flow/src/designer/browser/stores/designer/designer.store.ts
+++ b/packages/open-flow/src/designer/browser/stores/designer/designer.store.ts
@@ -319,11 +319,15 @@ export class DesignerStore {
   /** @internal */
   public readonly userLocalesContext: UserLocalesContext
 
+  private disposed = false
   private pendingDisplayModeLayout: FlowDisplayMode | undefined
   private displayModeLayoutMeasurementAttempts = 0
   private activeDisplayMode: FlowDisplayMode
 
   public constructor(type: DesignerType, editable: boolean, props: DesignerStoreProps) {
+    this.dispose.add(() => {
+      this.disposed = true
+    })
     this.rfCommand = this.dispose.add(props.rfCommand)
     this.designerUIStore = this.dispose.add(props.designerUIStore)
     this.connectorConnections = props.connectorConnections
@@ -921,6 +925,7 @@ export class DesignerStore {
    * @internal
    */
   public waitNode = async <T extends NodeStore = NodeStore>(nodeId: NodeId): Promise<T | undefined> => {
+    if (this.disposed) return undefined
     const existingNode = this.$.nodes.get(nodeId)
     if (existingNode) return existingNode as T
     return new Promise<T | undefined>((resolve) => {
@@ -931,13 +936,16 @@ export class DesignerStore {
           settled = true
           clearTimeout(timer)
           disposeReaction?.()
+          this.dispose.remove(cancel)
           resolve(node)
         }
       }
+      const cancel = () => finish(undefined)
       const timer = setTimeout(() => {
         console.error(`node ${nodeId} not found`)
         finish(undefined)
       }, 5000)
+      this.dispose.add(cancel)
       disposeReaction = this.$.nodes.$.reaction((nodeMap) => {
         const node = nodeMap.get(nodeId)
         if (node) {
@@ -961,13 +969,14 @@ export class DesignerStore {
    * @internal
    */
   public setupValueNode = async (source: NodeId, connection: Pick<RFConnection, 'target' | 'targetHandle'>): Promise<void> => {
+    if (this.disposed) return
     const targetNode = this.resolveRFNode(connection.target)
     const handle = toManifestHandleName(connection.targetHandle)
     if (TaskNodeStore.is(targetNode) || SubflowNodeStore.is(targetNode) || OutputNodeStore.is(targetNode) || ConditionNodeStore.is(targetNode)) {
       const def = targetNode.getInputHandleDef(handle)
       if (def) {
         const sourceNode = await this.waitValueNode(source)
-        if (sourceNode == null) return
+        if (sourceNode == null || this.disposed) return
         sourceNode.setupHandle(def, targetNode.getInputFrom(handle))
         if (OutputNodeStore.is(targetNode)) {
           this.onConnect?.({
@@ -985,30 +994,11 @@ export class DesignerStore {
   }
 
   private async waitValueNode(nodeId: NodeId): Promise<ValueNodeStore | null> {
-    const alreadyExist = this.$.nodes.get(nodeId)
-    if (ValueNodeStore.is(alreadyExist)) {
-      return alreadyExist
-    }
-    return new Promise<ValueNodeStore | null>((resolve) => {
-      const timer = setTimeout(() => {
-        console.error(`value node ${nodeId} not found`)
-        dispose()
-        resolve(null)
-      }, 5000)
-      const dispose = this.$.nodes.$.reaction((nodes) => {
-        const node = nodes.get(nodeId)
-        if (node) {
-          clearTimeout(timer)
-          dispose()
-          if (ValueNodeStore.is(node)) {
-            resolve(node)
-          } else {
-            console.error(`node ${nodeId} is not a value node`)
-            resolve(null)
-          }
-        }
-      })
-    })
+    const node = await this.waitNode(nodeId)
+    if (node == null || this.disposed) return null
+    if (ValueNodeStore.is(node)) return node
+    console.error(`node ${nodeId} is not a value node`)
+    return null
   }
 
   /**
@@ -1018,6 +1008,7 @@ export class DesignerStore {
    * @param handle The scriptlet input or output handle.
    */
   public setupScriptletNode = async (nodeId: NodeId, connection: PartialConnection, handle: HandleName): Promise<void> => {
+    if (this.disposed) return
     if (handle && 'source' in connection) {
       // Dragging right from a value or task node determines the scriptlet input type.
       const sourceNode = this.resolveRFNode(connection.source)
@@ -1032,7 +1023,8 @@ export class DesignerStore {
         const def = sourceNode.getOutputHandleDef(sourceHandle)
         if (def) {
           const targetNode = await this.waitInlineTaskNode(nodeId)
-          targetNode?.setupInputHandle(handle, def)
+          if (targetNode == null || this.disposed) return
+          targetNode.setupInputHandle(handle, def)
         }
       }
     } else if (handle && 'target' in connection) {
@@ -1043,7 +1035,8 @@ export class DesignerStore {
         const def = targetNode.getInputHandleDef(targetHandle)
         if (def) {
           const sourceNode = await this.waitInlineTaskNode(nodeId)
-          sourceNode?.setupOutputHandle(handle, def)
+          if (sourceNode == null || this.disposed) return
+          sourceNode.setupOutputHandle(handle, def)
         }
       }
     }
@@ -1051,35 +1044,11 @@ export class DesignerStore {
   }
 
   private async waitInlineTaskNode(nodeId: NodeId): Promise<TaskNodeStore | null> {
-    const alreadyExist = this.$.nodes.get(nodeId)
-    if (TaskNodeStore.is(alreadyExist)) {
-      if (isInlineTaskNode(alreadyExist)) {
-        return alreadyExist
-      } else {
-        console.error(`node ${nodeId} is not an inline task node`)
-        return null
-      }
-    }
-    return new Promise<TaskNodeStore | null>((resolve) => {
-      const timer = setTimeout(() => {
-        console.error(`task node ${nodeId} not found`)
-        dispose()
-        resolve(null)
-      }, 5000)
-      const dispose = this.$.nodes.$.reaction((nodes) => {
-        const node = nodes.get(nodeId)
-        if (node) {
-          clearTimeout(timer)
-          dispose()
-          if (TaskNodeStore.is(node) && isInlineTaskNode(node)) {
-            resolve(node)
-          } else {
-            console.error(`node ${nodeId} is not an inline task node`)
-            resolve(null)
-          }
-        }
-      })
-    })
+    const node = await this.waitNode(nodeId)
+    if (node == null || this.disposed) return null
+    if (TaskNodeStore.is(node) && isInlineTaskNode(node)) return node
+    console.error(`node ${nodeId} is not an inline task node`)
+    return null
   }
 }
 


### PR DESCRIPTION
Pending Designer node waits previously survived store disposal until their five-second timeout, logging errors and allowing setup callers to continue connecting nodes. Tie waits to the store lifecycle so disposal clears their timers and reactions and settles them with an empty result; reject new waits after disposal and remove completed waits from the disposal list.

Value and inline-task waits now share the existing `waitNode` lifecycle handling while retaining their node-kind checks. Stop scriptlet setup and menu connection callbacks when waiting returns no node. Missing-node timeouts use the shared `node … not found` diagnostic.

Adds seven regression cases covering concurrent cancellation, calls after disposal, cleanup after success/timeout, cancellation of value/scriptlet setup, and scriptlet timeout without a connection.

Validation:
- `bun run format`
- `bun run check`
- `bun run test` — 1,112 tests passed.
- `bun run build` — passed with the repository-required Bun 1.4.0.
- `bun run test:package` — passed with Bun 1.4.0.

Closes #83.
