### PR TITLE
fix(test): discover executor processes on Windows

### DIFF
--- a/apps/server/test/isolated-vm.test.ts
+++ b/apps/server/test/isolated-vm.test.ts
@@ -1,13 +1,11 @@
 import type { RuntimeHarness, RuntimeProgram } from '@oomol-lab/open-flow/runtime-contract'
 
 import { runtimeConformanceCases } from '@oomol-lab/open-flow/runtime-contract'
-import { execFile } from 'node:child_process'
-import { promisify } from 'node:util'
 import { afterAll, describe, expect, it } from 'vitest'
 import { IsolatedVmError, isolatedVmEngineDigest, isolatedVmLimits, IsolatedVmHost } from '../node/isolated-vm.ts'
+import { childProcessId } from './processTree.ts'
 
 const host = new IsolatedVmHost()
-const execFileAsync = promisify(execFile)
 
 const harness: RuntimeHarness = {
   engineDigest: isolatedVmEngineDigest,
@@ -38,13 +36,7 @@ function invoke(source: string, limits = isolatedVmLimits) {
 }
 
 async function executorPid(): Promise<number> {
-  const { stdout } = await execFileAsync('ps', ['-A', '-o', 'pid=,ppid=,command='])
-  const processLine = stdout
-    .split('\n')
-    .map((line) => /^(\s*\d+)\s+(\d+)\s+(.+)$/.exec(line))
-    .find((match) => match?.[2] == String(process.pid) && match[3].includes('--executor'))
-  if (processLine == null) throw new Error('Runtime Executor process was not found.')
-  return Number(processLine[1])
+  return await childProcessId(process.pid, '--executor')
 }
 
 describe('isolated-vm runtime conformance', () => {

--- a/apps/server/test/processTree.ts
+++ b/apps/server/test/processTree.ts
@@ -1,0 +1,30 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+export async function childProcessId(parentId: number, marker: string): Promise<number> {
+  if (process.platform == 'win32') {
+    const { stdout } = await execFileAsync('powershell.exe', [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      '$ErrorActionPreference = "Stop"; Get-CimInstance Win32_Process | Select-Object ProcessId, ParentProcessId, CommandLine | ConvertTo-Json -Compress',
+    ])
+    const rows = JSON.parse(stdout) as
+      | { readonly ProcessId?: number; readonly ParentProcessId?: number; readonly CommandLine?: string }
+      | readonly { readonly ProcessId?: number; readonly ParentProcessId?: number; readonly CommandLine?: string }[]
+    const processes = Array.isArray(rows) ? rows : [rows]
+    const match = processes.find((entry) => entry.ParentProcessId == parentId && typeof entry.CommandLine == 'string' && entry.CommandLine.includes(marker))
+    if (match?.ProcessId == null) throw new Error('Child process was not found.')
+    return match.ProcessId
+  }
+
+  const { stdout } = await execFileAsync('ps', ['-A', '-o', 'pid=,ppid=,command='])
+  const match = stdout
+    .split('\n')
+    .map((line) => /^(\s*\d+)\s+(\d+)\s+(.+)$/.exec(line))
+    .find((entry) => entry?.[2] == String(parentId) && entry[3].includes(marker))
+  if (match == null) throw new Error('Child process was not found.')
+  return Number(match[1])
+}

--- a/apps/server/test/service.test.ts
+++ b/apps/server/test/service.test.ts
@@ -5,22 +5,20 @@ import type { InvokeLlmTask } from '@oomol-lab/open-flow/runtime-contract'
 import { controlErrorCode } from '@oomol-lab/open-flow/control-api'
 import * as Effect from 'effect/Effect'
 import { TestClock } from 'effect/testing'
-import { execFile } from 'node:child_process'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
-import { promisify } from 'node:util'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createServerApp } from '../node/http.ts'
 import { ServerService } from '../node/service.ts'
 import { Store } from '../node/store.ts'
 import { createConnectorHost } from './connectorHost.ts'
+import { childProcessId } from './processTree.ts'
 import { acceptRun, storeRevision } from './runFixture.ts'
 import { closeService, openService, startService } from './serviceFixture.ts'
 
 const directories: string[] = []
-const execFileAsync = promisify(execFile)
 const port = { jsonSchema: {}, nullable: false } as const
 
 afterEach(async () => {
@@ -1144,13 +1142,7 @@ describe('Server application service', () => {
     if (first.kind != 'accepted' || second.kind != 'accepted') throw new Error('Concurrent Run setup conflicted.')
 
     await started.promise
-    const { stdout } = await execFileAsync('ps', ['-A', '-o', 'pid=,ppid=,command='])
-    const executor = stdout
-      .split('\n')
-      .map((line) => /^(\s*\d+)\s+(\d+)\s+(.+)$/.exec(line))
-      .find((match) => match?.[2] == String(process.pid) && match[3].includes('--executor'))
-    if (executor == null) throw new Error('Runtime Executor process was not found.')
-    process.kill(Number(executor[1]), 'SIGKILL')
+    process.kill(await childProcessId(process.pid, '--executor'), 'SIGKILL')
 
     await service.waitForIdle()
     await vi.waitFor(() => expect(aborted).toBe(2))


### PR DESCRIPTION
## Summary

- replace the POSIX-only `ps` process lookup in executor-loss tests with a cross-platform helper
- use PowerShell CIM process metadata on Windows and retain `ps` on POSIX

## Root cause

The executor crash tests located child processes by invoking `ps -A -o pid=,ppid=,command=`. Windows does not provide `ps`, so the tests failed with `spawn ps ENOENT` before exercising executor recovery.

## Behavioral impact

The tests now discover the executor by parent PID and command marker on both supported platform families. The process-loss assertions and executor rebuild coverage remain unchanged.

## Verification

- before the change: executor-loss coverage failed on Windows with `spawn ps ENOENT`
- after the change: executor-loss and idle-executor rebuild tests — 2 passed
- service shared-executor-loss test — passed
- TypeScript: `tsc --noEmit -p apps/server/tsconfig.json`
- oxlint and oxfmt on touched tests

No related issue; this is a focused cross-platform test infrastructure fix found while running the server suite on Windows.