### PR TITLE
fix(designer): ignore missing value node connections

### DIFF
--- a/packages/open-flow/src/designer/browser/stores/designer/designer.store.test.ts
+++ b/packages/open-flow/src/designer/browser/stores/designer/designer.store.test.ts
@@ -1,4 +1,4 @@
-import type { NodeId } from '../../../../schema/index.ts'
+import type { HandleName, NodeId } from '../../../../schema/index.ts'
 import type { NodeStatus, NodeType } from '../node/constants.ts'
 import type { NodeStoreDisplay$ } from '../node/node.store.ts'
 import type { InteractiveMode } from './designer.store.ts'
@@ -6,9 +6,11 @@ import type { InteractiveMode } from './designer.store.ts'
 import { val } from 'value-enhancer'
 import { reactiveMap } from 'value-enhancer/collections'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { toRFHandleName } from '../../base/rfHelpers.ts'
 import { CommentNodeStore } from '../node/commentNode.store.ts'
 import { NODE_STATUS, NODE_TYPE } from '../node/constants.ts'
 import { NodeStore } from '../node/node.store.ts'
+import { TaskNodeStore } from '../node/taskNode.store.ts'
 import { DesignerStore } from './designer.store.ts'
 import { DesignerUIStore } from './designerUI.store.ts'
 import { NodeMiniMapPhase } from './nodeMiniMap.ts'
@@ -19,10 +21,11 @@ interface TestSetup {
   readonly store: DesignerStore
   readonly nodes: ReturnType<typeof reactiveMap<NodeId, NodeStore>>
   createNode(nodeId: NodeId, nodeType?: NodeType): NodeStore
+  createTaskNode(nodeId: NodeId): TaskNodeStore
   dispose(): void
 }
 
-function createTestSetup(): TestSetup {
+function createTestSetup(onConnect: () => void = () => {}): TestSetup {
   const nodes = reactiveMap<NodeId, NodeStore>()
   const viewport = val<{ x: number; y: number; zoom: number } | undefined>()
   const designerUIStore = new DesignerUIStore({ viewport, nodeStores: nodes })
@@ -40,7 +43,7 @@ function createTestSetup(): TestSetup {
     bindValidateConnection: () => {},
     onAddNode: async () => undefined,
     onDeleteNodes: () => {},
-    onConnect: () => {},
+    onConnect,
     onDisconnect: () => {},
     onDuplicate: async () => {},
   })
@@ -62,6 +65,28 @@ function createTestSetup(): TestSetup {
         outputs_def: val(),
       }
       const node = new NodeStore(nodeId, nodeType, { display$, designerUIStore })
+      createdNodes.push(node)
+      return node
+    },
+    createTaskNode(nodeId) {
+      const node = new TaskNodeStore(nodeId, {
+        designerUIStore,
+        display$: {
+          icon: val(),
+          title: val(),
+          description: val(),
+          status: val<NodeStatus>(NODE_STATUS.Idle),
+          progress: val(),
+          showSettings: val(),
+          ignore: val(),
+          sections: val([]),
+          inputs_def: val([{ handle: 'input' as HandleName }]),
+          outputs_def: val([]),
+          inputs_from: val([]),
+          task: val(),
+          executorName: val(),
+        },
+      })
       createdNodes.push(node)
       return node
     },
@@ -113,6 +138,26 @@ describe('DesignerStore.waitNode', () => {
     setup.nodes.set(nodeId, setup.createNode(nodeId))
     await vi.runAllTimersAsync()
     expect(logError).toHaveBeenCalledTimes(1)
+    setup.dispose()
+  })
+})
+
+describe('DesignerStore.setupValueNode', () => {
+  it('does not publish a connection when the value node never appears', async () => {
+    vi.useFakeTimers()
+    const onConnect = vi.fn()
+    const setup = createTestSetup(onConnect)
+    const target = setup.createTaskNode('target' as NodeId)
+    setup.nodes.set(target.nodeId, target)
+
+    const result = setup.store.setupValueNode('missing' as NodeId, {
+      target: target.rfNodeId,
+      targetHandle: toRFHandleName('input' as HandleName),
+    })
+
+    await vi.advanceTimersByTimeAsync(5000)
+    await expect(result).resolves.toBeUndefined()
+    expect(onConnect).not.toHaveBeenCalled()
     setup.dispose()
   })
 })

--- a/packages/open-flow/src/designer/browser/stores/designer/designer.store.ts
+++ b/packages/open-flow/src/designer/browser/stores/designer/designer.store.ts
@@ -967,7 +967,8 @@ export class DesignerStore {
       const def = targetNode.getInputHandleDef(handle)
       if (def) {
         const sourceNode = await this.waitValueNode(source)
-        sourceNode?.setupHandle(def, targetNode.getInputFrom(handle))
+        if (sourceNode == null) return
+        sourceNode.setupHandle(def, targetNode.getInputFrom(handle))
         if (OutputNodeStore.is(targetNode)) {
           this.onConnect?.({
             from: { type: 'from_node', source: { node_id: source, output_handle: handle } },


### PR DESCRIPTION
## Summary

- avoid publishing a Flow connection when a value node never appears
- add a regression test for the value-node timeout path

## Root cause

`setupValueNode` used optional chaining only for `setupHandle`, but still called `onConnect` when `waitValueNode` returned `null`. This could persist a connection whose source value node was missing or had the wrong node type.

## Behavioral impact

When a value node cannot be resolved within the existing wait window, the designer now leaves the connection unpublished instead of emitting a dangling source reference. Valid value-node connections keep the existing behavior.

## Verification

- targeted Vitest: `designer.store.test.ts` — 14 tests passed
- TypeScript: `tsc --noEmit`
- oxlint on touched files
- oxfmt check on touched files

No related issue; this is a focused bug fix found while reviewing the designer connection lifecycle.