### PR TITLE
fix(workbench): retain trigger connections after authorization

### DIFF
--- a/packages/open-flow/src/workbench/browser/runtime/stores/triggerStore.test.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/triggerStore.test.ts
@@ -1,3 +1,5 @@
+import type { ConnectorConnection } from '../api.ts'
+
 import { describe, expect, it, vi } from 'vitest'
 import { WorkbenchClient } from '../api.ts'
 import { providerIcon } from '../providerIcon.ts'
@@ -15,77 +17,111 @@ const flow = {
   version: 1,
 } as const
 
+function createSetup() {
+  const requests: string[] = []
+  const request = vi.fn(async (path: string) => {
+    requests.push(path)
+    if (path == '/v1/flows?limit=50&includeTotal=true') return Response.json({ flows: [flow], total: 1, version: 1 })
+    if (path == `/v1/flows/${flow.flowId}/draft`) {
+      return Response.json({
+        actorId: 'actor',
+        content: {
+          document: {
+            bindings: Object.fromEntries(['github', 'mail'].map((provider) => [provider, { kind: 'connection', target: `${provider}-old` }])),
+            graph: {
+              nodes: Object.fromEntries(
+                ['github', 'mail'].map((provider) => [
+                  provider,
+                  {
+                    bindingId: provider,
+                    config: {},
+                    definition: {
+                      configSchema: { type: 'object' },
+                      definitionVersion: 1,
+                      description: '',
+                      displayName: 'New event',
+                      key: `${provider}.event`,
+                      name: 'event',
+                      payloadSchema: { type: 'object' },
+                      provider,
+                      type: 'poll',
+                    },
+                    kind: 'poll',
+                    name: provider,
+                    pollTimes: [],
+                  },
+                ]),
+              ),
+            },
+            subflows: {},
+            tasks: {},
+          },
+          modelVersion: 1,
+          modules: {},
+        },
+        createdAt: timestamp,
+        digest: 'digest',
+        flowId: flow.flowId,
+        modelVersion: 1,
+        parentRevisionId: null,
+        revisionId: flow.draftRevisionId,
+        version: 1,
+      })
+    }
+    if (path == `/v1/flows/${flow.flowId}/live`) {
+      return Response.json({ flowId: flow.flowId, hasUnpublishedChanges: true, publication: null, revision: 0, status: 'not-published', version: 1 })
+    }
+    if (path == `/v1/flows/${flow.flowId}/presentation`) {
+      return Response.json({ revision: 1, updatedAt: timestamp, value: {}, version: 1 })
+    }
+    if (path == `/v1/flows/${flow.flowId}/revisions/${flow.draftRevisionId}/check`) {
+      return Response.json({
+        closureDigest: 'closure',
+        diagnostics: [],
+        engineContract: 'open-flow-engine/v1',
+        flowId: flow.flowId,
+        modelVersion: 1,
+        revisionDigest: 'digest',
+        revisionId: flow.draftRevisionId,
+        valid: true,
+        version: 1,
+      })
+    }
+    if (path == '/v1/trigger-keys/catalog') {
+      return Response.json({
+        definitions: [
+          {
+            configSchema: { additionalProperties: false, type: 'object' },
+            definitionVersion: 1,
+            description: 'Runs when a repository changes.',
+            displayName: 'Repository event',
+            endpoint: {
+              body: { allowArray: false, allowEmpty: false, formats: ['json'] },
+              methods: ['POST'],
+              successStatus: 200,
+            },
+            key: 'github.on_repo_event',
+            name: 'on_repo_event',
+            payloadSchema: { additionalProperties: true, type: 'object' },
+            provider: 'github',
+            type: 'integration',
+          },
+        ],
+        version: 1,
+      })
+    }
+    throw new Error(`Unexpected request: ${path}`)
+  })
+  const client = new WorkbenchClient(request)
+  const workspace = new WorkspaceStore(client, vi.fn())
+  const triggers = new TriggerStore(client, workspace, vi.fn(), { openExternalPage: async () => true })
+  const signal = new AbortController().signal
+  return { client, workspace, triggers, requests, signal }
+}
+
 describe('TriggerStore', () => {
   it('loads catalog definitions without requesting Connections and creates an unconnected option', async () => {
-    const requests: string[] = []
-    const request = vi.fn(async (path: string) => {
-      requests.push(path)
-      if (path == '/v1/flows?limit=50&includeTotal=true') return Response.json({ flows: [flow], total: 1, version: 1 })
-      if (path == `/v1/flows/${flow.flowId}/draft`) {
-        return Response.json({
-          actorId: 'actor',
-          content: {
-            document: { bindings: {}, graph: { nodes: {} }, subflows: {}, tasks: {} },
-            modelVersion: 1,
-            modules: {},
-          },
-          createdAt: timestamp,
-          digest: 'digest',
-          flowId: flow.flowId,
-          modelVersion: 1,
-          parentRevisionId: null,
-          revisionId: flow.draftRevisionId,
-          version: 1,
-        })
-      }
-      if (path == `/v1/flows/${flow.flowId}/live`) {
-        return Response.json({ flowId: flow.flowId, hasUnpublishedChanges: true, publication: null, revision: 0, status: 'not-published', version: 1 })
-      }
-      if (path == `/v1/flows/${flow.flowId}/presentation`) {
-        return Response.json({ revision: 1, updatedAt: timestamp, value: {}, version: 1 })
-      }
-      if (path == `/v1/flows/${flow.flowId}/revisions/${flow.draftRevisionId}/check`) {
-        return Response.json({
-          closureDigest: 'closure',
-          diagnostics: [],
-          engineContract: 'open-flow-engine/v1',
-          flowId: flow.flowId,
-          modelVersion: 1,
-          revisionDigest: 'digest',
-          revisionId: flow.draftRevisionId,
-          valid: true,
-          version: 1,
-        })
-      }
-      if (path == '/v1/trigger-keys/catalog') {
-        return Response.json({
-          definitions: [
-            {
-              configSchema: { additionalProperties: false, type: 'object' },
-              definitionVersion: 1,
-              description: 'Runs when a repository changes.',
-              displayName: 'Repository event',
-              endpoint: {
-                body: { allowArray: false, allowEmpty: false, formats: ['json'] },
-                methods: ['POST'],
-                successStatus: 200,
-              },
-              key: 'github.on_repo_event',
-              name: 'on_repo_event',
-              payloadSchema: { additionalProperties: true, type: 'object' },
-              provider: 'github',
-              type: 'integration',
-            },
-          ],
-          version: 1,
-        })
-      }
-      throw new Error(`Unexpected request: ${path}`)
-    })
-    const client = new WorkbenchClient(request)
-    const workspace = new WorkspaceStore(client, vi.fn())
-    const triggers = new TriggerStore(client, workspace, vi.fn(), { openExternalPage: async () => false })
-    const signal = new AbortController().signal
+    const { workspace, triggers, requests, signal } = createSetup()
 
     try {
       await workspace.start(flow.flowId)
@@ -104,6 +140,89 @@ describe('TriggerStore', () => {
       expect(searched?.map((option) => option.id)).toEqual(['trigger:github.on_repo_event'])
       expect(requests.filter((path) => path == '/v1/trigger-keys/catalog')).toHaveLength(1)
       expect(requests.some((path) => path.startsWith('/v1/connector/connections/'))).toBe(false)
+    } finally {
+      triggers.dispose()
+      workspace.dispose()
+    }
+  })
+
+  it.each(['failure', 'success', 'empty'] as const)('keeps loaded connections during authorization refresh and handles %s', async (outcome) => {
+    const { client, workspace, triggers } = createSetup()
+    const old: ConnectorConnection = { connectionId: 'github-old', displayName: 'Old', isDefault: true, serviceId: 'github', status: 'active' }
+    const fresh = { ...old, displayName: 'Refreshed' }
+    const pending = Promise.withResolvers<readonly ConnectorConnection[]>()
+    const list = vi.spyOn(client, 'listConnectorConnections').mockResolvedValueOnce([old]).mockReturnValueOnce(pending.promise).mockResolvedValue([fresh])
+    try {
+      await workspace.start(flow.flowId)
+      workspace.selectNodes(['github'])
+      await triggers.refresh()
+      await triggers.connect('github')
+      const refresh = triggers.refreshAfterAuthorization()
+
+      expect(triggers.$.selectedAuthorizationPending.value).toBe(false)
+      expect(triggers.$.connectionLoading.value).toBe('github')
+      expect(triggers.$.selectedActiveConnections.value).toEqual([old])
+      expect(triggers.$.selectedConnection.value).toEqual(old)
+
+      if (outcome == 'failure') pending.reject(new Error('Connection refresh failed'))
+      else pending.resolve(outcome == 'empty' ? [] : [fresh])
+      await refresh
+
+      expect(triggers.$.connectionLoading.value).toBeUndefined()
+      if (outcome == 'failure') {
+        expect(triggers.$.selectedActiveConnections.value).toEqual([old])
+        expect(triggers.$.selectedConnection.value).toEqual(old)
+        expect(triggers.$.selectedConnectionError.value).toContain('Connection refresh failed')
+        await triggers.refresh()
+        expect(triggers.$.selectedConnection.value).toEqual(fresh)
+        expect(triggers.$.selectedConnectionError.value).toBeUndefined()
+        expect(list).toHaveBeenCalledTimes(3)
+      } else {
+        expect(triggers.$.selectedActiveConnections.value).toEqual(outcome == 'empty' ? [] : [fresh])
+        await triggers.refresh()
+        expect(list).toHaveBeenCalledTimes(2)
+      }
+    } finally {
+      triggers.dispose()
+      workspace.dispose()
+    }
+  })
+
+  it.each(['before', 'during'] as const)('reloads the authorized provider after switching away %s refresh', async (timing) => {
+    const { client, workspace, triggers } = createSetup()
+    const old: ConnectorConnection = { connectionId: 'github-old', displayName: 'Old', isDefault: true, serviceId: 'github', status: 'active' }
+    const fresh = { ...old, displayName: 'Refreshed' }
+    const pending = Promise.withResolvers<readonly ConnectorConnection[]>()
+    const list = vi.spyOn(client, 'listConnectorConnections').mockResolvedValue([old])
+    try {
+      await workspace.start(flow.flowId)
+      workspace.selectNodes(['mail'])
+      await triggers.refresh()
+      workspace.selectNodes(['github'])
+      await triggers.refresh()
+      await triggers.connect('github')
+      list.mockClear()
+
+      if (timing == 'before') {
+        workspace.selectNodes(['mail'])
+        await triggers.refreshAfterAuthorization()
+        expect(list).not.toHaveBeenCalled()
+      } else {
+        list.mockReturnValueOnce(pending.promise)
+        const refresh = triggers.refreshAfterAuthorization()
+        workspace.selectNodes(['mail'])
+        await triggers.refresh()
+        expect(triggers.$.connectionLoading.value).toBeUndefined()
+        pending.resolve([])
+        await refresh
+      }
+      workspace.selectNodes(['github'])
+      expect(triggers.$.selectedConnection.value).toEqual(old)
+      list.mockResolvedValue([fresh])
+      await triggers.refresh()
+      expect(list).toHaveBeenLastCalledWith('github', undefined, flow.flowId)
+      expect(triggers.$.selectedConnection.value).toEqual(fresh)
+      expect(list).toHaveBeenCalledTimes(timing == 'before' ? 1 : 2)
     } finally {
       triggers.dispose()
       workspace.dispose()

--- a/packages/open-flow/src/workbench/browser/runtime/stores/triggerStore.ts
+++ b/packages/open-flow/src/workbench/browser/runtime/stores/triggerStore.ts
@@ -82,6 +82,7 @@ export class TriggerStore {
   readonly #host: Pick<WorkbenchHost, 'openExternalPage'>
   readonly #i18n: I18n
   readonly #refresh = new Latest()
+  readonly #stale = new Set<string>()
   readonly #selected: ReadonlyVal<Selection>
   readonly #setNotice: SetNotice
   readonly #state: Val<TriggerState> = val(initialState)
@@ -143,6 +144,7 @@ export class TriggerStore {
     this.#catalogController.abort()
     this.#catalogController = new AbortController()
     this.#catalog = undefined
+    this.#stale.clear()
     this.#refresh.invalidate()
     this.#state.set(initialState)
   }
@@ -169,19 +171,23 @@ export class TriggerStore {
   }
 
   public async refresh(force = false): Promise<void> {
+    if (this.#disposed) return
     const current = this.#refresh.begin()
     const flowId = this.#workspace.$.flowId.value
     const selected = target(this.#workspace.$.selection.value, this.#workspace)
-    if (this.#disposed) return
     if (flowId == null || selected == null) {
       if (this.#state.value.connectionLoading != null) this.#set({ connectionLoading: undefined })
       return
     }
-    if (!force && this.#state.value.catalogs[selected.provider] != null) return
+    if (!force && !this.#stale.has(selected.provider) && this.#state.value.catalogs[selected.provider] != null) {
+      if (this.#state.value.connectionLoading != null) this.#set({ connectionLoading: undefined })
+      return
+    }
     this.#set({ connectionError: undefined, connectionLoading: selected.provider })
     try {
       const catalog = connectionCatalog(await this.#client.listConnectorConnections(selected.provider, undefined, flowId))
       if (!this.#current(current, flowId)) return
+      this.#stale.delete(selected.provider)
       this.#set({ catalogs: { ...this.#state.value.catalogs, [selected.provider]: catalog } })
     } catch (error) {
       if (this.#current(current, flowId)) {
@@ -216,11 +222,11 @@ export class TriggerStore {
   }
 
   public async refreshAfterAuthorization(): Promise<void> {
+    if (this.#disposed) return
     const provider = this.#state.value.authorizationProvider
-    if (this.#disposed || provider == null) return
-    const catalogs = { ...this.#state.value.catalogs }
-    delete catalogs[provider]
-    this.#set({ authorizationProvider: undefined, catalogs })
+    if (provider == null) return
+    this.#stale.add(provider)
+    this.#set({ authorizationProvider: undefined })
     if (target(this.#workspace.$.selection.value, this.#workspace)?.provider == provider) await this.refresh(true)
   }
 


### PR DESCRIPTION
Trigger authorization previously deleted the provider's loaded connection catalog before reloading it, losing the cached list and bound connection details when the request failed. Keep the catalog while refreshing and mark the authorized provider stale until a successful response replaces it, including an empty response.

If the user switches providers before or during the refresh, preserve the stale marker so selecting the authorized provider again reloads its connections. Clear an interrupted loading indicator when switching to a provider with a usable cache. This change retains store data; the Inspector's existing loading and error presentation remains unchanged.

Adds five regression cases covering pending refreshes, success, failure and retry, empty results, and selection changes before or during authorization refresh.

Validation:
- `bun run format`
- `bun run check`
- `bun run build` with Bun 1.4.0.
- `bun run test` with Bun 1.4.0 — all 1,110 tests passed. An earlier run alongside a build failed the Server process-recovery start-barrier test; the full rerun without a concurrent build passed.
- `git diff --check`

Closes #81.
