### PR TITLE
fix(designer): reject non-inline scriptlet connections

### DIFF
--- a/packages/open-flow/src/designer/browser/stores/designer/designer.store.test.ts
+++ b/packages/open-flow/src/designer/browser/stores/designer/designer.store.test.ts
@@ -1,4 +1,4 @@
-import type { NodeId } from '../../../../schema/index.ts'
+import type { HandleName, NodeId } from '../../../../schema/index.ts'
 import type { NodeStatus, NodeType } from '../node/constants.ts'
 import type { NodeStoreDisplay$ } from '../node/node.store.ts'
 import type { InteractiveMode } from './designer.store.ts'
@@ -6,9 +6,11 @@ import type { InteractiveMode } from './designer.store.ts'
 import { val } from 'value-enhancer'
 import { reactiveMap } from 'value-enhancer/collections'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { toRFHandleName } from '../../base/rfHelpers.ts'
 import { CommentNodeStore } from '../node/commentNode.store.ts'
 import { NODE_STATUS, NODE_TYPE } from '../node/constants.ts'
 import { NodeStore } from '../node/node.store.ts'
+import { TaskNodeStore } from '../node/taskNode.store.ts'
 import { DesignerStore } from './designer.store.ts'
 import { DesignerUIStore } from './designerUI.store.ts'
 import { NodeMiniMapPhase } from './nodeMiniMap.ts'
@@ -19,10 +21,11 @@ interface TestSetup {
   readonly store: DesignerStore
   readonly nodes: ReturnType<typeof reactiveMap<NodeId, NodeStore>>
   createNode(nodeId: NodeId, nodeType?: NodeType): NodeStore
+  createTaskNode(nodeId: NodeId): TaskNodeStore
   dispose(): void
 }
 
-function createTestSetup(): TestSetup {
+function createTestSetup(onConnect: () => void = () => {}): TestSetup {
   const nodes = reactiveMap<NodeId, NodeStore>()
   const viewport = val<{ x: number; y: number; zoom: number } | undefined>()
   const designerUIStore = new DesignerUIStore({ viewport, nodeStores: nodes })
@@ -40,7 +43,7 @@ function createTestSetup(): TestSetup {
     bindValidateConnection: () => {},
     onAddNode: async () => undefined,
     onDeleteNodes: () => {},
-    onConnect: () => {},
+    onConnect,
     onDisconnect: () => {},
     onDuplicate: async () => {},
   })
@@ -62,6 +65,28 @@ function createTestSetup(): TestSetup {
         outputs_def: val(),
       }
       const node = new NodeStore(nodeId, nodeType, { display$, designerUIStore })
+      createdNodes.push(node)
+      return node
+    },
+    createTaskNode(nodeId) {
+      const node = new TaskNodeStore(nodeId, {
+        designerUIStore,
+        display$: {
+          icon: val(),
+          title: val(),
+          description: val(),
+          status: val<NodeStatus>(NODE_STATUS.Idle),
+          progress: val(),
+          showSettings: val(),
+          ignore: val(),
+          sections: val([]),
+          inputs_def: val([{ handle: 'input' as HandleName }]),
+          outputs_def: val([{ handle: 'output' as HandleName }]),
+          inputs_from: val([]),
+          task: val(),
+          executorName: val(),
+        },
+      })
       createdNodes.push(node)
       return node
     },
@@ -113,6 +138,29 @@ describe('DesignerStore.waitNode', () => {
     setup.nodes.set(nodeId, setup.createNode(nodeId))
     await vi.runAllTimersAsync()
     expect(logError).toHaveBeenCalledTimes(1)
+    setup.dispose()
+  })
+})
+
+describe('DesignerStore.setupScriptletNode', () => {
+  it('does not publish a connection when the target is not an inline task', async () => {
+    const onConnect = vi.fn()
+    const setup = createTestSetup(onConnect)
+    const source = setup.createTaskNode('source' as NodeId)
+    const target = setup.createTaskNode('scriptlet' as NodeId)
+    setup.nodes.set(source.nodeId, source)
+    setup.nodes.set(target.nodeId, target)
+
+    await setup.store.setupScriptletNode(
+      target.nodeId,
+      {
+        source: source.rfNodeId,
+        sourceHandle: toRFHandleName('output' as HandleName),
+      },
+      'input' as HandleName,
+    )
+
+    expect(onConnect).not.toHaveBeenCalled()
     setup.dispose()
   })
 })

--- a/packages/open-flow/src/designer/browser/stores/designer/designer.store.ts
+++ b/packages/open-flow/src/designer/browser/stores/designer/designer.store.ts
@@ -1031,7 +1031,8 @@ export class DesignerStore {
         const def = sourceNode.getOutputHandleDef(sourceHandle)
         if (def) {
           const targetNode = await this.waitInlineTaskNode(nodeId)
-          targetNode?.setupInputHandle(handle, def)
+          if (targetNode == null) return
+          targetNode.setupInputHandle(handle, def)
         }
       }
     } else if (handle && 'target' in connection) {
@@ -1042,7 +1043,8 @@ export class DesignerStore {
         const def = targetNode.getInputHandleDef(targetHandle)
         if (def) {
           const sourceNode = await this.waitInlineTaskNode(nodeId)
-          sourceNode?.setupOutputHandle(handle, def)
+          if (sourceNode == null) return
+          sourceNode.setupOutputHandle(handle, def)
         }
       }
     }


### PR DESCRIPTION
## Summary

- stop publishing scriptlet connections when the created node is not an inline task
- add regression coverage for the non-inline-task path

## Root cause

`setupScriptletNode` waited for an inline task and conditionally initialized its handle, but always called `onRFConnect` afterward. When the node was a regular Task or otherwise failed inline-task validation, the connection could still be persisted.

## Behavioral impact

Connections are now emitted only after the target or source has been confirmed as an inline task and its handle has been initialized. Failed inline-task creation or type mismatches no longer leave dangling React Flow connections.

## Verification

- targeted Vitest: `designer.store.test.ts` — 14 tests passed
- TypeScript: `tsc --noEmit`
- oxlint on touched files
- oxfmt check on touched files

No related issue; this is a focused bug fix found while reviewing the designer connection lifecycle.