### PR TITLE
fix(server): report LLM task input validation reasons

### DIFF
--- a/apps/server/node/llm.ts
+++ b/apps/server/node/llm.ts
@@ -29,24 +29,15 @@ export function oomolLlm(connectorOrigin: string | undefined, token: string | un
 
 function invokeLlm(origin: URL, token: string): InvokeLlmTask {
   return async ({ input, mode, signal }) => {
+    let body: Record<string, unknown>
     try {
-      const model = record(input.model)
-      const messages = [
-        ...(input.messages == null ? [] : chatMessages(input.messages, (content) => content)),
-        ...chatMessages(input.template, (content) => render(content, input)),
-      ]
-      const body: Record<string, unknown> = {
-        messages,
-        model: typeof model.model == 'string' && model.model.length > 0 ? model.model : defaultModel,
-        ...(mode == 'json' ? { response_format: { type: 'json_object' } } : {}),
-      }
-      if (model.temperature != null) body.temperature = finite(model.temperature)
-      if (model.top_p != null) body.top_p = finite(model.top_p)
-      if (model.max_tokens != null) {
-        if (!Number.isSafeInteger(model.max_tokens) || Number(model.max_tokens) <= 0) throw new TypeError('Invalid LLM max_tokens.')
-        body.max_tokens = model.max_tokens
-      }
-
+      body = requestBody(input, mode)
+    } catch (error) {
+      // Task input validation messages are local and safe to report; other thrown values stay generic.
+      if (error instanceof TypeError) return { code: 'llm.unavailable', kind: 'failed', message: error.message, version: 1 }
+      throw error
+    }
+    try {
       const response = await fetch(new URL('chat/completions', origin), {
         body: JSON.stringify(body),
         headers: { 'authorization': `Bearer ${token}`, 'content-type': 'application/json' },
@@ -72,6 +63,26 @@ function invokeLlm(origin: URL, token: string): InvokeLlmTask {
       return unavailable()
     }
   }
+}
+
+function requestBody(input: Readonly<Record<string, JsonValue>>, mode: 'chat' | 'json'): Record<string, unknown> {
+  const model = record(input.model)
+  const messages = [
+    ...(input.messages == null ? [] : chatMessages(input.messages, (content) => content)),
+    ...chatMessages(input.template, (content) => render(content, input)),
+  ]
+  const body: Record<string, unknown> = {
+    messages,
+    model: typeof model.model == 'string' && model.model.length > 0 ? model.model : defaultModel,
+    ...(mode == 'json' ? { response_format: { type: 'json_object' } } : {}),
+  }
+  if (model.temperature != null) body.temperature = finite(model.temperature)
+  if (model.top_p != null) body.top_p = finite(model.top_p)
+  if (model.max_tokens != null) {
+    if (!Number.isSafeInteger(model.max_tokens) || Number(model.max_tokens) <= 0) throw new TypeError('Invalid LLM max_tokens.')
+    body.max_tokens = model.max_tokens
+  }
+  return body
 }
 
 function record(value: unknown): Record<string, unknown> {

--- a/apps/server/test/llm.test.ts
+++ b/apps/server/test/llm.test.ts
@@ -119,6 +119,31 @@ describe('OOMOL LLM host', () => {
     ).resolves.toEqual({ code: 'llm.output-invalid', kind: 'failed', message: 'The model returned invalid JSON.', version: 1 })
   })
 
+  it('reports the validation reason for invalid Task input', async () => {
+    vi.stubGlobal('fetch', vi.fn())
+    const llm = oomolLlm('https://connector.oomol.com', 'runtime-token')!
+
+    await expect(
+      llm({
+        input: { messages: null, model: { max_tokens: 0 }, template: [{ content: 'Answer.', role: 'user' }] },
+        invocationId: 'invocation-invalid-tokens',
+        mode: 'chat',
+        signal: new AbortController().signal,
+        version: 1,
+      }),
+    ).resolves.toEqual({ code: 'llm.unavailable', kind: 'failed', message: 'Invalid LLM max_tokens.', version: 1 })
+    await expect(
+      llm({
+        input: { messages: [{ content: 'Hi.', role: 'wizard' }], model: {}, template: [] },
+        invocationId: 'invocation-invalid-role',
+        mode: 'chat',
+        signal: new AbortController().signal,
+        version: 1,
+      }),
+    ).resolves.toEqual({ code: 'llm.unavailable', kind: 'failed', message: 'Invalid LLM message role.', version: 1 })
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled()
+  })
+
   it('does not infer an LLM host for a custom Connector or an empty token', () => {
     expect(oomolLlm('https://connector.example.com', 'runtime-token')).toBeUndefined()
     expect(oomolLlm('https://connector.oomol.com', '')).toBeUndefined()


### PR DESCRIPTION
## Summary

Invalid LLM task input (for example a non-positive `max_tokens` or an unknown message role) failed with the generic `llm.unavailable` message "The LLM request could not be completed", hiding the actual cause.

## Changes

- `apps/server/node/llm.ts`: request-body construction moved into a `requestBody` helper that runs before the network phase. Input validation `TypeError`s are mapped to a failed result that keeps the validation message; fetch and response failures keep the generic `unavailable` result.
- `apps/server/test/llm.test.ts`: covers `max_tokens` and message-role validation failures and asserts `fetch` is not called for invalid input.

## Motivation

The previous single `catch` conflated task input errors with transport failures. A user configuring an invalid `max_tokens` saw "The LLM request could not be completed" and had no hint the problem was their own input. Validation failures are local and their messages are authored by this code, so surfacing them adds the missing diagnosis without exposing transport details, which stay generic (unchanged behavior asserted by the existing `provider-secret-detail` test in `service.test.ts`).

## Testing

- `bun run check` and `bun run test` in `apps/server`.