### PR TITLE
fix: skip redundant computations in the schema subset checker

### DIFF
--- a/packages/open-flow/src/json-schema-subset/checker/cache.ts
+++ b/packages/open-flow/src/json-schema-subset/checker/cache.ts
@@ -50,7 +50,7 @@ function getWithCache<R, E, N extends ExtendsSchema | DeepReadonly<CompiledSchem
   const key = `${id1}/${id2}`
 
   let result = map.get(key)
-  if (!result) {
+  if (result === undefined) {
     map.set(key, (result = check(node1, node2)))
   }
   return result

--- a/packages/open-flow/src/json-schema-subset/checker/object.ts
+++ b/packages/open-flow/src/json-schema-subset/checker/object.ts
@@ -63,7 +63,7 @@ export function calculateObject<E>(context: Context<E>, schema1: CompiledSchema<
     for (const optionalKey of [...getOptionalKeys(schema1, schema2)].toSorted()) {
       const expression = calculateKey(optionalKey)
       if (expression !== ExpressionNone) {
-        quantumVariable.push(calculateKey(optionalKey), calculator)
+        quantumVariable.push(expression, calculator)
       }
     }
     const additionalProperties1 = (schema1.additionalProperties as Schema<E>) ?? ANY


### PR DESCRIPTION
## Summary

Fixes two redundant recomputations in the JSON Schema subset checker: cached falsy results never hit the cache, and `calculateObject` computes each optional key expression twice.

## Changes

- `checker/cache.ts`: `getWithCache` now checks `result === undefined` instead of `!result`, so cached falsy results (`false` and `ExpressionNone`) are reused. `checker/equals.ts` already used this form.
- `checker/object.ts`: the optional-key loop pushes the already computed `expression` instead of calling `calculateKey` a second time, matching the adjacent additionalProperties block.

## Motivation

- With `!result`, every deep-equality miss (`false`) and every `ExpressionNone` schema comparison bypassed the cache and was recomputed on each lookup.
- The optional-key loop called the recursive `calculateKey` twice per key purely to obtain the same value.

## Testing

- `bun run check` and `bun run test` in `packages/open-flow`. Both changes are behavior-preserving; the existing schema-compare suites cover the affected paths.