### PR TITLE
fix(test): close services before Windows cleanup

### DIFF
--- a/apps/server/test/service.test.ts
+++ b/apps/server/test/service.test.ts
@@ -17,13 +17,14 @@ import { ServerService } from '../node/service.ts'
 import { Store } from '../node/store.ts'
 import { createConnectorHost } from './connectorHost.ts'
 import { acceptRun, storeRevision } from './runFixture.ts'
-import { closeService, openService, startService } from './serviceFixture.ts'
+import { closeOpenServices, closeService, openService, startService } from './serviceFixture.ts'
 
 const directories: string[] = []
 const execFileAsync = promisify(execFile)
 const port = { jsonSchema: {}, nullable: false } as const
 
 afterEach(async () => {
+  await closeOpenServices()
   await Promise.all(directories.splice(0).map((directory) => rm(directory, { force: true, recursive: true })))
 })
 

--- a/apps/server/test/serviceFixture.ts
+++ b/apps/server/test/serviceFixture.ts
@@ -5,12 +5,14 @@ import { onTestFinished } from 'vitest'
 import { ServerService } from '../node/service.ts'
 
 const scopes = new WeakMap<ServerService, Scope.Closeable>()
+const openServices = new Set<ServerService>()
 
 export async function openService(...args: Parameters<typeof ServerService.open>): Promise<ServerService> {
   const scope = await Effect.runPromise(Scope.make())
   try {
     const service = await Effect.runPromise(ServerService.open(...args).pipe(Scope.provide(scope)))
     scopes.set(service, scope)
+    openServices.add(service)
     onTestFinished(() => closeService(service))
     return service
   } catch (error) {
@@ -23,7 +25,12 @@ export async function closeService(service: ServerService): Promise<void> {
   const scope = scopes.get(service)
   if (scope == null) return
   scopes.delete(service)
+  openServices.delete(service)
   await Effect.runPromise(Scope.close(scope, Exit.void))
+}
+
+export async function closeOpenServices(): Promise<void> {
+  await Promise.all([...openServices].map(closeService))
 }
 
 export async function startService(service: ServerService): Promise<void> {


### PR DESCRIPTION
## Summary

- close open ServerService test scopes before deleting temporary SQLite directories
- make service test cleanup deterministic on Windows

## Root cause

`openService` registered automatic cleanup with `onTestFinished`, while `service.test.ts` removed its temporary directories from `afterEach`. On Windows, SQLite database, WAL, and shared-memory files cannot be unlinked while the service scope is still open, producing `EBUSY` failures after otherwise successful assertions.

## Behavioral impact

The test fixture now tracks open services and exposes an explicit cleanup hook. `service.test.ts` closes those scopes before removing directories; the existing per-test `onTestFinished` callback remains idempotent as a fallback.

## Verification

- before the change: 17 service tests failed with SQLite `EBUSY` cleanup errors on Windows
- after the change: 33 of 34 `service.test.ts` tests passed; all prior `EBUSY` failures were eliminated
- oxfmt check on touched files

The remaining test failure is an unrelated `spawn ps ENOENT` dependency in the process-loss test and is not changed by this PR.

No related issue; this is a focused Windows test-lifecycle fix found while running the server suite locally.