### PR TITLE
fix(server): guard settings refreshes and form writes

### DIFF
--- a/apps/server/browser/locales/en.json
+++ b/apps/server/browser/locales/en.json
@@ -74,6 +74,7 @@
     "selectForCreation": "Select the Connector Team for the new Flow"
   },
   "variables": {
+    "nameExists": "A Variable with this name already exists. Edit the existing Variable instead.",
     "all": "All Variables",
     "cancel": "Cancel",
     "count": "{{count}} of 200",

--- a/apps/server/browser/locales/fr.json
+++ b/apps/server/browser/locales/fr.json
@@ -74,6 +74,7 @@
     "selectForCreation": "Sélectionner l’équipe du Connector pour le nouveau Flow"
   },
   "variables": {
+    "nameExists": "Une Variable portant ce nom existe déjà. Modifiez la Variable existante.",
     "all": "Toutes les Variables",
     "cancel": "Annuler",
     "count": "{{count}} sur 200",

--- a/apps/server/browser/locales/ja.json
+++ b/apps/server/browser/locales/ja.json
@@ -74,6 +74,7 @@
     "selectForCreation": "新しい Flow の Connector チームを選択"
   },
   "variables": {
+    "nameExists": "同じ名前の Variable が既に存在します。既存の Variable を編集してください。",
     "all": "すべての Variable",
     "cancel": "キャンセル",
     "count": "{{count}} / 200",

--- a/apps/server/browser/locales/ko.json
+++ b/apps/server/browser/locales/ko.json
@@ -74,6 +74,7 @@
     "selectForCreation": "새 Flow의 Connector 팀 선택"
   },
   "variables": {
+    "nameExists": "같은 이름의 Variable이 이미 있습니다. 기존 Variable을 편집하세요.",
     "all": "모든 Variable",
     "cancel": "취소",
     "count": "{{count}} / 200",

--- a/apps/server/browser/locales/ru.json
+++ b/apps/server/browser/locales/ru.json
@@ -74,6 +74,7 @@
     "selectForCreation": "Выбрать команду Connector для нового Flow"
   },
   "variables": {
+    "nameExists": "Variable с таким именем уже существует. Отредактируйте существующую Variable.",
     "all": "Все Variables",
     "cancel": "Отмена",
     "count": "{{count}} из 200",

--- a/apps/server/browser/locales/zh-CN.json
+++ b/apps/server/browser/locales/zh-CN.json
@@ -74,6 +74,7 @@
     "selectForCreation": "选择新 Flow 使用的 Connector 团队"
   },
   "variables": {
+    "nameExists": "同名 Variable 已存在，请编辑已有 Variable。",
     "all": "全部 Variable",
     "cancel": "取消",
     "count": "已使用 {{count}} / 200",

--- a/apps/server/browser/locales/zh-TW.json
+++ b/apps/server/browser/locales/zh-TW.json
@@ -74,6 +74,7 @@
     "selectForCreation": "選擇新 Flow 使用的 Connector 團隊"
   },
   "variables": {
+    "nameExists": "同名 Variable 已存在，請編輯現有 Variable。",
     "all": "全部 Variable",
     "cancel": "取消",
     "count": "已使用 {{count}} / 200",

--- a/apps/server/browser/settings.tsx
+++ b/apps/server/browser/settings.tsx
@@ -1,6 +1,6 @@
 import type { FormEvent, ReactElement } from 'react'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { useTranslate } from 'val-i18n-react'
 
@@ -80,6 +80,7 @@ function SettingItem({
   const [secret, setSecret] = useState('')
   const t = useTranslate()
   const managed = source == 'environment' || source == 'derived'
+  const secretTooShort = endpoint == '/config/integration' && new TextEncoder().encode(secret).byteLength < 32
   const Heading = heading
 
   async function request(method: 'DELETE' | 'PUT', requestBody: Record<string, unknown>): Promise<void> {
@@ -122,7 +123,7 @@ function SettingItem({
 
   function save(event: FormEvent): void {
     event.preventDefault()
-    if (draftOrigin.length == 0 || (secretLabel != null && secretRequired && secret.length == 0) || pending) return
+    if (draftOrigin.length == 0 || (secretLabel != null && secretRequired && secret.length == 0) || secretTooShort || pending) return
     void request('PUT', { ...body(draftOrigin, secret), expectedRevision: revision, version: 1 })
   }
 
@@ -180,6 +181,8 @@ function SettingItem({
             <>
               <label htmlFor={`${endpoint}-secret`}>{secretLabel}</label>
               <input
+                aria-describedby={`${endpoint}-secret-hint`}
+                aria-invalid={secretTooShort && secret != ''}
                 autoComplete="new-password"
                 id={`${endpoint}-secret`}
                 onChange={(event) => setSecret(event.target.value)}
@@ -187,7 +190,9 @@ function SettingItem({
                 type="password"
                 value={secret}
               />
-              <span className="settings-hint">{t(endpoint == '/config/integration' ? 'settings.callbackKeyHint' : 'settings.tokenHint')}</span>
+              <span className="settings-hint" id={`${endpoint}-secret-hint`}>
+                {t(endpoint == '/config/integration' ? 'settings.callbackKeyHint' : 'settings.tokenHint')}
+              </span>
             </>
           )}
           <div className="settings-form-actions">
@@ -196,7 +201,7 @@ function SettingItem({
             </button>
             <button
               className="server-button server-button-primary"
-              disabled={pending || draftOrigin.length == 0 || (secretLabel != null && secretRequired && secret.length == 0)}
+              disabled={pending || draftOrigin.length == 0 || (secretLabel != null && secretRequired && secret.length == 0) || secretTooShort}
               type="submit"
             >
               {t('settings.save')}
@@ -223,24 +228,36 @@ export function SettingsPage({
   const [current, setCurrent] = useState<NonNullable<ReturnType<typeof config>>>()
   const [failed, setFailed] = useState(false)
   const [loading, setLoading] = useState(true)
+  const loadSequence = useRef(0)
   const t = useTranslate()
 
+  const saved = useCallback((value: NonNullable<ReturnType<typeof config>>): void => {
+    loadSequence.current += 1
+    setCurrent((previous) => (previous != null && previous.revision > value.revision ? previous : value))
+    setFailed(false)
+    setLoading(false)
+  }, [])
+
   const load = useCallback(async (): Promise<void> => {
+    const sequence = ++loadSequence.current
     try {
       const response = await fetch('/config', { credentials: 'same-origin' })
+      if (sequence != loadSequence.current) return
       if (response.status == 401) {
         onUnauthorized()
         return
       }
       const value = config(await response.json())
+      if (sequence != loadSequence.current) return
       if (!response.ok || value == null) throw new Error('Invalid configuration response.')
-      setCurrent(value)
+      setCurrent((previous) => (previous != null && previous.revision > value.revision ? previous : value))
       setFailed(false)
     } catch {
+      if (sequence != loadSequence.current) return
       setFailed(true)
       toast.error(t('settings.loadFailed'))
     } finally {
-      setLoading(false)
+      if (sequence == loadSequence.current) setLoading(false)
     }
   }, [onUnauthorized, t])
 
@@ -248,7 +265,10 @@ export function SettingsPage({
     void load()
     const refresh = (): void => void load()
     globalThis.addEventListener('focus', refresh)
-    return () => globalThis.removeEventListener('focus', refresh)
+    return () => {
+      loadSequence.current += 1
+      globalThis.removeEventListener('focus', refresh)
+    }
   }, [load])
 
   return (
@@ -292,7 +312,7 @@ export function SettingsPage({
                 name={t('settings.runtime')}
                 onConflict={load}
                 onSaved={(value) => {
-                  setCurrent(value)
+                  saved(value)
                   onConnectorChange()
                 }}
                 onUnauthorized={onUnauthorized}
@@ -310,7 +330,7 @@ export function SettingsPage({
                 heading="h3"
                 name={t('settings.console')}
                 onConflict={load}
-                onSaved={setCurrent}
+                onSaved={saved}
                 onUnauthorized={onUnauthorized}
                 originLabel={t('settings.console')}
                 placeholder="https://console.example.com"
@@ -324,7 +344,7 @@ export function SettingsPage({
                 endpoint="/config/llm"
                 name="LLM"
                 onConflict={load}
-                onSaved={setCurrent}
+                onSaved={saved}
                 onUnauthorized={onUnauthorized}
                 originLabel={t('settings.origin')}
                 placeholder="https://llm.example.com"
@@ -339,7 +359,7 @@ export function SettingsPage({
                 endpoint="/config/integration"
                 name={t('settings.integration')}
                 onConflict={load}
-                onSaved={setCurrent}
+                onSaved={saved}
                 onUnauthorized={onUnauthorized}
                 originLabel={t('settings.publicOrigin')}
                 placeholder="https://flows.example.com"

--- a/apps/server/browser/styles.css
+++ b/apps/server/browser/styles.css
@@ -636,6 +636,14 @@ body {
   justify-content: flex-end;
 }
 
+.settings-form input[aria-invalid='true'] {
+  border-color: var(--ui-destructive);
+}
+
+.settings-form input[aria-invalid='true'] + .settings-hint {
+  color: var(--ui-destructive);
+}
+
 .settings-summary,
 .settings-state {
   display: flex;

--- a/apps/server/browser/variables.tsx
+++ b/apps/server/browser/variables.tsx
@@ -55,12 +55,13 @@ export function VariablesPage({ client, language }: { readonly client: ControlCl
     return query == '' ? variables : variables.filter((variable) => variable.name.toLocaleLowerCase().includes(query))
   }, [filter, variables])
   const valueTooLarge = new TextEncoder().encode(value).byteLength > maxValueBytes
-  const nameInvalid = editing == '' && !validVariableName(name)
+  const nameExists = editing == '' && variables.some((variable) => variable.name == name)
+  const nameInvalid = editing == '' && (!validVariableName(name) || nameExists)
 
   async function save(event: FormEvent): Promise<void> {
     event.preventDefault()
     const target = editing == '' ? name : editing
-    if (target == null || !validVariableName(target) || valueTooLarge || pending) return
+    if (target == null || !validVariableName(target) || nameExists || valueTooLarge || loading || failed || pending) return
     setPending(true)
     try {
       await client.putVariable(target, value)
@@ -134,7 +135,7 @@ export function VariablesPage({ client, language }: { readonly client: ControlCl
               </button>
               <button
                 className="server-button server-button-primary"
-                disabled={pending || variables.length >= maxCount}
+                disabled={loading || failed || pending || variables.length >= maxCount}
                 onClick={() => {
                   setEditing('')
                   setName('')
@@ -167,7 +168,7 @@ export function VariablesPage({ client, language }: { readonly client: ControlCl
               />
               {nameInvalid && name != '' && (
                 <span className="variable-error" id="variable-name-error">
-                  {t('variables.invalidName')}
+                  {t(nameExists ? 'variables.nameExists' : 'variables.invalidName')}
                 </span>
               )}
               <label htmlFor="variable-value">{t('variables.value')}</label>
@@ -191,7 +192,7 @@ export function VariablesPage({ client, language }: { readonly client: ControlCl
                 <button className="server-button server-button-outline" disabled={pending} onClick={() => setEditing(undefined)} type="button">
                   {t('variables.cancel')}
                 </button>
-                <button className="server-button server-button-primary" disabled={pending || nameInvalid || valueTooLarge} type="submit">
+                <button className="server-button server-button-primary" disabled={loading || failed || pending || nameInvalid || valueTooLarge} type="submit">
                   {t('variables.save')}
                 </button>
               </div>

--- a/apps/server/test/settingsPage.test.tsx
+++ b/apps/server/test/settingsPage.test.tsx
@@ -1,0 +1,141 @@
+import type { FormEvent, ReactElement, ReactNode } from 'react'
+
+import { Children, isValidElement } from 'react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { SettingsPage } from '../browser/settings.tsx'
+
+const hooks = vi.hoisted(() => ({
+  cleanup: undefined as (() => void) | undefined,
+  focus: undefined as (() => void) | undefined,
+  stateIndex: 0,
+  refIndex: 0,
+  states: [] as unknown[],
+  refs: [] as { current: unknown }[],
+  effects: true,
+  toast: vi.fn(),
+}))
+
+vi.mock('react', async (importOriginal) => {
+  const original = await importOriginal<typeof import('react')>()
+  return {
+    ...original,
+    useCallback: <T,>(callback: T) => callback,
+    useEffect: (callback: () => void | (() => void)) => {
+      if (hooks.effects) hooks.cleanup = callback() ?? undefined
+    },
+    useRef: <T,>(value: T) => {
+      const index = hooks.refIndex++
+      return (hooks.refs[index] ??= { current: value }) as { current: T }
+    },
+    useState: <T,>(initial: T) => {
+      const index = hooks.stateIndex++
+      if (!(index in hooks.states)) hooks.states[index] = initial
+      return [
+        hooks.states[index],
+        (value: T | ((current: T) => T)) => {
+          hooks.states[index] = typeof value == 'function' ? (value as (current: T) => T)(hooks.states[index] as T) : value
+        },
+      ] as const
+    },
+  }
+})
+vi.mock('sonner', () => ({ toast: { error: hooks.toast } }))
+vi.mock('val-i18n-react', () => ({ useTranslate: () => (key: string) => key }))
+
+beforeEach(() => {
+  hooks.cleanup = undefined
+  hooks.focus = undefined
+  hooks.stateIndex = 0
+  hooks.refIndex = 0
+  hooks.states = []
+  hooks.refs = []
+  hooks.effects = true
+  hooks.toast.mockClear()
+  vi.stubGlobal('addEventListener', (_type: string, callback: () => void) => {
+    hooks.focus = callback
+  })
+  vi.stubGlobal('removeEventListener', vi.fn())
+})
+afterEach(() => {
+  hooks.cleanup?.()
+  vi.unstubAllGlobals()
+})
+
+function config(revision: number) {
+  return {
+    version: 1,
+    revision,
+    connector: { runtime: { configured: false, source: 'none', tokenConfigured: false }, console: { configured: false, source: 'none' } },
+    llm: { configured: false, source: 'none', tokenConfigured: false },
+    integration: { configured: false, source: 'none' },
+  }
+}
+
+function find(element: ReactElement, predicate: (item: ReactElement) => boolean): ReactElement | undefined {
+  if (predicate(element)) return element
+  for (const child of Children.toArray((element.props as { readonly children?: ReactNode }).children)) {
+    if (!isValidElement(child)) continue
+    const result = find(child, predicate)
+    if (result != null) return result
+  }
+}
+
+it('ignores an older refresh that finishes after the latest refresh', async () => {
+  const older = Promise.withResolvers<Response>()
+  const newer = Promise.withResolvers<Response>()
+  vi.stubGlobal('fetch', vi.fn().mockReturnValueOnce(older.promise).mockReturnValueOnce(newer.promise))
+  SettingsPage({ onConnectorChange: vi.fn(), onUnauthorized: vi.fn() })
+  hooks.focus?.()
+  newer.resolve(Response.json(config(2)))
+  await vi.waitFor(() => expect(hooks.states[0]).toMatchObject({ revision: 2 }))
+  older.resolve(Response.json(config(1)))
+  await older.promise
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  expect(hooks.states[0]).toMatchObject({ revision: 2 })
+})
+
+it.each(['response', 'failure', 'unauthorized', 'unmount'])('ignores an obsolete refresh after save or unmount: %s', async (outcome) => {
+  hooks.states = [config(1), false, false]
+  const pending = Promise.withResolvers<Response>()
+  vi.stubGlobal('fetch', vi.fn().mockReturnValue(pending.promise))
+  const unauthorized = vi.fn()
+  const page = SettingsPage({ onConnectorChange: vi.fn(), onUnauthorized: unauthorized })
+  const item = find(page, (element) => element.props.endpoint == '/config/llm')
+  if (item == null) throw new Error('LLM settings are missing.')
+  const props = item.props as { readonly onSaved: (value: ReturnType<typeof config>) => void }
+  if (outcome == 'unmount') hooks.cleanup?.()
+  else props.onSaved(config(3))
+  if (outcome == 'failure') pending.reject(new Error('Network failed.'))
+  else pending.resolve(outcome == 'unauthorized' ? new Response(null, { status: 401 }) : Response.json(config(2)))
+  await pending.promise.catch(() => {})
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  expect(hooks.states[0]).toMatchObject({ revision: outcome == 'unmount' ? 1 : 3 })
+  expect(hooks.toast).not.toHaveBeenCalled()
+  expect(unauthorized).not.toHaveBeenCalled()
+})
+
+it.each([
+  { secret: 'a'.repeat(31), accepted: false },
+  { secret: 'a'.repeat(32), accepted: true },
+  { secret: '\u4e2d'.repeat(10), accepted: false },
+  { secret: '\u4e2d'.repeat(11), accepted: true },
+])('validates Integration callback keys in UTF-8 bytes: %j', async ({ secret, accepted }) => {
+  hooks.states = [config(1), false, false]
+  hooks.effects = false
+  const fetcher = vi.fn().mockResolvedValue(Response.json(config(2)))
+  vi.stubGlobal('fetch', fetcher)
+  const page = SettingsPage({ onConnectorChange: vi.fn(), onUnauthorized: vi.fn() })
+  const item = find(page, (element) => element.props.endpoint == '/config/integration')
+  if (item == null || typeof item.type != 'function') throw new Error('Integration settings are missing.')
+  hooks.states = ['https://example.invalid', true, false, false, secret]
+  hooks.stateIndex = 0
+  const render = item.type as (props: typeof item.props) => ReactElement
+  const form = find(render(item.props), (element) => element.type == 'form')
+  if (form == null) throw new Error('Integration form is missing.')
+  const props = form.props as { readonly onSubmit: (event: FormEvent) => void }
+  props.onSubmit({ preventDefault: vi.fn() } as unknown as FormEvent)
+  expect(fetcher).toHaveBeenCalledTimes(accepted ? 1 : 0)
+  const field = find(form, (element) => element.type == 'input' && element.props.type == 'password')
+  expect(field?.props['aria-invalid']).toBe(!accepted)
+  await new Promise((resolve) => setTimeout(resolve, 0))
+})

--- a/apps/server/test/variablesPage.test.tsx
+++ b/apps/server/test/variablesPage.test.tsx
@@ -1,6 +1,8 @@
 import type { ControlClient, Variable } from '@oomol-lab/open-flow/control-api'
+import type { FormEvent, ReactElement, ReactNode } from 'react'
 
-import { beforeEach, expect, it, vi } from 'vitest'
+import { Children, isValidElement } from 'react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
 import { VariablesPage } from '../browser/variables.tsx'
 
 const hooks = vi.hoisted(() => ({
@@ -38,6 +40,17 @@ vi.mock('react', async (importOriginal) => {
 
 vi.mock('sonner', () => ({ toast: { error: hooks.toast } }))
 vi.mock('val-i18n-react', () => ({ useTranslate: () => (key: string) => key }))
+
+afterEach(() => vi.unstubAllGlobals())
+
+function find(element: ReactElement, predicate: (item: ReactElement) => boolean): ReactElement | undefined {
+  if (predicate(element)) return element
+  for (const child of Children.toArray((element.props as { readonly children?: ReactNode }).children)) {
+    if (!isValidElement(child)) continue
+    const result = find(child, predicate)
+    if (result != null) return result
+  }
+}
 
 beforeEach(() => {
   hooks.cleanup = undefined
@@ -80,5 +93,32 @@ it('ignores an older Variable response that finishes last', async () => {
 
   expect(hooks.setters[0]).toHaveBeenCalledOnce()
   expect(hooks.toast).not.toHaveBeenCalled()
+  hooks.cleanup?.()
+})
+
+it.each([
+  { editing: '', name: 'TOKEN', loading: false, failed: false, accepted: false },
+  { editing: 'TOKEN', name: 'TOKEN', loading: false, failed: false, accepted: true },
+  { editing: '', name: 'token', loading: false, failed: false, accepted: true },
+  { editing: '', name: 'NEW', loading: true, failed: false, accepted: false },
+  { editing: '', name: 'NEW', loading: false, failed: true, accepted: false },
+])('protects Variable writes: %j', async ({ editing, name, loading, failed, accepted }) => {
+  const variables = [{ name: 'TOKEN', value: 'original', updatedAt: '2026-08-27T00:00:00.000Z', version: 1 }] as const
+  hooks.states = [variables, loading, failed, false, '', editing, name, 'replacement', undefined]
+  const putVariable = vi.fn().mockResolvedValue(undefined)
+  const client = { listVariables: vi.fn().mockResolvedValue({ variables }), putVariable } as unknown as ControlClient
+  const page = VariablesPage({ client, language: 'en' })
+  const form = find(page, (item) => item.type == 'form')
+  if (form == null) throw new Error('Variable form is missing.')
+  const props = form.props as { readonly onSubmit: (event: FormEvent) => void }
+  props.onSubmit({ preventDefault: vi.fn() } as unknown as FormEvent)
+  await Promise.resolve()
+  if (accepted) expect(putVariable).toHaveBeenCalledWith(name, 'replacement')
+  else expect(putVariable).not.toHaveBeenCalled()
+  if (editing == '' && name == 'TOKEN') {
+    const input = find(page, (item) => item.type == 'input' && item.props.id == 'variable-name')
+    expect(input?.props['aria-invalid']).toBe(true)
+    expect(find(page, (item) => item.props.children == 'variables.nameExists')).toBeDefined()
+  }
   hooks.cleanup?.()
 })


### PR DESCRIPTION
## Summary

- Prevent a new Variable from silently replacing a same-name Variable already loaded in the page, while keeping editing and case-sensitive names available. Disable writes while the Variable list is loading or unavailable.
- Ignore obsolete settings refresh responses, errors, and authentication responses after a newer refresh, a save, or unmount. Keep configuration revisions from moving backward when responses arrive out of order.
- Validate Integration callback keys against the existing 32 UTF-8 byte requirement before saving, with field-level invalid styling and an associated explanation.
- Add focused regression coverage and duplicate-name copy in all seven Server locales.

## Scope

These changes are limited to the Server browser host. They do not change the public Control API, runtime behavior, or persistence schema.

The Variable name check is intentionally a local UI safeguard, not an atomic cross-client guarantee. Atomic Variable writes are tracked in #107; durable failure summaries are tracked separately in #106.
