### PR TITLE
fix(designer): check connection types exhaustively in the edge store

### DIFF
--- a/packages/open-flow/src/designer/browser/stores/edge/edge.store.ts
+++ b/packages/open-flow/src/designer/browser/stores/edge/edge.store.ts
@@ -237,9 +237,10 @@ function toRFEdgeConnection(nodes: ReadonlyReactiveMap<NodeId, NodeStore>, conne
       source = nodes.get(connection.from.source.node_id)?.rfNodeId || toRFNodeId(connection.from.source.node_id)
       sourceHandle = toRFHandleName(connection.from.source.output_handle)
       break
-    default:
-      // @ts-expect-error This branch should be unreachable.
-      throw new Error(`Unknown connection.from.type: ${connection.from.type}`)
+    default: {
+      connection.from satisfies never
+      throw new Error(`Unknown connection.from: ${JSON.stringify(connection.from)}`)
+    }
   }
 
   switch (connection.to.type) {
@@ -251,9 +252,10 @@ function toRFEdgeConnection(nodes: ReadonlyReactiveMap<NodeId, NodeStore>, conne
       target = toRFNodeId(connection.to.target.node_id)
       targetHandle = toRFHandleName(connection.to.target.input_handle)
       break
-    default:
-      // @ts-expect-error This branch should be unreachable.
-      throw new Error(`Unknown connection.to.type: ${connection.to.type}`)
+    default: {
+      connection.to satisfies never
+      throw new Error(`Unknown connection.to: ${JSON.stringify(connection.to)}`)
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

Replaces the two remaining `@ts-expect-error` suppressions in `toRFEdgeConnection` with `satisfies never` exhaustive checks, matching the pattern already used in `sharedBlockManager.ts`.

## Changes

- `packages/open-flow/src/designer/browser/stores/edge/edge.store.ts`: the unreachable `default` branches now narrow `connection.from`/`connection.to` with `satisfies never` and throw with the serialized value.

## Motivation

`@ts-expect-error` suppresses every error on the following line, so a future edit could introduce a real type error that gets silently hidden. `satisfies never` fails at the exact spot when a new connection variant is added to the union, which is this repository's established convention. These were the only two `@ts-expect-error` occurrences left in the repository.

## Testing

- `bun run check` and `bun run test` in `packages/open-flow`.
- Runtime behavior is unchanged; the branches remain unreachable for the current union.