### PR TITLE
fix(test): normalize Windows path and line endings

### DIFF
--- a/packages/open-flow/test/designer/i18n-keys.test.ts
+++ b/packages/open-flow/test/designer/i18n-keys.test.ts
@@ -86,7 +86,8 @@ describe.each(bundles)('$name translations', ({ locales, name, sources }) => {
 
     for await (const file of glob(sources)) {
       // The IconPicker carries its own bundle, so the designer scan leaves those keys to it.
-      if (name == 'designer' && file.includes(iconPickerPath)) continue
+      // glob 返回平台原生路径分隔符，先统一后再判断语言包边界。
+      if (name == 'designer' && file.replaceAll('\\', '/').includes(iconPickerPath)) continue
       const source = await readFile(file, 'utf8')
       for (const match of source.matchAll(keyPattern)) {
         const key = match[2]!

--- a/packages/open-flow/test/workbench-ui-style-boundaries.test.ts
+++ b/packages/open-flow/test/workbench-ui-style-boundaries.test.ts
@@ -60,6 +60,10 @@ function referencedTokens(source: string, prefix: string): string[] {
   return [...new Set([...source.matchAll(new RegExp(`var\\((${prefix}[\\w-]+)`, 'g'))].map((match) => match[1]!))].toSorted()
 }
 
+function normalizeLineEndings(source: string): string {
+  return source.replaceAll('\r\n', '\n')
+}
+
 function relativeLuminance(hex: string): number {
   const channels = [1, 3, 5].map((start) => Number.parseInt(hex.slice(start, start + 2), 16) / 255)
   const [red, green, blue] = channels.map((channel) => (channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4))
@@ -118,7 +122,7 @@ test('keeps Workbench feature styles in their original cascade order', async () 
   assert.match(runs, /\.run-drawer \{/)
   assert.match(publications, /\.publication-view \{/)
   assert.match(responsive, /@container open-flow-workbench/)
-  assert.equal(entry.trim(), workbenchStyleImports.join('\n'))
+  assert.equal(normalizeLineEndings(entry).trim(), workbenchStyleImports.join('\n'))
 })
 
 test('keeps Resource Browser primitives on shared visual ownership', async () => {


### PR DESCRIPTION
## Summary

- make the designer i18n boundary test portable across Windows and POSIX path separators
- normalize CSS line endings before asserting the Workbench import order

## Root cause

The i18n test compared glob results against a POSIX-only `/icons/IconPicker/` fragment. On Windows, glob returns backslash-separated paths, so IconPicker's own translation keys were incorrectly attributed to the designer bundle. The Workbench style boundary test also compared a CRLF file directly with an LF-only expected string, causing a deterministic Windows failure even when the import order was correct.

## Behavioral impact

These changes only affect test diagnostics. They prevent false failures on Windows while preserving the existing bundle boundary and CSS import-order assertions.

## Verification

- package Vitest: 104 test files, 783 tests passed
- TypeScript: `tsc --noEmit -p packages/open-flow/tsconfig.json`
- oxlint on touched tests
- oxfmt check on touched tests

Before this change, the package suite failed with the two Windows-specific assertions described above.

No related issue; this is a focused cross-platform test fix found while running the repository checks on Windows.